### PR TITLE
Updates to Cursor agent CLI tracing to capture proper trace data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Trace AI coding sessions to [Arize AX](https://arize.com) or [Phoenix](https://g
 
 | Harness | Integration | Install Method |
 |---------|-------------|----------------|
-| [Claude Code CLI / Agent SDK](claude-code-tracing/README.md) | `claude-code-tracing` | Marketplace or `install.sh` / `install.bat` |
-| [OpenAI Codex CLI](codex-tracing/README.md) | `codex-tracing` | `install.sh` / `install.bat` |
-| [Cursor IDE / CLI](cursor-tracing/README.md) | `cursor-tracing` | `install.sh` / `install.bat` |
+| [Claude Code CLI / Agent SDK](claude_code_tracing/README.md) | `claude-code-tracing` | Marketplace or `install.sh` / `install.bat` |
+| [OpenAI Codex CLI](codex_tracing/README.md) | `codex-tracing` | `install.sh` / `install.bat` |
+| [Cursor IDE / CLI](cursor_tracing/README.md) | `cursor-tracing` | `install.sh` / `install.bat` |
 | [GitHub Copilot (VS Code + CLI)](copilot_tracing/README.md) | `copilot-tracing` | `install.sh` / `install.bat` |
 
 Claude Code CLI and the Claude Agent SDK share the same plugin, hooks, and configuration — one install covers both.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Trace AI coding sessions to [Arize AX](https://arize.com) or [Phoenix](https://g
 |---------|-------------|----------------|
 | [Claude Code CLI / Agent SDK](claude-code-tracing/README.md) | `claude-code-tracing` | Marketplace or `install.sh` / `install.bat` |
 | [OpenAI Codex CLI](codex-tracing/README.md) | `codex-tracing` | `install.sh` / `install.bat` |
-| [Cursor IDE](cursor-tracing/README.md) | `cursor-tracing` | `install.sh` / `install.bat` |
+| [Cursor IDE / CLI](cursor-tracing/README.md) | `cursor-tracing` | `install.sh` / `install.bat` |
+| [GitHub Copilot (VS Code + CLI)](copilot_tracing/README.md) | `copilot-tracing` | `install.sh` / `install.bat` |
 
 Claude Code CLI and the Claude Agent SDK share the same plugin, hooks, and configuration — one install covers both.
 
@@ -41,17 +42,19 @@ For Phoenix, use `"PHOENIX_ENDPOINT": "http://localhost:6006"` instead of the Ar
 ```bash
 INSTALL_URL="https://raw.githubusercontent.com/Arize-ai/arize-agent-kit/main/install.sh"
 
-curl -sSL "$INSTALL_URL" | bash -s -- claude   # Claude Code / Agent SDK
-curl -sSL "$INSTALL_URL" | bash -s -- codex    # OpenAI Codex
-curl -sSL "$INSTALL_URL" | bash -s -- cursor   # Cursor IDE
+curl -sSL "$INSTALL_URL" | bash -s -- claude    # Claude Code / Agent SDK
+curl -sSL "$INSTALL_URL" | bash -s -- codex     # OpenAI Codex
+curl -sSL "$INSTALL_URL" | bash -s -- cursor    # Cursor IDE / CLI
+curl -sSL "$INSTALL_URL" | bash -s -- copilot   # GitHub Copilot (VS Code + CLI)
 ```
 
 **Or run locally:**
 
 ```bash
-./install.sh claude   # Claude Code / Agent SDK
-./install.sh codex    # OpenAI Codex
-./install.sh cursor   # Cursor IDE
+./install.sh claude    # Claude Code / Agent SDK
+./install.sh codex     # OpenAI Codex
+./install.sh cursor    # Cursor IDE / CLI
+./install.sh copilot   # GitHub Copilot (VS Code + CLI)
 ```
 
 The installer:

--- a/cursor_tracing/README.md
+++ b/cursor_tracing/README.md
@@ -4,7 +4,7 @@ Automatic [OpenInference](https://github.com/Arize-ai/openinference) tracing for
 
 ## Features
 
-- 12 hook-based span types covering the full Cursor session lifecycle
+- 15 hook-based span types covering the full Cursor session lifecycle
 - Before/after event merging for shell execution and MCP tool use via disk-backed state stack
 - Sends spans directly to Phoenix (REST) or Arize AX (HTTP) — no background process needed
 - Per-harness backend credentials via `harnesses.cursor.*` in config
@@ -88,16 +88,17 @@ If you used the installer, hooks.json is generated automatically with the correc
 
 If your project already has a `.cursor/hooks.json`, merge the hook entries rather than overwriting the file. The setup script handles this automatically.
 
-> **Note:** All 12 hook events route to the same `arize-hook-cursor` CLI entry point. The handler reads `hook_event_name` from the stdin JSON payload and dispatches to the appropriate logic.
+> **Note:** All 15 hook events route to the same `arize-hook-cursor` CLI entry point. The handler reads `hook_event_name` from the stdin JSON payload and dispatches to the appropriate logic.
 
 ## Hook Events
 
 ### IDE Hooks
 
-The Cursor IDE fires 12 hook events. Each produces one OpenInference span (or pushes state for later merging):
+The Cursor IDE fires 15 hook events. Each produces one OpenInference span (or pushes state for later merging):
 
 | Hook Event | Span Name | Span Kind | Description |
 |------------|-----------|-----------|-------------|
+| `sessionStart` | Session Start | CHAIN | Root span for the conversation; captures session metadata |
 | `beforeSubmitPrompt` | User Prompt | CHAIN | Root span for the turn; captures user prompt text |
 | `afterAgentResponse` | Agent Response | LLM | Agent's response with input/output values |
 | `afterAgentThought` | Agent Thinking | CHAIN | Agent's intermediate reasoning step |
@@ -109,7 +110,9 @@ The Cursor IDE fires 12 hook events. Each produces one OpenInference span (or pu
 | `afterFileEdit` | File Edit | TOOL | File path and edit details |
 | `beforeTabFileRead` | Tab Read File | TOOL | File read from a tab context |
 | `afterTabFileEdit` | Tab File Edit | TOOL | File edit from a tab context |
-| `stop` | Agent Stop | CHAIN | Session or conversation stop event |
+| `postToolUse` | Tool: {name} | TOOL | Generic tool span; postToolUse is suppressed for tools with a dedicated handler (Shell, Read, File Edit, Tab ops, MCP) to avoid duplicate spans |
+| `stop` | Agent Stop | CHAIN | Per-turn stop event with token counts when available |
+| `sessionEnd` | Session End | CHAIN | End-of-session span with duration and final status |
 
 ### CLI Hooks
 
@@ -117,6 +120,7 @@ Cursor CLI currently emits a smaller hook surface than the IDE. The supported
 CLI hooks in this package are:
 
 - `sessionStart`
+- `sessionEnd`
 - `beforeShellExecution`
 - `afterShellExecution`
 - `afterFileEdit`
@@ -127,6 +131,15 @@ Cursor CLI hooks do not currently emit afterAgentResponse or afterAgentThought.
 
 Full Cursor CLI assistant and thinking coverage requires parsing --output-format stream-json, which is out of scope for this change.
 
+### What We Capture
+
+- **`sessionStart`** produces a `Session Start` CHAIN span that acts as the root for the conversation.
+- **`sessionEnd`** produces a `Session End` CHAIN span with `cursor.session.duration_ms`, `cursor.session.final_status`, `cursor.session.reason`, and end-of-session token counts when available.
+- **`stop`** produces an `Agent Stop` CHAIN span with per-turn token counts captured when the payload includes them: `llm.token_count.prompt`, `llm.token_count.completion`, `llm.token_count.cache_read`, `llm.token_count.cache_write`, `llm.token_count.total`, and `llm.model_name`.
+- **`postToolUse`** produces a generic `Tool: <name>` span ONLY for tools without a dedicated handler. Shell, file read/edit, tab file ops, and MCP execution are handled by their dedicated `before*`/`after*` events; the generic postToolUse is suppressed for these to avoid duplicate spans.
+
+Every span includes `cursor.conversation.id` as a span attribute. Since `sessionStart` and per-turn activity use different `trace_id` values, `cursor.conversation.id` is the recommended cross-trace join key in Arize. To gather all activity for a Cursor session regardless of trace, filter spans by `attributes.cursor.conversation.id = "<id>"`.
+
 ### Hooks JSON Example (IDE + CLI)
 
 ```json
@@ -134,6 +147,7 @@ Full Cursor CLI assistant and thinking coverage requires parsing --output-format
   "version": 1,
   "hooks": {
     "sessionStart": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "sessionEnd": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
     "beforeSubmitPrompt": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
     "afterAgentResponse": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
     "afterAgentThought": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
@@ -226,7 +240,7 @@ Hook logic lives in `core/` at the repository root (installed as a Python packag
 core/
   hooks/cursor/
     adapter.py       Cursor-specific state stack, ID generation, sanitize
-    handlers.py      12-event dispatcher entry point
+    handlers.py      15-event dispatcher entry point
   common.py          Shared: span building, direct send, state, logging, IDs
   config.py          YAML config helper
   constants.py       Single source of truth for all paths

--- a/cursor_tracing/constants.py
+++ b/cursor_tracing/constants.py
@@ -10,9 +10,9 @@ HARNESS_BIN = "cursor"  # binary name for shutil.which() fallback
 HOOKS_FILE = Path.home() / ".cursor" / "hooks.json"
 HOOK_BIN_NAME = "arize-hook-cursor"
 
-# 14 events, all routed to a single CLI entry point (the handler dispatches
+# 15 events, all routed to a single CLI entry point (the handler dispatches
 # based on hook_event_name / hookEventName in the JSON payload).
-# Includes IDE events plus CLI-specific events (sessionStart, postToolUse).
+# Includes IDE events plus CLI-specific events (sessionStart, sessionEnd, postToolUse).
 HOOK_EVENTS = (
     "beforeSubmitPrompt",
     "afterAgentResponse",
@@ -27,5 +27,6 @@ HOOK_EVENTS = (
     "beforeTabFileRead",
     "afterTabFileEdit",
     "sessionStart",
+    "sessionEnd",
     "postToolUse",
 )

--- a/cursor_tracing/hooks/handlers.py
+++ b/cursor_tracing/hooks/handlers.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Cursor hook handler: single entry point dispatching all 14 Cursor hook events.
+"""Cursor hook handler: single entry point dispatching all 15 Cursor hook events.
 
 Replaces cursor-tracing/hooks/hook-handler.sh (475 lines).
 
-Input contract: JSON on stdin, all 14 events (IDE + CLI) routed here.
+Input contract: JSON on stdin, all 15 events (IDE + CLI) routed here.
 stdout: MUST print permissive JSON response, even on error.
 stderr: redirected to ARIZE_LOG_FILE before dispatch.
 """
@@ -57,6 +57,14 @@ def _jq_str(input_json: dict, *keys, default: str = "") -> str:
         if val is not None and val != "":
             return str(val)
     return default
+
+
+def _to_int(v):
+    """Coerce *v* to int if possible; return None for None, empty, or ``"--"``."""
+    try:
+        return int(v) if v not in (None, "", "--") else None
+    except (TypeError, ValueError):
+        return None
 
 
 def _event_name(input_json: dict) -> str:
@@ -129,6 +137,7 @@ def _dispatch(event: str, input_json: dict) -> None:
         "afterTabFileEdit": _handle_after_tab_file_edit,
         "stop": _handle_stop,
         "sessionStart": _handle_session_start,
+        "sessionEnd": _handle_session_end,
         "postToolUse": _handle_post_tool_use,
     }
 
@@ -181,6 +190,8 @@ def _handle_before_submit_prompt(input_json, conversation_id, gen_id, trace_id, 
         "input.value": prompt,
         "session.id": conversation_id,
     }
+    if conversation_id:
+        root_attrs["cursor.conversation.id"] = conversation_id
     if model:
         root_attrs["llm.model_name"] = model
 
@@ -217,12 +228,15 @@ def _handle_after_agent_response(input_json, conversation_id, gen_id, trace_id, 
 
     # IDE: send User Prompt CHAIN first (parent before LLM for strict backends), full I/O + duration.
     if root_state and deferred_root:
+        root_conv_id = root_state.get("conversation_id", conversation_id)
         root_attrs = {
             "openinference.span.kind": "CHAIN",
             "input.value": prompt,
             "output.value": response,
-            "session.id": root_state.get("conversation_id", conversation_id),
+            "session.id": root_conv_id,
         }
+        if root_conv_id:
+            root_attrs["cursor.conversation.id"] = root_conv_id
         root_model = model or root_state.get("model", "")
         if root_model:
             root_attrs["llm.model_name"] = root_model
@@ -249,6 +263,8 @@ def _handle_after_agent_response(input_json, conversation_id, gen_id, trace_id, 
         "output.value": response,
         "session.id": conversation_id,
     }
+    if conversation_id:
+        attrs["cursor.conversation.id"] = conversation_id
     if model:
         attrs["llm.model_name"] = model
 
@@ -280,6 +296,8 @@ def _handle_after_agent_thought(input_json, conversation_id, gen_id, trace_id, n
         "output.value": thought,
         "session.id": conversation_id,
     }
+    if conversation_id:
+        attrs["cursor.conversation.id"] = conversation_id
 
     span = build_span(
         "Agent Thinking",
@@ -347,6 +365,8 @@ def _handle_after_shell_execution(input_json, conversation_id, gen_id, trace_id,
         "output.value": output,
         "session.id": conversation_id,
     }
+    if conversation_id:
+        attrs["cursor.conversation.id"] = conversation_id
     if exit_code:
         attrs["shell.exit_code"] = exit_code
 
@@ -422,6 +442,8 @@ def _handle_after_mcp_execution(input_json, conversation_id, gen_id, trace_id, n
         "output.value": result,
         "session.id": conversation_id,
     }
+    if conversation_id:
+        attrs["cursor.conversation.id"] = conversation_id
 
     span = build_span(
         f"MCP: {tool_name}",
@@ -452,6 +474,8 @@ def _handle_before_read_file(input_json, conversation_id, gen_id, trace_id, now_
         "input.value": file_path,
         "session.id": conversation_id,
     }
+    if conversation_id:
+        attrs["cursor.conversation.id"] = conversation_id
 
     span = build_span(
         "Read File",
@@ -484,6 +508,8 @@ def _handle_after_file_edit(input_json, conversation_id, gen_id, trace_id, now_m
         "input.value": input_val,
         "session.id": conversation_id,
     }
+    if conversation_id:
+        attrs["cursor.conversation.id"] = conversation_id
 
     span = build_span(
         "File Edit",
@@ -514,6 +540,8 @@ def _handle_before_tab_file_read(input_json, conversation_id, gen_id, trace_id, 
         "input.value": file_path,
         "session.id": conversation_id,
     }
+    if conversation_id:
+        attrs["cursor.conversation.id"] = conversation_id
 
     span = build_span(
         "Tab Read File",
@@ -546,6 +574,8 @@ def _handle_after_tab_file_edit(input_json, conversation_id, gen_id, trace_id, n
         "input.value": input_val,
         "session.id": conversation_id,
     }
+    if conversation_id:
+        attrs["cursor.conversation.id"] = conversation_id
 
     span = build_span(
         "Tab File Edit",
@@ -575,10 +605,41 @@ def _handle_stop(input_json, conversation_id, gen_id, trace_id, now_ms):
         "openinference.span.kind": "CHAIN",
         "session.id": conversation_id,
     }
+    if conversation_id:
+        attrs["cursor.conversation.id"] = conversation_id
     if status:
         attrs["cursor.stop.status"] = status
     if loop_count:
         attrs["cursor.stop.loop_count"] = loop_count
+
+    # Token counts from CLI stop payload
+    # Use explicit None checks — 0 is a valid token count but falsy with ``or``
+    _inp_tok = input_json.get("input_tokens")
+    prompt_tokens = _to_int(_inp_tok if _inp_tok is not None else input_json.get("inputTokens"))
+    _out_tok = input_json.get("output_tokens")
+    completion_tokens = _to_int(_out_tok if _out_tok is not None else input_json.get("outputTokens"))
+    _cr_tok = input_json.get("cache_read_tokens")
+    cache_read = _to_int(_cr_tok if _cr_tok is not None else input_json.get("cacheReadTokens"))
+    _cw_tok = input_json.get("cache_write_tokens")
+    cache_write = _to_int(_cw_tok if _cw_tok is not None else input_json.get("cacheWriteTokens"))
+    model = _jq_str(input_json, "model")
+    _dur = input_json.get("duration_ms")
+    duration_ms = _to_int(_dur if _dur is not None else input_json.get("durationMs"))
+
+    if prompt_tokens is not None:
+        attrs["llm.token_count.prompt"] = prompt_tokens
+    if completion_tokens is not None:
+        attrs["llm.token_count.completion"] = completion_tokens
+    if cache_read is not None:
+        attrs["llm.token_count.cache_read"] = cache_read
+    if cache_write is not None:
+        attrs["llm.token_count.cache_write"] = cache_write
+    if prompt_tokens is not None and completion_tokens is not None:
+        attrs["llm.token_count.total"] = prompt_tokens + completion_tokens
+    if model:
+        attrs["llm.model_name"] = model
+    if duration_ms is not None:
+        attrs["cursor.stop.duration_ms"] = duration_ms
 
     span = build_span(
         "Agent Stop",
@@ -607,6 +668,8 @@ def _handle_session_start(input_json, conversation_id, gen_id, trace_id, now_ms)
         "openinference.span.kind": "CHAIN",
         "session.id": conversation_id,
     }
+    if conversation_id:
+        attrs["cursor.conversation.id"] = conversation_id
 
     cwd = _jq_str(input_json, "cwd", "workspace_root")
     if cwd:
@@ -636,15 +699,87 @@ def _handle_session_start(input_json, conversation_id, gen_id, trace_id, now_ms)
     log(f"sessionStart: span {sid} (trace={trace_id})")
 
 
+def _handle_session_end(input_json, conversation_id, gen_id, trace_id, now_ms):
+    """CHAIN span for Cursor CLI sessionEnd event — closes the session.
+
+    Reuses tokens/duration from the payload when present.  Always cleans up
+    the gen_id keyed root span if one was saved by sessionStart.
+    """
+    sid = span_id_16()
+    parent = gen_root_span_get(gen_id)
+
+    _dur = input_json.get("duration_ms")
+    duration_ms = _to_int(_dur if _dur is not None else input_json.get("durationMs"))
+    final_status = _jq_str(input_json, "final_status", "finalStatus", "status")
+    reason = _jq_str(input_json, "reason")
+
+    attrs = {
+        "openinference.span.kind": "CHAIN",
+        "session.id": conversation_id,
+    }
+    if conversation_id:
+        attrs["cursor.conversation.id"] = conversation_id
+    if duration_ms is not None:
+        attrs["cursor.session.duration_ms"] = duration_ms
+    if final_status:
+        attrs["cursor.session.final_status"] = final_status
+    if reason:
+        attrs["cursor.session.reason"] = reason
+
+    # Token fields can also appear on sessionEnd
+    _inp_tok = input_json.get("input_tokens")
+    prompt_tokens = _to_int(_inp_tok if _inp_tok is not None else input_json.get("inputTokens"))
+    _out_tok = input_json.get("output_tokens")
+    completion_tokens = _to_int(_out_tok if _out_tok is not None else input_json.get("outputTokens"))
+    if prompt_tokens is not None:
+        attrs["llm.token_count.prompt"] = prompt_tokens
+    if completion_tokens is not None:
+        attrs["llm.token_count.completion"] = completion_tokens
+    if prompt_tokens is not None and completion_tokens is not None:
+        attrs["llm.token_count.total"] = prompt_tokens + completion_tokens
+
+    span = build_span(
+        "Session End",
+        "CHAIN",
+        sid,
+        trace_id,
+        parent,
+        now_ms,
+        now_ms,
+        attrs,
+        SERVICE_NAME,
+        SCOPE_NAME,
+    )
+    send_span(span)
+
+    if gen_id:
+        state_cleanup_generation(gen_id)
+    log(f"sessionEnd: span {sid}, cleaned up gen={gen_id}")
+
+
 _SHELL_TOOL_NAMES = frozenset({"shell", "terminal", "bash", "run_command"})
+
+_DEDICATED_TOOL_NAMES = frozenset({
+    "shell", "terminal", "bash", "run_command", "run_shell",
+    "read_file", "read", "view_file", "view",
+    "edit_file", "edit", "write_file", "write", "create_file", "delete_file",
+    "tab_file_read", "tab_file_edit",
+    "mcp", "mcp_execution",
+})
 
 
 def _handle_post_tool_use(input_json, conversation_id, gen_id, trace_id, now_ms):
     """TOOL span for Cursor CLI postToolUse event."""
+    tool_name = _jq_str(input_json, "tool_name", "toolName", "name", "tool")
+
+    # Dedup: skip tools that have dedicated before*/after* handlers
+    if tool_name.lower() in _DEDICATED_TOOL_NAMES:
+        log(f"postToolUse: skipping {tool_name!r} — covered by dedicated handler")
+        return
+
     sid = span_id_16()
     parent = gen_root_span_get(gen_id) if gen_id else ""
 
-    tool_name = _jq_str(input_json, "tool_name", "toolName", "name", "tool")
     tool_input = _jq_str(input_json, "tool_input", "toolInput", "input", "arguments", "args")
     output = _jq_str(input_json, "result", "output", "response", "stdout")
 
@@ -658,6 +793,8 @@ def _handle_post_tool_use(input_json, conversation_id, gen_id, trace_id, now_ms)
         "openinference.span.kind": "TOOL",
         "session.id": conversation_id,
     }
+    if conversation_id:
+        attrs["cursor.conversation.id"] = conversation_id
     if tool_name:
         attrs["tool.name"] = tool_name
     if tool_input:
@@ -691,7 +828,7 @@ def _handle_post_tool_use(input_json, conversation_id, gen_id, trace_id, now_ms)
 def main():
     """Entry point for arize-hook-cursor. Cursor hook.
 
-    Input contract: JSON on stdin, all 14 events (IDE + CLI) routed here.
+    Input contract: JSON on stdin, all 15 events (IDE + CLI) routed here.
     stdout: MUST print permissive JSON response, even on error.
     stderr: redirected to ARIZE_LOG_FILE before dispatch.
     """

--- a/cursor_tracing/hooks/handlers.py
+++ b/cursor_tracing/hooks/handlers.py
@@ -757,8 +757,6 @@ def _handle_session_end(input_json, conversation_id, gen_id, trace_id, now_ms):
     log(f"sessionEnd: span {sid}, cleaned up gen={gen_id}")
 
 
-_SHELL_TOOL_NAMES = frozenset({"shell", "terminal", "bash", "run_command"})
-
 _DEDICATED_TOOL_NAMES = frozenset(
     {
         "shell",
@@ -798,12 +796,6 @@ def _handle_post_tool_use(input_json, conversation_id, gen_id, trace_id, now_ms)
 
     tool_input = _jq_str(input_json, "tool_input", "toolInput", "input", "arguments", "args")
     output = _jq_str(input_json, "result", "output", "response", "stdout")
-
-    # Shell-like tools: prefer the top-level ``command`` field as input
-    if tool_name.lower() in _SHELL_TOOL_NAMES:
-        command = _jq_str(input_json, "command")
-        if command:
-            tool_input = command
 
     attrs = {
         "openinference.span.kind": "TOOL",

--- a/cursor_tracing/hooks/handlers.py
+++ b/cursor_tracing/hooks/handlers.py
@@ -759,13 +759,29 @@ def _handle_session_end(input_json, conversation_id, gen_id, trace_id, now_ms):
 
 _SHELL_TOOL_NAMES = frozenset({"shell", "terminal", "bash", "run_command"})
 
-_DEDICATED_TOOL_NAMES = frozenset({
-    "shell", "terminal", "bash", "run_command", "run_shell",
-    "read_file", "read", "view_file", "view",
-    "edit_file", "edit", "write_file", "write", "create_file", "delete_file",
-    "tab_file_read", "tab_file_edit",
-    "mcp", "mcp_execution",
-})
+_DEDICATED_TOOL_NAMES = frozenset(
+    {
+        "shell",
+        "terminal",
+        "bash",
+        "run_command",
+        "run_shell",
+        "read_file",
+        "read",
+        "view_file",
+        "view",
+        "edit_file",
+        "edit",
+        "write_file",
+        "write",
+        "create_file",
+        "delete_file",
+        "tab_file_read",
+        "tab_file_edit",
+        "mcp",
+        "mcp_execution",
+    }
+)
 
 
 def _handle_post_tool_use(input_json, conversation_id, gen_id, trace_id, now_ms):

--- a/cursor_tracing/skills/manage-cursor-tracing/SKILL.md
+++ b/cursor_tracing/skills/manage-cursor-tracing/SKILL.md
@@ -131,6 +131,8 @@ Create `.cursor/hooks.json` in the user's project (or merge into it if it alread
 {
   "version": 1,
   "hooks": {
+    "sessionStart": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "sessionEnd": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
     "beforeSubmitPrompt": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
     "afterAgentResponse": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
     "afterAgentThought": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
@@ -142,7 +144,8 @@ Create `.cursor/hooks.json` in the user's project (or merge into it if it alread
     "afterFileEdit": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
     "stop": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
     "beforeTabFileRead": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
-    "afterTabFileEdit": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }]
+    "afterTabFileEdit": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "postToolUse": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }]
   }
 }
 ```
@@ -170,10 +173,11 @@ Tell the user:
 
 ### IDE Hooks
 
-Cursor IDE fires 12 hook events. Here's what each one traces:
+Cursor IDE fires 15 hook events. Here's what each one traces:
 
 | Event | Span Name | Kind | Description |
 |-------|-----------|------|-------------|
+| `sessionStart` | Session Start | CHAIN | Root span for the conversation; captures session metadata |
 | `beforeSubmitPrompt` | User Prompt | CHAIN | Root span for the turn; captures prompt text, model, attachments |
 | `afterAgentResponse` | Agent Response | LLM | LLM response text and model name |
 | `afterAgentThought` | Agent Thinking | CHAIN | Agent thinking/reasoning text |
@@ -185,7 +189,9 @@ Cursor IDE fires 12 hook events. Here's what each one traces:
 | `afterFileEdit` | File Edit | TOOL | File path and edit details |
 | `beforeTabFileRead` | Tab Read File | TOOL | Tab file read (file path) |
 | `afterTabFileEdit` | Tab File Edit | TOOL | Tab file edit (path and edits) |
-| `stop` | Agent Stop | CHAIN | Turn completion status and loop count |
+| `postToolUse` | Tool: {name} | TOOL | Generic tool span; postToolUse is suppressed for tools with a dedicated handler (Shell, Read, File Edit, Tab ops, MCP) to avoid duplicate spans |
+| `stop` | Agent Stop | CHAIN | Per-turn stop event with token counts when available |
+| `sessionEnd` | Session End | CHAIN | End-of-session span with duration and final status |
 
 Shell and MCP events use a disk-backed state stack to merge before/after context into single spans with both input and output.
 
@@ -195,6 +201,7 @@ Cursor CLI currently emits a smaller hook surface than the IDE. The supported
 CLI hooks in this package are:
 
 - `sessionStart`
+- `sessionEnd`
 - `beforeShellExecution`
 - `afterShellExecution`
 - `afterFileEdit`
@@ -205,6 +212,15 @@ Cursor CLI hooks do not currently emit afterAgentResponse or afterAgentThought.
 
 Full Cursor CLI assistant and thinking coverage requires parsing --output-format stream-json, which is out of scope for this change.
 
+### What We Capture
+
+- **`sessionStart`** produces a `Session Start` CHAIN span that acts as the root for the conversation.
+- **`sessionEnd`** produces a `Session End` CHAIN span with `cursor.session.duration_ms`, `cursor.session.final_status`, `cursor.session.reason`, and end-of-session token counts when available.
+- **`stop`** produces an `Agent Stop` CHAIN span with per-turn token counts captured when the payload includes them: `llm.token_count.prompt`, `llm.token_count.completion`, `llm.token_count.cache_read`, `llm.token_count.cache_write`, `llm.token_count.total`, and `llm.model_name`.
+- **`postToolUse`** produces a generic `Tool: <name>` span ONLY for tools without a dedicated handler. Shell, file read/edit, tab file ops, and MCP execution are handled by their dedicated `before*`/`after*` events; the generic postToolUse is suppressed for these to avoid duplicate spans.
+
+Every span includes `cursor.conversation.id` as a span attribute. Since `sessionStart` and per-turn activity use different `trace_id` values, `cursor.conversation.id` is the recommended cross-trace join key in Arize. To gather all activity for a Cursor session regardless of trace, filter spans by `attributes.cursor.conversation.id = "<id>"`.
+
 ### Hooks JSON Example (IDE + CLI)
 
 When configuring `.cursor/hooks.json`, include both IDE and CLI events:
@@ -214,6 +230,7 @@ When configuring `.cursor/hooks.json`, include both IDE and CLI events:
   "version": 1,
   "hooks": {
     "sessionStart": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
+    "sessionEnd": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
     "beforeSubmitPrompt": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
     "afterAgentResponse": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],
     "afterAgentThought": [{ "command": "~/.arize/harness/venv/bin/arize-hook-cursor" }],

--- a/tests/test_cursor_hook.py
+++ b/tests/test_cursor_hook.py
@@ -1487,7 +1487,10 @@ class TestHandleStopTokenCounts:
                 },
             )
 
-        attrs = {a["key"]: a["value"] for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]}
+        attrs = {
+            a["key"]: a["value"]
+            for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
+        }
         assert attrs["llm.token_count.prompt"]["intValue"] == 100
         assert "llm.token_count.completion" not in attrs
         assert "llm.token_count.cache_read" not in attrs
@@ -1676,9 +1679,9 @@ class TestConversationIdAttribute:
         for sent in captured_spans:
             span = sent["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
             attrs = {a["key"]: a["value"] for a in span["attributes"]}
-            assert attrs.get("cursor.conversation.id", {}).get("stringValue") == "conv-abc", (
-                f"cursor.conversation.id missing or wrong on {event} span {span['name']}"
-            )
+            assert (
+                attrs.get("cursor.conversation.id", {}).get("stringValue") == "conv-abc"
+            ), f"cursor.conversation.id missing or wrong on {event} span {span['name']}"
 
     def test_conversation_id_attribute_omitted_when_missing(self, captured_spans, monkeypatch):
         """When conversation_id is empty, cursor.conversation.id is not set."""

--- a/tests/test_cursor_hook.py
+++ b/tests/test_cursor_hook.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for cursor_tracing.hooks.handlers — the Cursor hook dispatcher and 14 event handlers."""
+"""Tests for cursor_tracing.hooks.handlers — the Cursor hook dispatcher and 15 event handlers."""
 
 import io
 import json
@@ -1124,6 +1124,21 @@ class TestDispatchNewEvents:
             )
             h.assert_called_once()
 
+    def test_dispatch_routes_session_end(self, monkeypatch):
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=1000),
+            mock.patch("cursor_tracing.hooks.handlers._handle_session_end") as h,
+        ):
+            _dispatch(
+                "sessionEnd",
+                {
+                    "conversation_id": "c1",
+                    "generation_id": "g1",
+                },
+            )
+            h.assert_called_once()
+
     def test_dispatch_routes_post_tool_use(self, monkeypatch):
         monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
         with (
@@ -1260,25 +1275,25 @@ class TestHandlePostToolUse:
                 {
                     "conversation_id": "conv-pt",
                     "generation_id": "gen-pt",
-                    "toolName": "read_file",
-                    "toolInput": '{"path": "src/main.py"}',
-                    "result": "<file contents elided>",
+                    "toolName": "code_search",
+                    "toolInput": '{"query": "main function"}',
+                    "result": "<search results>",
                 },
             )
 
         assert len(captured_spans) == 1
         span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
         attrs = {a["key"]: a["value"] for a in span["attributes"]}
-        assert span["name"] == "Tool: read_file"
+        assert span["name"] == "Tool: code_search"
         assert attrs["openinference.span.kind"]["stringValue"] == "TOOL"
-        assert attrs["tool.name"]["stringValue"] == "read_file"
-        assert attrs["input.value"]["stringValue"] == '{"path": "src/main.py"}'
-        assert attrs["output.value"]["stringValue"] == "<file contents elided>"
+        assert attrs["tool.name"]["stringValue"] == "code_search"
+        assert attrs["input.value"]["stringValue"] == '{"query": "main function"}'
+        assert attrs["output.value"]["stringValue"] == "<search results>"
         assert attrs["session.id"]["stringValue"] == "conv-pt"
         assert span["parentSpanId"] == "parent-pt"
 
-    def test_post_tool_use_shell_command_uses_command_as_input(self, captured_spans, monkeypatch):
-        """Shell-like postToolUse uses 'command' field as input.value."""
+    def test_post_tool_use_unknown_tool_uses_command_field_when_present(self, captured_spans, monkeypatch):
+        """Non-deduped shell-like tool uses 'command' field as input.value fallback."""
         monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
         with (
             mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=3000),
@@ -1289,10 +1304,9 @@ class TestHandlePostToolUse:
                 {
                     "conversation_id": "c1",
                     "generation_id": "g1",
-                    "toolName": "shell",
+                    "toolName": "custom_runner",
                     "command": "ls -la",
                     "stdout": "total 40\ndrwxr-xr-x ...",
-                    "exit_code": 0,
                 },
             )
 
@@ -1300,33 +1314,9 @@ class TestHandlePostToolUse:
             a["key"]: a["value"]
             for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
         }
-        assert attrs["input.value"]["stringValue"] == "ls -la"
+        # custom_runner is not in _SHELL_TOOL_NAMES so command field is NOT used as input
+        # tool_input comes from the standard extraction keys
         assert attrs["output.value"]["stringValue"] == "total 40\ndrwxr-xr-x ..."
-
-    def test_post_tool_use_bash_tool_uses_command(self, captured_spans, monkeypatch):
-        """Other shell-like tool names (bash, terminal, run_command) also use command."""
-        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
-        for tool in ("bash", "terminal", "run_command"):
-            captured_spans.clear()
-            with (
-                mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=3000),
-                mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
-            ):
-                _dispatch(
-                    "postToolUse",
-                    {
-                        "conversation_id": "c1",
-                        "generation_id": "g1",
-                        "toolName": tool,
-                        "command": "echo hi",
-                    },
-                )
-
-            attrs = {
-                a["key"]: a["value"]
-                for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
-            }
-            assert attrs["input.value"]["stringValue"] == "echo hi", f"Failed for tool={tool}"
 
     def test_post_tool_use_missing_fields_omitted(self, captured_spans, monkeypatch):
         """Missing optional fields are omitted from attributes."""
@@ -1347,3 +1337,417 @@ class TestHandlePostToolUse:
         assert "tool.name" not in attr_keys
         assert "input.value" not in attr_keys
         assert "output.value" not in attr_keys
+
+    def test_post_tool_use_skips_shell_tool(self, captured_spans, monkeypatch):
+        """postToolUse with tool_name='shell' is skipped (covered by dedicated handler)."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=3000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
+        ):
+            _dispatch(
+                "postToolUse",
+                {
+                    "conversation_id": "c1",
+                    "generation_id": "g1",
+                    "toolName": "shell",
+                    "command": "ls -la",
+                },
+            )
+
+        assert len(captured_spans) == 0
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        ["shell", "Shell", "TERMINAL", "bash", "read_file", "edit_file", "tab_file_read", "mcp"],
+    )
+    def test_post_tool_use_skips_each_dedicated_tool_name(self, captured_spans, monkeypatch, tool_name):
+        """postToolUse short-circuits for each known dedicated tool name (case-insensitive)."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=3000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
+        ):
+            _dispatch(
+                "postToolUse",
+                {
+                    "conversation_id": "c1",
+                    "generation_id": "g1",
+                    "toolName": tool_name,
+                },
+            )
+
+        assert len(captured_spans) == 0, f"Expected no span for tool_name={tool_name!r}"
+
+    def test_post_tool_use_emits_for_unknown_tool_name(self, captured_spans, monkeypatch):
+        """postToolUse emits a span for tools not in the dedup set."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=3000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
+        ):
+            _dispatch(
+                "postToolUse",
+                {
+                    "conversation_id": "c1",
+                    "generation_id": "g1",
+                    "toolName": "glob",
+                    "toolInput": '{"pattern": "*.py"}',
+                },
+            )
+
+        assert len(captured_spans) == 1
+        span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert span["name"] == "Tool: glob"
+        assert attrs["tool.name"]["stringValue"] == "glob"
+        assert attrs["input.value"]["stringValue"] == '{"pattern": "*.py"}'
+
+
+# ---------------------------------------------------------------------------
+# _handle_stop token count tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandleStopTokenCounts:
+
+    def test_stop_captures_token_counts(self, captured_spans, monkeypatch):
+        """Stop payload with token fields produces llm.token_count.* attributes."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=5000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value="root1"),
+            mock.patch("cursor_tracing.hooks.handlers.state_cleanup_generation"),
+        ):
+            _dispatch(
+                "stop",
+                {
+                    "conversation_id": "conv-1",
+                    "generation_id": "gen-1",
+                    "status": "completed",
+                    "input_tokens": 85919,
+                    "output_tokens": 1523,
+                    "cache_read_tokens": 68000,
+                    "cache_write_tokens": 0,
+                    "model": "claude-sonnet-4.5",
+                },
+            )
+
+        assert len(captured_spans) == 1
+        span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert attrs["llm.token_count.prompt"]["intValue"] == 85919
+        assert attrs["llm.token_count.completion"]["intValue"] == 1523
+        assert attrs["llm.token_count.cache_read"]["intValue"] == 68000
+        assert attrs["llm.token_count.cache_write"]["intValue"] == 0
+        assert attrs["llm.token_count.total"]["intValue"] == 87442
+        assert attrs["llm.model_name"]["stringValue"] == "claude-sonnet-4.5"
+
+    def test_stop_omits_token_attrs_when_payload_has_none(self, captured_spans, monkeypatch):
+        """Stop payload without token fields produces no llm.token_count.* attributes."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=5000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
+            mock.patch("cursor_tracing.hooks.handlers.state_cleanup_generation"),
+        ):
+            _dispatch(
+                "stop",
+                {
+                    "conversation_id": "conv-1",
+                    "generation_id": "gen-1",
+                    "status": "completed",
+                },
+            )
+
+        attr_keys = {a["key"] for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]}
+        assert "llm.token_count.prompt" not in attr_keys
+        assert "llm.token_count.completion" not in attr_keys
+        assert "llm.token_count.cache_read" not in attr_keys
+        assert "llm.token_count.cache_write" not in attr_keys
+        assert "llm.token_count.total" not in attr_keys
+        assert "llm.model_name" not in attr_keys
+
+    def test_stop_token_count_handles_string_and_dash_values(self, captured_spans, monkeypatch):
+        """String token values are coerced; '--' and None are omitted."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=5000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
+            mock.patch("cursor_tracing.hooks.handlers.state_cleanup_generation"),
+        ):
+            _dispatch(
+                "stop",
+                {
+                    "conversation_id": "conv-1",
+                    "generation_id": "gen-1",
+                    "input_tokens": "100",
+                    "output_tokens": "--",
+                    "cache_read_tokens": None,
+                },
+            )
+
+        attrs = {a["key"]: a["value"] for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]}
+        assert attrs["llm.token_count.prompt"]["intValue"] == 100
+        assert "llm.token_count.completion" not in attrs
+        assert "llm.token_count.cache_read" not in attrs
+        assert "llm.token_count.total" not in attrs
+
+
+# ---------------------------------------------------------------------------
+# _handle_session_end tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandleSessionEnd:
+
+    def test_session_end_emits_chain_span_with_duration_and_status(self, captured_spans, monkeypatch):
+        """sessionEnd produces a CHAIN span with duration, status, and reason."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=9000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value="root-se"),
+            mock.patch("cursor_tracing.hooks.handlers.state_cleanup_generation"),
+        ):
+            _dispatch(
+                "sessionEnd",
+                {
+                    "conversation_id": "conv-end",
+                    "generation_id": "gen-end",
+                    "duration_ms": 7447445,
+                    "final_status": "completed",
+                    "reason": "window_close",
+                },
+            )
+
+        assert len(captured_spans) == 1
+        span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert span["name"] == "Session End"
+        assert attrs["openinference.span.kind"]["stringValue"] == "CHAIN"
+        assert attrs["cursor.session.duration_ms"]["intValue"] == 7447445
+        assert attrs["cursor.session.final_status"]["stringValue"] == "completed"
+        assert attrs["cursor.session.reason"]["stringValue"] == "window_close"
+        assert attrs["session.id"]["stringValue"] == "conv-end"
+        assert span["parentSpanId"] == "root-se"
+
+    def test_session_end_cleans_up_generation(self, captured_spans, monkeypatch):
+        """sessionEnd calls state_cleanup_generation with the gen_id."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=9000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
+            mock.patch("cursor_tracing.hooks.handlers.state_cleanup_generation") as cleanup,
+        ):
+            _dispatch(
+                "sessionEnd",
+                {
+                    "conversation_id": "conv-end",
+                    "generation_id": "g-123",
+                },
+            )
+
+        cleanup.assert_called_once_with("g-123")
+
+    def test_session_end_handles_empty_payload(self, captured_spans, monkeypatch):
+        """sessionEnd with only conversation_id emits a span without optional attrs."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=9000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
+            mock.patch("cursor_tracing.hooks.handlers.state_cleanup_generation"),
+        ):
+            _dispatch(
+                "sessionEnd",
+                {
+                    "conversation_id": "conv-end",
+                },
+            )
+
+        assert len(captured_spans) == 1
+        attr_keys = {a["key"] for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]}
+        assert "session.id" in attr_keys
+        assert "cursor.conversation.id" in attr_keys
+        assert "cursor.session.duration_ms" not in attr_keys
+        assert "cursor.session.final_status" not in attr_keys
+        assert "cursor.session.reason" not in attr_keys
+        assert "llm.token_count.prompt" not in attr_keys
+
+
+# ---------------------------------------------------------------------------
+# cursor.conversation.id attribute tests
+# ---------------------------------------------------------------------------
+
+
+class TestConversationIdAttribute:
+
+    # Minimal payloads per event that produce at least one span
+    _EVENT_PAYLOADS = {
+        "beforeSubmitPrompt": {
+            "hookEventName": "beforeSubmitPrompt",  # CLI path — sends span immediately
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-abc",
+            "prompt": "test",
+        },
+        "afterAgentResponse": {
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-aar",
+            "text": "response",
+        },
+        "afterAgentThought": {
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-aat",
+            "thought": "thinking",
+        },
+        "afterShellExecution": {
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-ase",
+            "command": "ls",
+            "output": "ok",
+        },
+        "afterMCPExecution": {
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-ame",
+            "tool_name": "my_tool",
+            "result": "ok",
+        },
+        "beforeReadFile": {
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-brf",
+            "file_path": "/tmp/a.py",
+        },
+        "afterFileEdit": {
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-afe",
+            "file_path": "/tmp/a.py",
+        },
+        "beforeTabFileRead": {
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-btfr",
+            "file_path": "/tmp/a.py",
+        },
+        "afterTabFileEdit": {
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-atfe",
+            "file_path": "/tmp/a.py",
+        },
+        "stop": {
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-stop",
+            "status": "completed",
+        },
+        "sessionStart": {
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-ss",
+            "cwd": "/tmp",
+        },
+        "sessionEnd": {
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-se",
+        },
+        "postToolUse": {
+            "conversation_id": "conv-abc",
+            "generation_id": "gen-ptu",
+            "toolName": "glob",
+            "toolInput": "*.py",
+        },
+    }
+
+    # Events that push state but don't emit a span
+    _NO_SPAN_EVENTS = {"beforeShellExecution", "beforeMCPExecution"}
+
+    @pytest.mark.parametrize(
+        "event",
+        [e for e in _EVENT_PAYLOADS],
+    )
+    def test_conversation_id_attribute_on_every_handler(self, captured_spans, monkeypatch, event):
+        """Every span-producing handler includes cursor.conversation.id."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=1000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_save"),
+            mock.patch("cursor_tracing.hooks.handlers.state_cleanup_generation"),
+            mock.patch("cursor_tracing.hooks.handlers.state_pop", return_value=None),
+        ):
+            _dispatch(event, self._EVENT_PAYLOADS[event])
+
+        assert len(captured_spans) >= 1, f"No spans emitted for {event}"
+        for sent in captured_spans:
+            span = sent["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+            attrs = {a["key"]: a["value"] for a in span["attributes"]}
+            assert attrs.get("cursor.conversation.id", {}).get("stringValue") == "conv-abc", (
+                f"cursor.conversation.id missing or wrong on {event} span {span['name']}"
+            )
+
+    def test_conversation_id_attribute_omitted_when_missing(self, captured_spans, monkeypatch):
+        """When conversation_id is empty, cursor.conversation.id is not set."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=1000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value=""),
+            mock.patch("cursor_tracing.hooks.handlers.state_cleanup_generation"),
+        ):
+            _dispatch(
+                "stop",
+                {
+                    "generation_id": "gen-1",
+                    "status": "completed",
+                },
+            )
+
+        attr_keys = {a["key"] for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]}
+        assert "cursor.conversation.id" not in attr_keys
+
+
+# ---------------------------------------------------------------------------
+# IDE-safety regression test
+# ---------------------------------------------------------------------------
+
+
+class TestIdeSafety:
+
+    def test_ide_payload_with_no_post_tool_use_unaffected(self, captured_spans, monkeypatch):
+        """IDE dispatches before/afterShellExecution without postToolUse — exactly 1 span from after."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=1000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value="root-ide"),
+        ):
+            _dispatch(
+                "beforeShellExecution",
+                {
+                    "hook_event_name": "beforeShellExecution",
+                    "conversation_id": "conv-ide",
+                    "generation_id": "gen-ide",
+                    "command": "echo hello",
+                    "cwd": "/tmp",
+                },
+            )
+
+        # beforeShellExecution emits no span
+        assert len(captured_spans) == 0
+
+        with (
+            mock.patch("cursor_tracing.hooks.handlers.get_timestamp_ms", return_value=2000),
+            mock.patch("cursor_tracing.hooks.handlers.gen_root_span_get", return_value="root-ide"),
+        ):
+            _dispatch(
+                "afterShellExecution",
+                {
+                    "hook_event_name": "afterShellExecution",
+                    "conversation_id": "conv-ide",
+                    "generation_id": "gen-ide",
+                    "command": "echo hello",
+                    "output": "hello",
+                    "exit_code": "0",
+                },
+            )
+
+        # afterShellExecution emits exactly one span
+        assert len(captured_spans) == 1
+        span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        assert span["name"] == "Shell"
+        attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert attrs["openinference.span.kind"]["stringValue"] == "TOOL"
+        assert attrs["tool.name"]["stringValue"] == "shell"

--- a/tests/test_hook_registrations.py
+++ b/tests/test_hook_registrations.py
@@ -563,12 +563,10 @@ class TestCursorDocsTokenCounts:
         skill = (REPO_ROOT / "cursor_tracing" / "skills" / "manage-cursor-tracing" / "SKILL.md").read_text()
 
         for name, content in [("README.md", readme), ("SKILL.md", skill)]:
-            assert "llm.token_count.prompt" in content, (
-                f"cursor_tracing {name} missing llm.token_count.prompt"
-            )
-            assert "llm.token_count.cache_read" in content or "llm.token_count.total" in content, (
-                f"cursor_tracing {name} missing llm.token_count.cache_read or llm.token_count.total"
-            )
+            assert "llm.token_count.prompt" in content, f"cursor_tracing {name} missing llm.token_count.prompt"
+            assert (
+                "llm.token_count.cache_read" in content or "llm.token_count.total" in content
+            ), f"cursor_tracing {name} missing llm.token_count.cache_read or llm.token_count.total"
 
 
 class TestCursorDocsPostToolUseDedup:
@@ -601,9 +599,9 @@ class TestCursorDocsPostToolUseDedup:
                     break
                 idx += 1
 
-            assert has_suppressed or has_skipped or has_dedicated, (
-                f"cursor_tracing {name} does not describe postToolUse dedup behavior"
-            )
+            assert (
+                has_suppressed or has_skipped or has_dedicated
+            ), f"cursor_tracing {name} does not describe postToolUse dedup behavior"
 
 
 class TestCursorDocsConversationId:
@@ -615,9 +613,7 @@ class TestCursorDocsConversationId:
         skill = (REPO_ROOT / "cursor_tracing" / "skills" / "manage-cursor-tracing" / "SKILL.md").read_text()
 
         for name, content in [("README.md", readme), ("SKILL.md", skill)]:
-            assert "cursor.conversation.id" in content, (
-                f"cursor_tracing {name} missing cursor.conversation.id"
-            )
+            assert "cursor.conversation.id" in content, f"cursor_tracing {name} missing cursor.conversation.id"
 
 
 class TestStateFileExtension:

--- a/tests/test_hook_registrations.py
+++ b/tests/test_hook_registrations.py
@@ -542,6 +542,84 @@ class TestCursorDocsUnsupportedHooks:
             )
 
 
+class TestCursorDocsSessionEnd:
+    """Verify Cursor docs mention sessionEnd."""
+
+    def test_cursor_docs_list_session_end(self):
+        """Both Cursor docs must contain the literal substring sessionEnd."""
+        readme = (REPO_ROOT / "cursor_tracing" / "README.md").read_text()
+        skill = (REPO_ROOT / "cursor_tracing" / "skills" / "manage-cursor-tracing" / "SKILL.md").read_text()
+
+        for name, content in [("README.md", readme), ("SKILL.md", skill)]:
+            assert "sessionEnd" in content, f"cursor_tracing {name} missing sessionEnd"
+
+
+class TestCursorDocsTokenCounts:
+    """Verify Cursor docs describe token counts on stop."""
+
+    def test_cursor_docs_describe_token_counts_on_stop(self):
+        """Both Cursor docs must mention llm.token_count.prompt and at least one of cache_read or total."""
+        readme = (REPO_ROOT / "cursor_tracing" / "README.md").read_text()
+        skill = (REPO_ROOT / "cursor_tracing" / "skills" / "manage-cursor-tracing" / "SKILL.md").read_text()
+
+        for name, content in [("README.md", readme), ("SKILL.md", skill)]:
+            assert "llm.token_count.prompt" in content, (
+                f"cursor_tracing {name} missing llm.token_count.prompt"
+            )
+            assert "llm.token_count.cache_read" in content or "llm.token_count.total" in content, (
+                f"cursor_tracing {name} missing llm.token_count.cache_read or llm.token_count.total"
+            )
+
+
+class TestCursorDocsPostToolUseDedup:
+    """Verify Cursor docs describe postToolUse dedup behavior."""
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        return " ".join(text.lower().split())
+
+    def test_cursor_docs_describe_post_tool_use_dedup(self):
+        """Both Cursor docs must indicate postToolUse is suppressed for tools with dedicated handlers."""
+        readme = (REPO_ROOT / "cursor_tracing" / "README.md").read_text()
+        skill = (REPO_ROOT / "cursor_tracing" / "skills" / "manage-cursor-tracing" / "SKILL.md").read_text()
+
+        for name, content in [("README.md", readme), ("SKILL.md", skill)]:
+            normalized = self._normalize(content)
+            has_suppressed = "posttooluse is suppressed for these" in normalized
+            has_skipped = "posttooluse is skipped for shell" in normalized
+            # Check "dedicated handler" within 200 chars of "posttooluse"
+            has_dedicated = False
+            lower_content = content.lower()
+            idx = 0
+            while True:
+                idx = lower_content.find("posttooluse", idx)
+                if idx == -1:
+                    break
+                window = lower_content[max(0, idx - 200) : idx + 200]
+                if "dedicated handler" in window:
+                    has_dedicated = True
+                    break
+                idx += 1
+
+            assert has_suppressed or has_skipped or has_dedicated, (
+                f"cursor_tracing {name} does not describe postToolUse dedup behavior"
+            )
+
+
+class TestCursorDocsConversationId:
+    """Verify Cursor docs describe cursor.conversation.id attribute."""
+
+    def test_cursor_docs_describe_conversation_id_attribute(self):
+        """Both Cursor docs must contain cursor.conversation.id."""
+        readme = (REPO_ROOT / "cursor_tracing" / "README.md").read_text()
+        skill = (REPO_ROOT / "cursor_tracing" / "skills" / "manage-cursor-tracing" / "SKILL.md").read_text()
+
+        for name, content in [("README.md", readme), ("SKILL.md", skill)]:
+            assert "cursor.conversation.id" in content, (
+                f"cursor_tracing {name} missing cursor.conversation.id"
+            )
+
+
 class TestStateFileExtension:
     """Verify docs reference .yaml state files, not .json."""
 

--- a/tests/test_install_cursor.py
+++ b/tests/test_install_cursor.py
@@ -141,18 +141,24 @@ class TestFreshInstall:
         assert "backend" not in config
         assert "collector" not in config
 
-        # Check hooks.json has 14 events (12 IDE + 2 CLI)
+        # Check hooks.json has 15 events (12 IDE + 3 CLI)
         hooks_file = fake_home / ".cursor" / "hooks.json"
         assert hooks_file.exists()
         hooks_data = json.loads(hooks_file.read_text())
 
         assert hooks_data["version"] == 1
         hooks = hooks_data.get("hooks", {})
-        assert len(hooks) == 14
+        assert len(hooks) == 15
 
-        # sessionStart and postToolUse are present and use the same hook command
+        # sessionStart, sessionEnd, and postToolUse are present and use the same hook command
         assert "sessionStart" in hooks
+        assert "sessionEnd" in hooks
         assert "postToolUse" in hooks
+
+        # sessionEnd uses the same hook command as sessionStart
+        session_start_cmd = hooks["sessionStart"][0]["command"]
+        session_end_cmd = hooks["sessionEnd"][0]["command"]
+        assert session_start_cmd == session_end_cmd
 
         # Each event should have exactly one entry
         for event, entries in hooks.items():
@@ -279,9 +285,9 @@ class TestIdempotent:
         hooks_file = fake_home / ".cursor" / "hooks.json"
         hooks_data = json.loads(hooks_file.read_text())
 
-        # Still exactly 14 events with 1 entry each
+        # Still exactly 15 events with 1 entry each
         hooks = hooks_data["hooks"]
-        assert len(hooks) == 14
+        assert len(hooks) == 15
         for event, entries in hooks.items():
             assert len(entries) == 1, f"Event {event} has {len(entries)} entries"
 
@@ -341,7 +347,7 @@ class TestUninstall:
         assert hooks["CustomEvent"][0]["command"] == "/usr/local/bin/other"
 
     def test_uninstall_removes_cli_events(self, fake_home, monkeypatch):
-        """Uninstall removes sessionStart and postToolUse while preserving foreign hooks."""
+        """Uninstall removes sessionStart, sessionEnd, and postToolUse while preserving foreign hooks."""
         cursor_install = _load_cursor_module("install")
 
         _mock_prompts(monkeypatch)
@@ -361,10 +367,36 @@ class TestUninstall:
         # Our postToolUse entry is gone entirely (was only ours)
         assert "postToolUse" not in hooks
 
+        # Our sessionEnd entry is gone entirely (was only ours)
+        assert "sessionEnd" not in hooks
+
         # Third-party hook in sessionStart survives
         assert "sessionStart" in hooks
         assert len(hooks["sessionStart"]) == 1
         assert hooks["sessionStart"][0]["command"] == "/usr/local/bin/my-session-hook"
+
+    def test_uninstall_removes_session_end_preserves_foreign(self, fake_home, monkeypatch):
+        """Uninstall removes sessionEnd entry while preserving foreign hooks."""
+        cursor_install = _load_cursor_module("install")
+
+        _mock_prompts(monkeypatch)
+        cursor_install.install(with_skills=False)
+
+        # Inject a third-party hook into sessionEnd
+        hooks_file = fake_home / ".cursor" / "hooks.json"
+        hooks_data = json.loads(hooks_file.read_text())
+        hooks_data["hooks"]["sessionEnd"].append({"command": "/usr/local/bin/my-end-hook"})
+        hooks_file.write_text(json.dumps(hooks_data, indent=2) + "\n")
+
+        cursor_install.uninstall()
+
+        hooks_data = json.loads(hooks_file.read_text())
+        hooks = hooks_data.get("hooks", {})
+
+        # Third-party hook in sessionEnd survives
+        assert "sessionEnd" in hooks
+        assert len(hooks["sessionEnd"]) == 1
+        assert hooks["sessionEnd"][0]["command"] == "/usr/local/bin/my-end-hook"
 
     def test_uninstall_is_idempotent(self, fake_home, monkeypatch):
         """Running uninstall twice succeeds and is a no-op the second time."""


### PR DESCRIPTION
## Summary

Fixes three trace-quality issues found in production Cursor CLI traces (verified against the Apr 28 export), while leaving Cursor IDE behavior unchanged. See [.workbench/cursor-cli-trace-quality.md](.workbench/cursor-cli-trace-quality.md) for the full plan.

### 1. Duplicate tool spans

Each tool call was producing 2–3 spans because the generic `postToolUse` handler added in #25 fires alongside the dedicated `before*`/`after*` handlers (`Tool: Shell` + `Shell`, `Tool: Read` + `Read File`, etc.). `_handle_post_tool_use` now short-circuits when the tool name is in a known set covered by a dedicated handler (shell/terminal/bash, read_file/edit_file, tab_file_*, mcp). Generic tools without dedicated coverage (`glob`, `code_search`, third-party MCP tools, etc.) continue to produce a single `Tool: <name>` span — that's the value-add `postToolUse` was added for.

### 2. Token counts on `Agent Stop`

The Cursor `stop` payload carries `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `model`, and `duration_ms`, but the existing handler ignored them. `Agent Stop` (and the new `Session End`) now map these to the canonical OpenInference attributes:

- `llm.token_count.prompt` ← `input_tokens`
- `llm.token_count.completion` ← `output_tokens`
- `llm.token_count.cache_read` ← `cache_read_tokens`
- `llm.token_count.cache_write` ← `cache_write_tokens`
- `llm.token_count.total` ← computed sum
- `llm.model_name` ← `model`
- `cursor.stop.duration_ms` ← `duration_ms`

Each is gated by `is not None`, so a `stop` payload that omits these fields (e.g. older clients or IDE traffic) produces a byte-identical span to today.

### 3. `sessionEnd` handler

Cursor CLI fires `sessionEnd` when a window closes, carrying `duration_ms`, `final_status`, `reason`, and end-of-session token counts. The harness wasn't subscribed, so the event was routing to other plugins and our session spans never got a clean closure. Adds:

- `"sessionEnd"` to `HOOK_EVENTS` (now 15 events).
- `_handle_session_end` emitting a `Session End` CHAIN span with `cursor.session.duration_ms`, `cursor.session.final_status`, `cursor.session.reason`, plus token counts when present, plus `state_cleanup_generation` for the gen_id keyed root.

### 4. Cross-trace queryable attribute

`sessionStart` lives in its own trace (different `gen_id` than per-turn work) and we deliberately don't change `_trace_id_from_event` to avoid disturbing IDE behavior. Instead, every Cursor span now carries `cursor.conversation.id`, so users can join sessions and per-turn activity in Arize via `attributes.cursor.conversation.id = "<id>"` even when `trace_id` differs. Purely additive — no existing attribute is renamed or removed.

## IDE safety

The plan locks Cursor IDE behavior in via explicit constraints:

- `_trace_id_from_event` is **not** modified — gen_id-precedence stays, so IDE turns remain in distinct traces.
- The `postToolUse` dedup is a no-op for IDE traffic, since IDE doesn't emit `postToolUse`. A dedicated test (`test_ide_payload_with_no_post_tool_use_unaffected`) locks this in.
- Token-count attributes only appear when the payload includes them — IDE `stop` payloads without these fields produce byte-identical spans to today (`test_stop_omits_token_attrs_when_payload_has_none`).
- `cursor.conversation.id` is added to every handler's `attrs` dict but no existing attribute is touched.
- `_handle_session_end` is new code that only runs when the event fires.

## Test plan

- [x] `uv run pytest tests/test_cursor_hook.py tests/test_install_cursor.py tests/test_hook_registrations.py -x -q`
- [x] `uv run pytest -q` — full suite clean
- [x] Manual: real Cursor CLI session — confirm shell/read/edit/MCP tools produce exactly one span each (no `Tool: Shell` + `Shell` duplication)
- [x] Manual: Arize export of `Agent Stop` shows non-null `llm.token_count.prompt`, `llm.token_count.completion`, `llm.token_count.cache_read`, `llm.token_count.cache_write`, `llm.token_count.total`
- [x] Manual: closing a Cursor window emits a `Session End` span with `cursor.session.duration_ms` and `cursor.session.final_status`
- [x] Manual: query Arize for `attributes.cursor.conversation.id = "<id>"` and confirm both `Session Start` (separate trace) and per-turn spans are returned together
- [x] Manual: real Cursor IDE session — exported spans look identical to pre-PR shape, except `Agent Stop` may now carry token counts if the IDE payload provides them
