### PR TITLE
Codex exec proxy shim + Cursor CLI hook coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ The installer:
 
 Spans are sent directly to the backend from hooks — no background process is needed. (Codex additionally starts a lightweight buffer service for native OTLP event buffering.)
 
+> **Codex exec:** `codex exec` tracing requires the `arize-codex-proxy` shim at `~/.arize/harness/bin/codex` to be on `PATH` ahead of the real Codex binary. See [codex_tracing/README.md](codex_tracing/README.md) for details.
+
+> **Cursor CLI:** Cursor CLI emits a subset of the IDE hook events. `afterAgentResponse` and `afterAgentThought` are not available through CLI hooks. See [cursor_tracing/README.md](cursor_tracing/README.md) for coverage details.
+
 ### Uninstall
 
 ```bash

--- a/codex_tracing/README.md
+++ b/codex_tracing/README.md
@@ -27,6 +27,34 @@ Codex CLI
 
 When both the notify hook and native OTLP export are enabled, the notify handler builds a parent LLM span and attaches child spans from buffered event data, producing a rich trace tree per turn.
 
+## Codex Exec Tracing
+
+Interactive Codex tracing uses `notify` and `[otel.exporter.otlp-http]` in
+`~/.codex/config.toml`. The notify hook fires after each agent turn, drains
+buffered OTLP events, and sends spans directly to the backend.
+
+`codex exec` tracing requires the `arize-codex-proxy` entry point because the
+proxy runs the real Codex binary and then drains buffered events after the
+process exits. Without the proxy, `codex exec` bypasses the notify hook and
+buffered events are never flushed.
+
+The installer creates a `~/.arize/harness/bin/codex` shim that points to
+`arize-codex-proxy`. Users must ensure `~/.arize/harness/bin` appears before the
+real Codex binary on `PATH`; otherwise the installer prints a shadowing warning
+and `codex exec` tracing is not active.
+
+### Verifying exec tracing
+
+Run:
+
+```bash
+command -v codex
+```
+
+The output should resolve to `~/.arize/harness/bin/codex` for exec tracing to be
+active. If it resolves to a different path, `codex exec` invocations will not be
+traced.
+
 ## Installation
 
 ### Pip installer (recommended)

--- a/codex_tracing/install.py
+++ b/codex_tracing/install.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
+import stat
 import sys
 from pathlib import Path
 
@@ -31,6 +33,7 @@ from codex_tracing.constants import (
 )
 from core.config import get_value, load_config
 from core.setup import (
+    BIN_DIR,
     CONFIG_FILE,
     dry_run,
     ensure_harness_installed,
@@ -417,6 +420,102 @@ def _is_our_env_file(path: Path) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Codex proxy shim helpers
+# ---------------------------------------------------------------------------
+
+
+def _codex_proxy_shim_path() -> Path:
+    """Return the path where the Arize-managed ``codex`` shim should live."""
+    if os.name == "nt":
+        return BIN_DIR / "codex.cmd"
+    return BIN_DIR / "codex"
+
+
+def _is_our_codex_proxy_shim(path: Path) -> bool:
+    """Return True only if *path* exists and is an Arize-managed codex shim."""
+    if not path.is_file():
+        return False
+    try:
+        text = path.read_text()
+        return "arize-codex-proxy" in text and "Arize Codex proxy shim" in text
+    except OSError:
+        return False
+
+
+def _write_codex_proxy_shim(path: Path, proxy_cmd: Path) -> None:
+    """Create the codex proxy shim at *path* pointing to *proxy_cmd*.
+
+    Honors ``dry_run()`` — logs intent without writing.
+    """
+    if dry_run():
+        info(f"would write codex proxy shim at {path}")
+        return
+
+    # Never overwrite a file that isn't ours
+    if path.is_file() and not _is_our_codex_proxy_shim(path):
+        info(f"Skipping codex proxy shim — {path} exists and is not ours")
+        return
+
+    if os.name == "nt":
+        content = (
+            "@echo off\r\n"
+            "REM Arize Codex proxy shim\r\n"
+            f'"{proxy_cmd}" %*\r\n'
+        )
+    else:
+        content = (
+            "#!/bin/sh\n"
+            "# Arize Codex proxy shim\n"
+            f"exec '{proxy_cmd}' \"$@\"\n"
+        )
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+    if os.name != "nt":
+        path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _remove_codex_proxy_shim(path: Path) -> None:
+    """Remove the codex proxy shim at *path* only if it is Arize-owned.
+
+    Honors ``dry_run()`` — logs intent without deleting.
+    """
+    if not path.exists():
+        return
+
+    if not _is_our_codex_proxy_shim(path):
+        info(f"Skipping removal of {path} — not an Arize-managed shim")
+        return
+
+    if dry_run():
+        info(f"would remove codex proxy shim at {path}")
+        return
+
+    path.unlink()
+
+
+def _codex_proxy_path_status(shim_path: Path) -> tuple[str, "str | None"]:
+    """Check whether the shim is the ``codex`` that the user's shell will run.
+
+    Returns one of:
+    - ``("active", "<resolved_shim_path>")``
+    - ``("shadowed", "<resolved_other_path>")``
+    - ``("missing", None)``
+    """
+    resolved = shutil.which("codex")
+    if resolved is None:
+        return ("missing", None)
+
+    shim_real = os.path.realpath(str(shim_path))
+    which_real = os.path.realpath(resolved)
+
+    if shim_real == which_real:
+        return ("active", which_real)
+    return ("shadowed", which_real)
+
+
+# ---------------------------------------------------------------------------
 # Install / Uninstall
 # ---------------------------------------------------------------------------
 
@@ -489,7 +588,26 @@ def install(with_skills: bool = False) -> None:
     else:
         info("would start buffer service")
 
-    # 7. Symlink skills
+    # 7. Write codex proxy shim
+    shim_path = _codex_proxy_shim_path()
+    _write_codex_proxy_shim(shim_path, venv_bin("arize-codex-proxy"))
+
+    status, resolved = _codex_proxy_path_status(shim_path)
+    if status == "active":
+        info(f"Codex proxy active for codex exec (resolves to {resolved})")
+    elif status == "shadowed":
+        info(
+            f"Codex proxy shim installed at {shim_path}, but PATH resolves codex"
+            f" to {resolved}. Put ~/.arize/harness/bin before the real Codex"
+            " binary to trace codex exec."
+        )
+    else:
+        info(
+            f"Codex proxy shim installed at {shim_path}."
+            " Add ~/.arize/harness/bin to PATH to trace codex exec."
+        )
+
+    # 8. Symlink skills
     if with_skills:
         symlink_skills(HARNESS_NAME)
         info("Symlinked skills")
@@ -514,7 +632,10 @@ def uninstall() -> None:
     _codex_toml_remove(CODEX_CONFIG_FILE, notify_cmd, otel_endpoint)
     info(f"Reverted TOML config: {CODEX_CONFIG_FILE}")
 
-    # 3. Remove env file if it's ours
+    # 3. Remove codex proxy shim
+    _remove_codex_proxy_shim(_codex_proxy_shim_path())
+
+    # 4. Remove env file if it's ours
     if CODEX_ENV_FILE.is_file():
         if _is_our_env_file(CODEX_ENV_FILE):
             if dry_run():
@@ -525,11 +646,11 @@ def uninstall() -> None:
         else:
             info(f"Skipping {CODEX_ENV_FILE} — does not look like our file")
 
-    # 4. Remove harness entry
+    # 5. Remove harness entry
     remove_harness_entry(HARNESS_NAME)
     info("Removed codex harness entry from config.yaml")
 
-    # 5. Unlink skills
+    # 6. Unlink skills
     unlink_skills(HARNESS_NAME)
     info("Unlinked skills")
 

--- a/codex_tracing/skills/manage-codex-tracing/SKILL.md
+++ b/codex_tracing/skills/manage-codex-tracing/SKILL.md
@@ -32,6 +32,29 @@ Codex CLI
 
 **Graceful degradation**: If the buffer service isn't running or returns no buffered events, the notify hook falls back to a single flat Turn span.
 
+## Codex Exec Tracing
+
+Interactive Codex tracing uses the `notify` hook and `[otel.exporter.otlp-http]`
+configured in `~/.codex/config.toml`. The notify hook fires after each agent
+turn to drain buffered events and send spans.
+
+`codex exec` tracing requires the `arize-codex-proxy` entry point. The proxy
+runs the real Codex binary and then drains buffered events after the process
+exits. Without the proxy, `codex exec` bypasses the notify hook entirely.
+
+The installer creates a `~/.arize/harness/bin/codex` shim that points to
+`arize-codex-proxy`. Users must ensure `~/.arize/harness/bin` appears before the
+real Codex binary on `PATH`; otherwise the installer prints a shadowing warning
+and `codex exec` tracing is not active.
+
+To verify exec tracing is active, run:
+
+```bash
+command -v codex
+```
+
+The output should resolve to `~/.arize/harness/bin/codex`.
+
 ## How to Use This Skill
 
 **This skill follows a decision tree workflow.** Start by asking the user where they are in the setup process:

--- a/cursor_tracing/README.md
+++ b/cursor_tracing/README.md
@@ -131,6 +131,7 @@ Full Cursor CLI assistant and thinking coverage requires parsing --output-format
 
 ```json
 {
+  "version": 1,
   "hooks": {
     "sessionStart": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
     "beforeSubmitPrompt": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],

--- a/cursor_tracing/README.md
+++ b/cursor_tracing/README.md
@@ -92,7 +92,9 @@ If your project already has a `.cursor/hooks.json`, merge the hook entries rathe
 
 ## Hook Events
 
-Each Cursor hook event produces one OpenInference span (or pushes state for later merging):
+### IDE Hooks
+
+The Cursor IDE fires 12 hook events. Each produces one OpenInference span (or pushes state for later merging):
 
 | Hook Event | Span Name | Span Kind | Description |
 |------------|-----------|-----------|-------------|
@@ -108,6 +110,45 @@ Each Cursor hook event produces one OpenInference span (or pushes state for late
 | `beforeTabFileRead` | Tab Read File | TOOL | File read from a tab context |
 | `afterTabFileEdit` | Tab File Edit | TOOL | File edit from a tab context |
 | `stop` | Agent Stop | CHAIN | Session or conversation stop event |
+
+### CLI Hooks
+
+Cursor CLI currently emits a smaller hook surface than the IDE. The supported
+CLI hooks in this package are:
+
+- `sessionStart`
+- `beforeShellExecution`
+- `afterShellExecution`
+- `afterFileEdit`
+- `postToolUse`
+- `stop`
+
+Cursor CLI hooks do not currently emit afterAgentResponse or afterAgentThought.
+
+Full Cursor CLI assistant and thinking coverage requires parsing --output-format stream-json, which is out of scope for this change.
+
+### Hooks JSON Example (IDE + CLI)
+
+```json
+{
+  "hooks": {
+    "sessionStart": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "beforeSubmitPrompt": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "afterAgentResponse": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "afterAgentThought": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "beforeShellExecution": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "afterShellExecution": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "beforeMCPExecution": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "afterMCPExecution": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "beforeReadFile": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "afterFileEdit": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "stop": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "beforeTabFileRead": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "afterTabFileEdit": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "postToolUse": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }]
+  }
+}
+```
 
 All spans include `session.id` (from `conversation_id`), `project.name`, and `openinference.span.kind` attributes. Trace IDs are deterministically derived from `generation_id` using `hashlib.md5` (32 hex chars). Span IDs are 16 random hex chars from `os.urandom`.
 

--- a/cursor_tracing/constants.py
+++ b/cursor_tracing/constants.py
@@ -10,8 +10,9 @@ HARNESS_BIN = "cursor"  # binary name for shutil.which() fallback
 HOOKS_FILE = Path.home() / ".cursor" / "hooks.json"
 HOOK_BIN_NAME = "arize-hook-cursor"
 
-# 12 events, all routed to a single CLI entry point (the handler dispatches
-# based on hook_event_name in the JSON payload).
+# 14 events, all routed to a single CLI entry point (the handler dispatches
+# based on hook_event_name / hookEventName in the JSON payload).
+# Includes IDE events plus CLI-specific events (sessionStart, postToolUse).
 HOOK_EVENTS = (
     "beforeSubmitPrompt",
     "afterAgentResponse",
@@ -25,4 +26,6 @@ HOOK_EVENTS = (
     "stop",
     "beforeTabFileRead",
     "afterTabFileEdit",
+    "sessionStart",
+    "postToolUse",
 )

--- a/cursor_tracing/hooks/handlers.py
+++ b/cursor_tracing/hooks/handlers.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Cursor hook handler: single entry point dispatching all 12 Cursor hook events.
+"""Cursor hook handler: single entry point dispatching all 14 Cursor hook events.
 
 Replaces cursor-tracing/hooks/hook-handler.sh (475 lines).
 
-Input contract: JSON on stdin, all 12 events routed here.
+Input contract: JSON on stdin, all 14 events (IDE + CLI) routed here.
 stdout: MUST print permissive JSON response, even on error.
 stderr: redirected to ARIZE_LOG_FILE before dispatch.
 """
@@ -59,6 +59,27 @@ def _jq_str(input_json: dict, *keys, default: str = "") -> str:
     return default
 
 
+def _event_name(input_json: dict) -> str:
+    """Extract event name from payload, tolerant of IDE and CLI key variants.
+
+    Cursor IDE uses ``hook_event_name``; Cursor CLI uses ``hookEventName``.
+    """
+    return _jq_str(input_json, "hook_event_name", "hookEventName", "event_name", "eventName", "event")
+
+
+def _trace_id_from_event(gen_id: str, conversation_id: str) -> str:
+    """Derive a trace ID from generation or conversation ID.
+
+    Prefers gen_id; falls back to conversation_id for CLI events that may
+    lack a generation_id.
+    """
+    if gen_id:
+        return trace_id_from_generation(gen_id)
+    if conversation_id:
+        return trace_id_from_generation(conversation_id)
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # Dispatch
 # ---------------------------------------------------------------------------
@@ -73,7 +94,7 @@ def _dispatch(event: str, input_json: dict) -> None:
     if not env.trace_enabled:
         return
 
-    trace_id = trace_id_from_generation(gen_id) if gen_id else ""
+    trace_id = _trace_id_from_event(gen_id, conversation_id)
     now_ms = get_timestamp_ms()
 
     handlers = {
@@ -89,6 +110,8 @@ def _dispatch(event: str, input_json: dict) -> None:
         "beforeTabFileRead": _handle_before_tab_file_read,
         "afterTabFileEdit": _handle_after_tab_file_edit,
         "stop": _handle_stop,
+        "sessionStart": _handle_session_start,
+        "postToolUse": _handle_post_tool_use,
     }
 
     handler = handlers.get(event)
@@ -525,6 +548,90 @@ def _handle_stop(input_json, conversation_id, gen_id, trace_id, now_ms):
     log(f"stop: span {sid}, cleaned up gen={gen_id}")
 
 
+def _handle_session_start(input_json, conversation_id, gen_id, trace_id, now_ms):
+    """CHAIN span for Cursor CLI sessionStart event."""
+    sid = span_id_16()
+
+    attrs = {
+        "openinference.span.kind": "CHAIN",
+        "session.id": conversation_id,
+    }
+
+    cwd = _jq_str(input_json, "cwd", "workspace_root")
+    if cwd:
+        attrs["cursor.session.cwd"] = cwd
+
+    user_email = _jq_str(input_json, "user_email")
+    if user_email:
+        attrs["user.id"] = user_email
+
+    span = build_span(
+        "Session Start",
+        "CHAIN",
+        sid,
+        trace_id,
+        "",
+        now_ms,
+        now_ms,
+        attrs,
+        SERVICE_NAME,
+        SCOPE_NAME,
+    )
+    send_span(span)
+
+    if gen_id:
+        gen_root_span_save(gen_id, sid)
+
+    log(f"sessionStart: span {sid} (trace={trace_id})")
+
+
+_SHELL_TOOL_NAMES = frozenset({"shell", "terminal", "bash", "run_command"})
+
+
+def _handle_post_tool_use(input_json, conversation_id, gen_id, trace_id, now_ms):
+    """TOOL span for Cursor CLI postToolUse event."""
+    sid = span_id_16()
+    parent = gen_root_span_get(gen_id) if gen_id else ""
+
+    tool_name = _jq_str(input_json, "tool_name", "toolName", "name", "tool")
+    tool_input = _jq_str(input_json, "tool_input", "toolInput", "input", "arguments", "args")
+    output = _jq_str(input_json, "result", "output", "response", "stdout")
+
+    # Shell-like tools: prefer the top-level ``command`` field as input
+    if tool_name.lower() in _SHELL_TOOL_NAMES:
+        command = _jq_str(input_json, "command")
+        if command:
+            tool_input = command
+
+    attrs = {
+        "openinference.span.kind": "TOOL",
+        "session.id": conversation_id,
+    }
+    if tool_name:
+        attrs["tool.name"] = tool_name
+    if tool_input:
+        attrs["input.value"] = tool_input
+    if output:
+        attrs["output.value"] = output
+
+    span_name = f"Tool: {tool_name}" if tool_name else "Tool Use"
+
+    span = build_span(
+        span_name,
+        "TOOL",
+        sid,
+        trace_id,
+        parent,
+        now_ms,
+        now_ms,
+        attrs,
+        SERVICE_NAME,
+        SCOPE_NAME,
+    )
+    send_span(span)
+    log(f"postToolUse: span {sid} (tool={tool_name})")
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -533,7 +640,7 @@ def _handle_stop(input_json, conversation_id, gen_id, trace_id, now_ms):
 def main():
     """Entry point for arize-hook-cursor. Cursor hook.
 
-    Input contract: JSON on stdin, all 12 events routed here.
+    Input contract: JSON on stdin, all 14 events (IDE + CLI) routed here.
     stdout: MUST print permissive JSON response, even on error.
     stderr: redirected to ARIZE_LOG_FILE before dispatch.
     """
@@ -551,7 +658,7 @@ def main():
             return
 
         input_json = json.loads(sys.stdin.read() or "{}")
-        event = input_json.get("hook_event_name", "")
+        event = _event_name(input_json)
         _dispatch(event, input_json)
     except Exception as e:
         error(f"cursor hook failed ({event}): {e}")

--- a/cursor_tracing/skills/manage-cursor-tracing/SKILL.md
+++ b/cursor_tracing/skills/manage-cursor-tracing/SKILL.md
@@ -168,7 +168,9 @@ Tell the user:
 
 ## Hook Events
 
-Cursor fires 12 hook events. Here's what each one traces:
+### IDE Hooks
+
+Cursor IDE fires 12 hook events. Here's what each one traces:
 
 | Event | Span Name | Kind | Description |
 |-------|-----------|------|-------------|
@@ -186,6 +188,47 @@ Cursor fires 12 hook events. Here's what each one traces:
 | `stop` | Agent Stop | CHAIN | Turn completion status and loop count |
 
 Shell and MCP events use a disk-backed state stack to merge before/after context into single spans with both input and output.
+
+### CLI Hooks
+
+Cursor CLI currently emits a smaller hook surface than the IDE. The supported
+CLI hooks in this package are:
+
+- `sessionStart`
+- `beforeShellExecution`
+- `afterShellExecution`
+- `afterFileEdit`
+- `postToolUse`
+- `stop`
+
+Cursor CLI hooks do not currently emit afterAgentResponse or afterAgentThought.
+
+Full Cursor CLI assistant and thinking coverage requires parsing --output-format stream-json, which is out of scope for this change.
+
+### Hooks JSON Example (IDE + CLI)
+
+When configuring `.cursor/hooks.json`, include both IDE and CLI events:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "beforeSubmitPrompt": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "afterAgentResponse": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "afterAgentThought": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "beforeShellExecution": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "afterShellExecution": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "beforeMCPExecution": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "afterMCPExecution": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "beforeReadFile": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "afterFileEdit": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "stop": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "beforeTabFileRead": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "afterTabFileEdit": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "postToolUse": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }]
+  }
+}
 
 ## Troubleshoot
 

--- a/cursor_tracing/skills/manage-cursor-tracing/SKILL.md
+++ b/cursor_tracing/skills/manage-cursor-tracing/SKILL.md
@@ -229,6 +229,7 @@ When configuring `.cursor/hooks.json`, include both IDE and CLI events:
     "postToolUse": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }]
   }
 }
+```
 
 ## Troubleshoot
 

--- a/tests/test_codex_proxy.py
+++ b/tests/test_codex_proxy.py
@@ -259,3 +259,47 @@ class TestMain:
         mock_run.assert_called_once()
         assert str(codex) == mock_run.call_args[0][0][0]
         assert exc_info.value.code == 42
+
+    def test_exec_mode_calls_drain_idle_after_subprocess(self, tmp_path):
+        """``codex exec`` uses subprocess.run and calls drain_idle() after."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        codex = bin_dir / "codex"
+        codex.write_text("#!/bin/sh\nexit 0\n")
+        codex.chmod(codex.stat().st_mode | stat.S_IEXEC)
+
+        fake_result = mock.Mock()
+        fake_result.returncode = 0
+
+        with (
+            mock.patch("codex_tracing.hooks.proxy._quick_health_check", return_value=True),
+            mock.patch("codex_tracing.hooks.proxy._find_real_codex", return_value=str(codex)),
+            mock.patch("subprocess.run", return_value=fake_result) as mock_run,
+            mock.patch("codex_tracing.hooks.handlers.drain_idle") as mock_drain,
+            mock.patch.object(sys, "argv", ["codex", "exec", "say hi"]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+
+        mock_run.assert_called_once()
+        mock_drain.assert_called_once()
+        assert exc_info.value.code == 0
+
+    def test_non_exec_posix_uses_execvp_without_drain(self, tmp_path):
+        """Interactive/non-exec POSIX path uses os.execvp and does not call drain_idle."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        codex = bin_dir / "codex"
+        codex.write_text("#!/bin/sh\nexit 0\n")
+        codex.chmod(codex.stat().st_mode | stat.S_IEXEC)
+
+        with (
+            mock.patch("codex_tracing.hooks.proxy._quick_health_check", return_value=True),
+            mock.patch("codex_tracing.hooks.proxy._find_real_codex", return_value=str(codex)),
+            mock.patch("os.execvp") as mock_exec,
+            mock.patch.object(sys, "argv", ["codex", "--help"]),
+        ):
+            main()
+
+        mock_exec.assert_called_once()
+        # drain_idle should NOT have been imported/called for non-exec path

--- a/tests/test_codex_proxy.py
+++ b/tests/test_codex_proxy.py
@@ -297,9 +297,10 @@ class TestMain:
             mock.patch("codex_tracing.hooks.proxy._quick_health_check", return_value=True),
             mock.patch("codex_tracing.hooks.proxy._find_real_codex", return_value=str(codex)),
             mock.patch("os.execvp") as mock_exec,
+            mock.patch("codex_tracing.hooks.handlers.drain_idle") as mock_drain,
             mock.patch.object(sys, "argv", ["codex", "--help"]),
         ):
             main()
 
         mock_exec.assert_called_once()
-        # drain_idle should NOT have been imported/called for non-exec path
+        mock_drain.assert_not_called()

--- a/tests/test_cursor_hook.py
+++ b/tests/test_cursor_hook.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for cursor_tracing.hooks.handlers — the Cursor hook dispatcher and 12 event handlers."""
+"""Tests for cursor_tracing.hooks.handlers — the Cursor hook dispatcher and 14 event handlers."""
 
 import io
 import json
@@ -9,7 +9,14 @@ from unittest import mock
 import pytest
 
 from cursor_tracing.hooks import adapter
-from cursor_tracing.hooks.handlers import _dispatch, _jq_str, _print_permissive, main
+from cursor_tracing.hooks.handlers import (
+    _dispatch,
+    _event_name,
+    _jq_str,
+    _print_permissive,
+    _trace_id_from_event,
+    main,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -979,3 +986,306 @@ class TestMain:
 
         # Restore stderr for safety
         sys.stderr = original_stderr
+
+
+# ---------------------------------------------------------------------------
+# _event_name tests
+# ---------------------------------------------------------------------------
+
+
+class TestEventName:
+
+    def test_supports_hook_event_name(self):
+        assert _event_name({"hook_event_name": "stop"}) == "stop"
+
+    def test_supports_hookEventName(self):
+        assert _event_name({"hookEventName": "sessionStart"}) == "sessionStart"
+
+    def test_supports_event_name(self):
+        assert _event_name({"event_name": "postToolUse"}) == "postToolUse"
+
+    def test_supports_eventName(self):
+        assert _event_name({"eventName": "afterFileEdit"}) == "afterFileEdit"
+
+    def test_supports_event(self):
+        assert _event_name({"event": "beforeSubmitPrompt"}) == "beforeSubmitPrompt"
+
+    def test_prefers_hook_event_name_over_hookEventName(self):
+        assert _event_name({"hook_event_name": "stop", "hookEventName": "sessionStart"}) == "stop"
+
+    def test_returns_empty_for_missing(self):
+        assert _event_name({}) == ""
+
+
+# ---------------------------------------------------------------------------
+# _trace_id_from_event tests
+# ---------------------------------------------------------------------------
+
+
+class TestTraceIdFromEvent:
+
+    def test_prefers_gen_id(self):
+        result = _trace_id_from_event("gen-1", "conv-1")
+        assert result  # non-empty
+        from cursor_tracing.hooks.adapter import trace_id_from_generation
+
+        assert result == trace_id_from_generation("gen-1")
+
+    def test_falls_back_to_conversation_id(self):
+        result = _trace_id_from_event("", "conv-1")
+        assert result
+        from cursor_tracing.hooks.adapter import trace_id_from_generation
+
+        assert result == trace_id_from_generation("conv-1")
+
+    def test_returns_empty_when_both_empty(self):
+        assert _trace_id_from_event("", "") == ""
+
+
+# ---------------------------------------------------------------------------
+# _dispatch routes sessionStart / postToolUse
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchNewEvents:
+
+    def test_dispatch_routes_session_start(self, monkeypatch):
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=1000),
+            mock.patch("cursor_tracing.hooks.handlers._handle_session_start") as h,
+        ):
+            _dispatch(
+                "sessionStart",
+                {
+                    "conversation_id": "c1",
+                    "generation_id": "g1",
+                },
+            )
+            h.assert_called_once()
+
+    def test_dispatch_routes_post_tool_use(self, monkeypatch):
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=1000),
+            mock.patch("cursor_tracing.hooks.handlers._handle_post_tool_use") as h,
+        ):
+            _dispatch(
+                "postToolUse",
+                {
+                    "conversation_id": "c1",
+                    "generation_id": "g1",
+                },
+            )
+            h.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# main() dispatches camelCase event key
+# ---------------------------------------------------------------------------
+
+
+class TestMainCamelCase:
+
+    def test_main_dispatches_camel_case_event_key(self, monkeypatch, tmp_path):
+        """main() resolves hookEventName from CLI payloads and dispatches correctly."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.setenv("ARIZE_LOG_FILE", str(tmp_path / "hook.log"))
+
+        input_data = {
+            "hookEventName": "sessionStart",
+            "conversation_id": "c1",
+            "generation_id": "g1",
+            "cwd": "/tmp",
+        }
+        stdout_buf = io.StringIO()
+
+        with (
+            mock.patch("sys.stdin", io.StringIO(json.dumps(input_data))),
+            mock.patch.object(sys, "__stdout__", stdout_buf),
+            mock.patch("cursor_tracing.hooks.handlers.check_requirements", return_value=True),
+            mock.patch("cursor_tracing.hooks.handlers._dispatch") as dispatch_mock,
+        ):
+            main()
+
+        dispatch_mock.assert_called_once_with("sessionStart", input_data)
+
+
+# ---------------------------------------------------------------------------
+# _handle_session_start tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandleSessionStart:
+
+    def test_session_start_sends_chain_span(self, captured_spans, monkeypatch):
+        """sessionStart produces a CHAIN span with session.id and cwd."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=5000),
+            mock.patch("cursor_tracing.hooks.handlers.span_id_16", return_value="ss11" * 4),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_save") as save_mock,
+        ):
+            _dispatch(
+                "sessionStart",
+                {
+                    "conversation_id": "conv-sess",
+                    "generation_id": "gen-sess",
+                    "cwd": "/Users/alice/code/myrepo",
+                    "user_email": "alice@example.com",
+                },
+            )
+
+        save_mock.assert_called_once_with("gen-sess", "ss11" * 4)
+        assert len(captured_spans) == 1
+        span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert span["name"] == "Session Start"
+        assert attrs["openinference.span.kind"]["stringValue"] == "CHAIN"
+        assert attrs["session.id"]["stringValue"] == "conv-sess"
+        assert attrs["cursor.session.cwd"]["stringValue"] == "/Users/alice/code/myrepo"
+        assert attrs["user.id"]["stringValue"] == "alice@example.com"
+
+    def test_session_start_no_gen_id_skips_save(self, captured_spans, monkeypatch):
+        """Without gen_id, gen_root_span_save is not called."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=5000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_save") as save_mock,
+        ):
+            _dispatch(
+                "sessionStart",
+                {
+                    "conversation_id": "conv-sess",
+                    "cwd": "/tmp",
+                },
+            )
+
+        save_mock.assert_not_called()
+        assert len(captured_spans) == 1
+
+    def test_session_start_optional_fields_omitted(self, captured_spans, monkeypatch):
+        """Optional fields like cwd and user_email are omitted when absent."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=5000),
+        ):
+            _dispatch(
+                "sessionStart",
+                {
+                    "conversation_id": "conv-sess",
+                },
+            )
+
+        attr_keys = {a["key"] for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]}
+        assert "cursor.session.cwd" not in attr_keys
+        assert "user.id" not in attr_keys
+
+
+# ---------------------------------------------------------------------------
+# _handle_post_tool_use tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandlePostToolUse:
+
+    def test_post_tool_use_sends_tool_span(self, captured_spans, monkeypatch):
+        """postToolUse produces a TOOL span with tool.name, input.value, output.value."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=3000),
+            mock.patch("cursor_tracing.hooks.handlers.span_id_16", return_value="pt11" * 4),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value="parent-pt"),
+        ):
+            _dispatch(
+                "postToolUse",
+                {
+                    "conversation_id": "conv-pt",
+                    "generation_id": "gen-pt",
+                    "toolName": "read_file",
+                    "toolInput": '{"path": "src/main.py"}',
+                    "result": "<file contents elided>",
+                },
+            )
+
+        assert len(captured_spans) == 1
+        span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert span["name"] == "Tool: read_file"
+        assert attrs["openinference.span.kind"]["stringValue"] == "TOOL"
+        assert attrs["tool.name"]["stringValue"] == "read_file"
+        assert attrs["input.value"]["stringValue"] == '{"path": "src/main.py"}'
+        assert attrs["output.value"]["stringValue"] == "<file contents elided>"
+        assert attrs["session.id"]["stringValue"] == "conv-pt"
+        assert span["parentSpanId"] == "parent-pt"
+
+    def test_post_tool_use_shell_command_uses_command_as_input(self, captured_spans, monkeypatch):
+        """Shell-like postToolUse uses 'command' field as input.value."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=3000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
+        ):
+            _dispatch(
+                "postToolUse",
+                {
+                    "conversation_id": "c1",
+                    "generation_id": "g1",
+                    "toolName": "shell",
+                    "command": "ls -la",
+                    "stdout": "total 40\ndrwxr-xr-x ...",
+                    "exit_code": 0,
+                },
+            )
+
+        attrs = {
+            a["key"]: a["value"]
+            for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
+        }
+        assert attrs["input.value"]["stringValue"] == "ls -la"
+        assert attrs["output.value"]["stringValue"] == "total 40\ndrwxr-xr-x ..."
+
+    def test_post_tool_use_bash_tool_uses_command(self, captured_spans, monkeypatch):
+        """Other shell-like tool names (bash, terminal, run_command) also use command."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        for tool in ("bash", "terminal", "run_command"):
+            captured_spans.clear()
+            with (
+                mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=3000),
+                mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
+            ):
+                _dispatch(
+                    "postToolUse",
+                    {
+                        "conversation_id": "c1",
+                        "generation_id": "g1",
+                        "toolName": tool,
+                        "command": "echo hi",
+                    },
+                )
+
+            attrs = {
+                a["key"]: a["value"]
+                for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
+            }
+            assert attrs["input.value"]["stringValue"] == "echo hi", f"Failed for tool={tool}"
+
+    def test_post_tool_use_missing_fields_omitted(self, captured_spans, monkeypatch):
+        """Missing optional fields are omitted from attributes."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=3000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
+        ):
+            _dispatch(
+                "postToolUse",
+                {
+                    "conversation_id": "c1",
+                    "generation_id": "g1",
+                },
+            )
+
+        attr_keys = {a["key"] for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]}
+        assert "tool.name" not in attr_keys
+        assert "input.value" not in attr_keys
+        assert "output.value" not in attr_keys

--- a/tests/test_hook_registrations.py
+++ b/tests/test_hook_registrations.py
@@ -465,6 +465,89 @@ class TestCursorHookReference:
 # --- State file extension ---
 
 
+class TestCodexProxyEntryPoint:
+    """Verify pyproject.toml includes the codex proxy entry point."""
+
+    def test_pyproject_includes_codex_proxy_entry_point(self):
+        """pyproject.toml must include the arize-codex-proxy console script."""
+        scripts = _parse_pyproject_scripts()
+        assert "arize-codex-proxy" in scripts, "Missing arize-codex-proxy entry point in pyproject.toml"
+
+
+class TestCodexDocsProxyAndShim:
+    """Verify Codex docs mention the proxy and shim."""
+
+    def test_codex_docs_mention_proxy_and_shim(self):
+        """codex_tracing README and SKILL.md must mention arize-codex-proxy and the shim path."""
+        readme = (REPO_ROOT / "codex_tracing" / "README.md").read_text()
+        skill = (REPO_ROOT / "codex_tracing" / "skills" / "manage-codex-tracing" / "SKILL.md").read_text()
+
+        for name, content in [("README.md", readme), ("SKILL.md", skill)]:
+            assert "arize-codex-proxy" in content, f"codex_tracing {name} missing arize-codex-proxy"
+            assert "~/.arize/harness/bin/codex" in content, f"codex_tracing {name} missing ~/.arize/harness/bin/codex"
+
+
+class TestCursorDocsCliEvents:
+    """Verify Cursor docs list CLI-supported events."""
+
+    def test_cursor_docs_list_cli_supported_events(self):
+        """Cursor README and SKILL.md must mention sessionStart and postToolUse."""
+        readme = (REPO_ROOT / "cursor_tracing" / "README.md").read_text()
+        skill = (REPO_ROOT / "cursor_tracing" / "skills" / "manage-cursor-tracing" / "SKILL.md").read_text()
+
+        for name, content in [("README.md", readme), ("SKILL.md", skill)]:
+            assert "sessionStart" in content, f"cursor_tracing {name} missing sessionStart"
+            assert "postToolUse" in content, f"cursor_tracing {name} missing postToolUse"
+
+
+class TestCursorDocsUnsupportedHooks:
+    """Verify Cursor docs explicitly state unsupported CLI hooks."""
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        return " ".join(text.lower().split())
+
+    def test_cursor_docs_state_unsupported_cli_hooks_explicitly(self):
+        """Cursor docs must contain required disclaimer phrases."""
+        readme = (REPO_ROOT / "cursor_tracing" / "README.md").read_text()
+        skill = (REPO_ROOT / "cursor_tracing" / "skills" / "manage-cursor-tracing" / "SKILL.md").read_text()
+
+        docs = [self._normalize(readme), self._normalize(skill)]
+
+        phrase1 = self._normalize(
+            "Cursor CLI hooks do not currently emit afterAgentResponse or afterAgentThought."
+        )
+        phrase2 = self._normalize(
+            "Full Cursor CLI assistant and thinking coverage requires parsing --output-format stream-json"
+        )
+
+        assert any(phrase1 in d for d in docs), (
+            f"Neither cursor README nor SKILL.md contains: {phrase1!r}"
+        )
+        assert any(phrase2 in d for d in docs), (
+            f"Neither cursor README nor SKILL.md contains: {phrase2!r}"
+        )
+
+    def test_cursor_docs_do_not_list_unsupported_hooks_as_cli_supported(self):
+        """Cursor docs must not claim CLI supports afterAgentResponse or afterAgentThought."""
+        readme = (REPO_ROOT / "cursor_tracing" / "README.md").read_text()
+        skill = (REPO_ROOT / "cursor_tracing" / "skills" / "manage-cursor-tracing" / "SKILL.md").read_text()
+
+        # Match lines claiming CLI supports/emits afterAgentResponse or afterAgentThought
+        pattern = re.compile(
+            r"(?:afterAgentResponse|afterAgentThought).*CLI.*(?:supports|emits|is supported)"
+            r"|CLI.*(?:supports|emits|is supported).*(?:afterAgentResponse|afterAgentThought)",
+            re.IGNORECASE,
+        )
+
+        for name, content in [("README.md", readme), ("SKILL.md", skill)]:
+            matches = pattern.findall(content)
+            assert not matches, (
+                f"cursor_tracing {name} incorrectly claims CLI supports "
+                f"afterAgentResponse/afterAgentThought: {matches}"
+            )
+
+
 class TestStateFileExtension:
     """Verify docs reference .yaml state files, not .json."""
 

--- a/tests/test_install_codex.py
+++ b/tests/test_install_codex.py
@@ -1075,7 +1075,7 @@ class TestCodexProxyShim:
         monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/codex")
         status, resolved = codex_install._codex_proxy_path_status(shim)
         assert status == "shadowed"
-        assert resolved == "/usr/local/bin/codex"
+        assert resolved == os.path.realpath("/usr/local/bin/codex")
 
         # Missing: shutil.which returns None
         monkeypatch.setattr("shutil.which", lambda cmd: None)

--- a/tests/test_install_codex.py
+++ b/tests/test_install_codex.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import os
+import stat
 import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -63,6 +65,7 @@ def fake_home(tmp_path, monkeypatch):
     monkeypatch.setattr("core.config.CONFIG_FILE", config_file)
 
     # Patch the constants in the install module itself
+    monkeypatch.setattr(codex_install, "BIN_DIR", install_dir / "bin")
     monkeypatch.setattr(codex_install, "CODEX_CONFIG_DIR", codex_dir)
     monkeypatch.setattr(codex_install, "CODEX_CONFIG_FILE", codex_dir / "config.toml")
     monkeypatch.setattr(codex_install, "CODEX_ENV_FILE", codex_dir / "arize-env.sh")
@@ -998,3 +1001,139 @@ class TestTomlFallbackQuoting:
         text = p.read_text()
         parsed = tomllib.loads(text)
         assert parsed == data
+
+
+# ---------------------------------------------------------------------------
+# Codex proxy shim tests
+# ---------------------------------------------------------------------------
+
+
+class TestCodexProxyShim:
+    """Tests for the codex proxy shim install/uninstall helpers."""
+
+    def test_install_writes_codex_proxy_shim(self, fake_home, mock_buffer, mock_prompts):
+        """Install creates a codex shim in BIN_DIR containing arize-codex-proxy."""
+        codex_install.install()
+
+        shim = fake_home / ".arize" / "harness" / "bin" / "codex"
+        assert shim.is_file()
+        text = shim.read_text()
+        assert "arize-codex-proxy" in text
+        assert "Arize Codex proxy shim" in text
+        # POSIX shim must be executable
+        assert shim.stat().st_mode & stat.S_IXUSR
+
+    def test_install_does_not_overwrite_foreign_codex_shim(self, fake_home, mock_buffer, mock_prompts):
+        """A pre-existing non-Arize codex file is never overwritten."""
+        bin_dir = fake_home / ".arize" / "harness" / "bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        foreign = bin_dir / "codex"
+        foreign.write_text("#!/bin/sh\necho real codex\n")
+        original_text = foreign.read_text()
+
+        codex_install.install()
+
+        assert foreign.read_text() == original_text
+
+    def test_uninstall_removes_our_codex_proxy_shim(self, fake_home, mock_buffer, mock_prompts):
+        """Install creates the shim, uninstall removes it."""
+        codex_install.install()
+
+        shim = fake_home / ".arize" / "harness" / "bin" / "codex"
+        assert shim.is_file()
+
+        codex_install.uninstall()
+        assert not shim.exists()
+
+    def test_uninstall_preserves_foreign_codex_shim(self, fake_home, mock_buffer, mock_prompts):
+        """A non-Arize codex file survives uninstall."""
+        bin_dir = fake_home / ".arize" / "harness" / "bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        foreign = bin_dir / "codex"
+        foreign.write_text("#!/bin/sh\necho real codex\n")
+        original_text = foreign.read_text()
+
+        codex_install.uninstall()
+
+        assert foreign.read_text() == original_text
+
+    def test_codex_proxy_path_status_active_shadowed_missing(self, tmp_path, monkeypatch):
+        """Unit-test _codex_proxy_path_status for each case."""
+        shim = tmp_path / "bin" / "codex"
+        shim.parent.mkdir(parents=True)
+        shim.write_text("#!/bin/sh\n# Arize Codex proxy shim\nexec arize-codex-proxy \"$@\"\n")
+
+        shim_real = os.path.realpath(str(shim))
+
+        # Active: shutil.which returns the shim path
+        monkeypatch.setattr("shutil.which", lambda cmd: str(shim))
+        status, resolved = codex_install._codex_proxy_path_status(shim)
+        assert status == "active"
+        assert resolved == shim_real
+
+        # Shadowed: shutil.which returns a different path
+        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/codex")
+        status, resolved = codex_install._codex_proxy_path_status(shim)
+        assert status == "shadowed"
+        assert resolved == "/usr/local/bin/codex"
+
+        # Missing: shutil.which returns None
+        monkeypatch.setattr("shutil.which", lambda cmd: None)
+        status, resolved = codex_install._codex_proxy_path_status(shim)
+        assert status == "missing"
+        assert resolved is None
+
+    def test_codex_proxy_shim_dry_run(self, tmp_path, monkeypatch):
+        """In dry-run mode, no shim file is created."""
+        monkeypatch.setenv("ARIZE_DRY_RUN", "true")
+        shim = tmp_path / "bin" / "codex"
+        codex_install._write_codex_proxy_shim(shim, Path("/fake/arize-codex-proxy"))
+        assert not shim.exists()
+
+    def test_install_prints_active_message_when_shim_resolves_first(
+        self, fake_home, mock_buffer, mock_prompts, monkeypatch, capsys
+    ):
+        """When shutil.which('codex') returns the shim, the active message prints."""
+        shim = fake_home / ".arize" / "harness" / "bin" / "codex"
+
+        def fake_which(cmd):
+            if cmd == "codex":
+                return str(shim)
+            return None
+
+        monkeypatch.setattr("shutil.which", fake_which)
+        codex_install.install()
+
+        output = capsys.readouterr().out
+        assert "Codex proxy active for codex exec" in output
+
+    def test_install_prints_shadowed_message_with_resolved_path(
+        self, fake_home, mock_buffer, mock_prompts, monkeypatch, capsys
+    ):
+        """When shutil.which('codex') returns a different path, the shadowed message prints."""
+
+        def fake_which(cmd):
+            if cmd == "codex":
+                return "/usr/local/bin/codex"
+            return None
+
+        monkeypatch.setattr("shutil.which", fake_which)
+        codex_install.install()
+
+        output = capsys.readouterr().out
+        assert "but PATH resolves codex to /usr/local/bin/codex" in output
+        assert "Put ~/.arize/harness/bin before the real Codex binary" in output
+
+    def test_install_prints_missing_message_when_no_codex_on_path(
+        self, fake_home, mock_buffer, mock_prompts, monkeypatch, capsys
+    ):
+        """When shutil.which('codex') returns None, the missing message prints."""
+
+        def fake_which(cmd):
+            return None
+
+        monkeypatch.setattr("shutil.which", fake_which)
+        codex_install.install()
+
+        output = capsys.readouterr().out
+        assert "Add ~/.arize/harness/bin to PATH to trace codex exec" in output

--- a/tests/test_install_cursor.py
+++ b/tests/test_install_cursor.py
@@ -141,14 +141,18 @@ class TestFreshInstall:
         assert "backend" not in config
         assert "collector" not in config
 
-        # Check hooks.json has 12 events
+        # Check hooks.json has 14 events (12 IDE + 2 CLI)
         hooks_file = fake_home / ".cursor" / "hooks.json"
         assert hooks_file.exists()
         hooks_data = json.loads(hooks_file.read_text())
 
         assert hooks_data["version"] == 1
         hooks = hooks_data.get("hooks", {})
-        assert len(hooks) == 12
+        assert len(hooks) == 14
+
+        # sessionStart and postToolUse are present and use the same hook command
+        assert "sessionStart" in hooks
+        assert "postToolUse" in hooks
 
         # Each event should have exactly one entry
         for event, entries in hooks.items():
@@ -275,9 +279,9 @@ class TestIdempotent:
         hooks_file = fake_home / ".cursor" / "hooks.json"
         hooks_data = json.loads(hooks_file.read_text())
 
-        # Still exactly 12 events with 1 entry each
+        # Still exactly 14 events with 1 entry each
         hooks = hooks_data["hooks"]
-        assert len(hooks) == 12
+        assert len(hooks) == 14
         for event, entries in hooks.items():
             assert len(entries) == 1, f"Event {event} has {len(entries)} entries"
 
@@ -335,6 +339,32 @@ class TestUninstall:
         # CustomEvent survives
         assert "CustomEvent" in hooks
         assert hooks["CustomEvent"][0]["command"] == "/usr/local/bin/other"
+
+    def test_uninstall_removes_cli_events(self, fake_home, monkeypatch):
+        """Uninstall removes sessionStart and postToolUse while preserving foreign hooks."""
+        cursor_install = _load_cursor_module("install")
+
+        _mock_prompts(monkeypatch)
+        cursor_install.install(with_skills=False)
+
+        # Inject a third-party hook into sessionStart
+        hooks_file = fake_home / ".cursor" / "hooks.json"
+        hooks_data = json.loads(hooks_file.read_text())
+        hooks_data["hooks"]["sessionStart"].append({"command": "/usr/local/bin/my-session-hook"})
+        hooks_file.write_text(json.dumps(hooks_data, indent=2) + "\n")
+
+        cursor_install.uninstall()
+
+        hooks_data = json.loads(hooks_file.read_text())
+        hooks = hooks_data.get("hooks", {})
+
+        # Our postToolUse entry is gone entirely (was only ours)
+        assert "postToolUse" not in hooks
+
+        # Third-party hook in sessionStart survives
+        assert "sessionStart" in hooks
+        assert len(hooks["sessionStart"]) == 1
+        assert hooks["sessionStart"][0]["command"] == "/usr/local/bin/my-session-hook"
 
     def test_uninstall_is_idempotent(self, fake_home, monkeypatch):
         """Running uninstall twice succeeds and is a no-op the second time."""


### PR DESCRIPTION
## Summary

Addresses two review findings ([.workbench/codex-exec-cursor-cli-tracing.md](.workbench/codex-exec-cursor-cli-tracing.md)):

- **Codex `exec` tracing was inactive by default.** The proxy entry point (`arize-codex-proxy`) drains buffered OTLP events after Codex exits, but nothing put it on `PATH`. The installer now creates an Arize-owned `~/.arize/harness/bin/codex` shim, validates whether `PATH` resolves to it (`active` / `shadowed` / `missing`), and prints a clear status line so the user knows whether `codex exec` tracing will fire on their next shell. No silent shell-profile mutation.
- **Cursor CLI hook coverage was IDE-shaped.** Adds `sessionStart` and `postToolUse` to `HOOK_EVENTS` (now 14 events), tolerant event-name parsing for camelCase CLI payloads (`hookEventName`, `eventName`, `event`), generic shell-tool detection that uses top-level `command` as `input.value`, and root-span linking via `gen_root_span_save` / `gen_root_span_get`. Docs explicitly disclaim that Cursor CLI does not currently emit `afterAgentResponse` or `afterAgentThought`, and direct readers to `--output-format stream-json` for full assistant/thinking coverage.

Three task branches merged in via the workbench session:

- `wb/codex-proxy` — installer shim + active/shadowed/missing validation + tests
- `wb/cursor-cli` — CLI hook handlers + reference-payload-driven tests
- `wb/docs-verify` — README + SKILL.md updates with literal-substring assertions in `tests/test_hook_registrations.py`

## Test plan

- [x] `uv run pytest tests/test_install_codex.py tests/test_codex_proxy.py tests/test_install_cursor.py tests/test_cursor_hook.py tests/test_hook_registrations.py -x -q` — 215 tests pass
- [ ] `uv run pytest -q` — full suite clean
- [ ] Manual: run `arize-setup-codex`; confirm output prints exactly one of `Codex proxy active for codex exec`, `but PATH resolves codex to ...`, or `Add ~/.arize/harness/bin to PATH to trace codex exec` depending on `command -v codex`
- [ ] Manual: with the shim active on PATH, run `codex exec "say hi"` and confirm a span tree appears in Arize
- [ ] Manual: configure Cursor CLI hooks for `sessionStart` and `postToolUse`; run an agent with `cursor agent`; confirm CHAIN + TOOL spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)