### PR TITLE
Fix Copilot hook payload schema (single-mode snake_case)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,6 @@ arize-hook-copilot-user-prompt = "tracing.copilot.hooks.handlers:user_prompt_sub
 arize-hook-copilot-pre-tool = "tracing.copilot.hooks.handlers:pre_tool_use"
 arize-hook-copilot-post-tool = "tracing.copilot.hooks.handlers:post_tool_use"
 arize-hook-copilot-stop = "tracing.copilot.hooks.handlers:stop"
-arize-hook-copilot-error = "tracing.copilot.hooks.handlers:error_occurred"
-arize-hook-copilot-session-end = "tracing.copilot.hooks.handlers:session_end"
 arize-hook-copilot-subagent-stop = "tracing.copilot.hooks.handlers:subagent_stop"
 # Gemini hooks
 arize-hook-gemini-session-start = "tracing.gemini.hooks.handlers:session_start"

--- a/tests/test_copilot_adapter.py
+++ b/tests/test_copilot_adapter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for tracing.copilot.hooks.adapter — dual-mode session resolution, init, GC, requirements."""
+"""Tests for tracing.copilot.hooks.adapter — single-mode session resolution, init, GC, requirements."""
 import os
 import subprocess
 from unittest.mock import mock_open, patch
@@ -30,7 +30,7 @@ def disable_env_vars(monkeypatch):
     monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
 
 
-# ── is_vscode_mode tests ────────────────────────────────────────────────────
+# ── is_vscode_mode tests (kept — function still present) ─────────────────────
 
 
 class TestIsVscodeMode:
@@ -59,41 +59,58 @@ class TestIsVscodeMode:
 
 
 class TestResolveSession:
-    def test_vscode_uses_session_id(self, copilot_state_dir, disable_env_vars):
-        """VS Code mode: sessionId from payload used as state file key."""
-        sm = adapter.resolve_session({"sessionId": "vscode-sess-42", "hookEventName": "SessionStart"})
-        assert sm.state_file == copilot_state_dir / "state_vscode-sess-42.yaml"
+    def test_snake_case_session_id_used_as_key(self, copilot_state_dir, disable_env_vars):
+        """session_id from payload used as state file key."""
+        sm = adapter.resolve_session({"session_id": "sess-42", "hook_event_name": "SessionStart"})
+        assert sm.state_file == copilot_state_dir / "state_sess-42.yaml"
         assert sm.state_file.exists()
 
-    def test_cli_uses_pid(self, copilot_state_dir, disable_env_vars, monkeypatch):
-        """CLI mode: falls back to PID-based key when no VS Code fields."""
+    def test_fallback_to_pid_when_no_session_id(self, copilot_state_dir, disable_env_vars, monkeypatch):
+        """Falls back to PID-based key when session_id absent."""
         monkeypatch.setattr(adapter, "_get_grandparent_pid", lambda: "54321")
-        sm = adapter.resolve_session({"prompt": "hello"})
+        sm = adapter.resolve_session({"cwd": "/tmp/project"})
         assert sm.state_file == copilot_state_dir / "state_54321.yaml"
+
+    def test_fallback_to_pid_when_session_id_empty(self, copilot_state_dir, disable_env_vars, monkeypatch):
+        """Falls back to PID-based key when session_id is empty string."""
+        monkeypatch.setattr(adapter, "_get_grandparent_pid", lambda: "11111")
+        sm = adapter.resolve_session({"session_id": "", "cwd": "/tmp/project"})
+        assert sm.state_file == copilot_state_dir / "state_11111.yaml"
 
     def test_init_state_called(self, copilot_state_dir, disable_env_vars):
         """Returned StateManager has init_state() called (file exists with {})."""
-        sm = adapter.resolve_session({"sessionId": "test-init", "hookEventName": "SessionStart"})
+        sm = adapter.resolve_session({"session_id": "test-init", "hook_event_name": "SessionStart"})
         assert sm.state_file.exists()
         data = yaml.safe_load(sm.state_file.read_text())
         assert data == {}
 
     def test_same_input_same_file(self, copilot_state_dir, disable_env_vars):
         """Calling resolve_session twice with same input returns same file path."""
-        inp = {"sessionId": "stable", "hookEventName": "Stop"}
+        inp = {"session_id": "stable", "hook_event_name": "Stop"}
         sm1 = adapter.resolve_session(inp)
         sm2 = adapter.resolve_session(inp)
         assert sm1.state_file == sm2.state_file
 
-    def test_vscode_session_id_required(self, copilot_state_dir, disable_env_vars):
-        """VS Code mode requires sessionId in payload (hookEventName alone triggers vscode mode)."""
-        # hookEventName present but no sessionId — is_vscode_mode returns True,
-        # but sessionId key is missing; should raise KeyError or use hookEventName path
-        # Actually: hookEventName triggers vscode mode, sessionId must be there
-        # This tests the expected behavior when only hookEventName present
-        inp = {"hookEventName": "SessionStart", "sessionId": "from-event"}
-        sm = adapter.resolve_session(inp)
-        assert sm.state_file == copilot_state_dir / "state_from-event.yaml"
+    def test_uuid_session_id(self, copilot_state_dir, disable_env_vars):
+        """UUID-style session_id (as seen in real payloads) works correctly."""
+        uuid = "d4870649-2f69-472d-96a2-599e55ab13f0"
+        sm = adapter.resolve_session({"session_id": uuid, "hook_event_name": "SessionStart"})
+        assert sm.state_file == copilot_state_dir / f"state_{uuid}.yaml"
+        assert sm.state_file.exists()
+
+    def test_windows_fallback_uses_ppid(self, copilot_state_dir, disable_env_vars, monkeypatch):
+        """On Windows, falls back to os.getppid() when no session_id."""
+        monkeypatch.setattr("platform.system", lambda: "Windows")
+        monkeypatch.setattr(os, "getppid", lambda: 12345)
+        sm = adapter.resolve_session({"cwd": "/tmp/project"})
+        assert sm.state_file == copilot_state_dir / "state_12345.yaml"
+
+    def test_camel_case_session_id_not_used(self, copilot_state_dir, disable_env_vars, monkeypatch):
+        """Old camelCase sessionId is NOT recognized — triggers PID fallback."""
+        monkeypatch.setattr(adapter, "_get_grandparent_pid", lambda: "77777")
+        sm = adapter.resolve_session({"sessionId": "camel-case-id", "hookEventName": "SessionStart"})
+        # Should NOT use "camel-case-id"; should fall back to PID
+        assert sm.state_file == copilot_state_dir / "state_77777.yaml"
 
 
 # ── ensure_session_initialized tests ─────────────────────────────────────────
@@ -112,7 +129,7 @@ class TestEnsureSessionInitialized:
     def test_sets_all_keys(self, copilot_state_dir, disable_env_vars):
         """First call sets all expected keys."""
         sm = self._make_state(copilot_state_dir, "all-keys")
-        adapter.ensure_session_initialized(sm, {"sessionId": "sid-1"})
+        adapter.ensure_session_initialized(sm, {"session_id": "sid-1"})
         assert sm.get("session_id") == "sid-1"
         assert sm.get("session_start_time") is not None
         assert sm.get("project_name") is not None
@@ -123,26 +140,44 @@ class TestEnsureSessionInitialized:
     def test_idempotent(self, copilot_state_dir, disable_env_vars):
         """Second call is a no-op — values unchanged."""
         sm = self._make_state(copilot_state_dir, "idempotent")
-        adapter.ensure_session_initialized(sm, {"sessionId": "sid-2"})
+        adapter.ensure_session_initialized(sm, {"session_id": "sid-2"})
         start_time = sm.get("session_start_time")
-        adapter.ensure_session_initialized(sm, {"sessionId": "sid-different"})
+        adapter.ensure_session_initialized(sm, {"session_id": "sid-different"})
         assert sm.get("session_id") == "sid-2"
         assert sm.get("session_start_time") == start_time
 
-    def test_session_id_from_vscode_payload(self, copilot_state_dir, disable_env_vars):
-        """sessionId from VS Code payload is used as session_id."""
-        sm = self._make_state(copilot_state_dir, "from-vscode")
-        adapter.ensure_session_initialized(sm, {"sessionId": "vscode-session"})
-        assert sm.get("session_id") == "vscode-session"
+    def test_session_id_from_snake_case_payload(self, copilot_state_dir, disable_env_vars):
+        """session_id from snake_case payload is used as session_id."""
+        sm = self._make_state(copilot_state_dir, "from-payload")
+        adapter.ensure_session_initialized(sm, {"session_id": "payload-session"})
+        assert sm.get("session_id") == "payload-session"
 
-    def test_session_id_generated_for_cli(self, copilot_state_dir, disable_env_vars):
-        """session_id is generated (32-hex) when not in input (CLI mode)."""
+    def test_session_id_generated_when_missing(self, copilot_state_dir, disable_env_vars):
+        """session_id is generated (32-hex) when not in input."""
         sm = self._make_state(copilot_state_dir, "generated")
-        adapter.ensure_session_initialized(sm, {"prompt": "hello"})
+        adapter.ensure_session_initialized(sm, {"cwd": "/tmp/project"})
         sid = sm.get("session_id")
         assert sid is not None
         assert len(sid) == 32
         int(sid, 16)  # should not raise
+
+    def test_session_id_generated_when_empty(self, copilot_state_dir, disable_env_vars):
+        """session_id is generated when payload has empty string session_id."""
+        sm = self._make_state(copilot_state_dir, "empty-sid")
+        adapter.ensure_session_initialized(sm, {"session_id": ""})
+        sid = sm.get("session_id")
+        assert sid is not None
+        assert len(sid) == 32
+        int(sid, 16)  # should not raise
+
+    def test_camel_case_session_id_not_used(self, copilot_state_dir, disable_env_vars):
+        """Old camelCase sessionId is NOT recognized — generates new ID."""
+        sm = self._make_state(copilot_state_dir, "camel-ignore")
+        adapter.ensure_session_initialized(sm, {"sessionId": "camel-case-id"})
+        sid = sm.get("session_id")
+        assert sid != "camel-case-id"
+        assert len(sid) == 32
+        int(sid, 16)
 
     def test_project_name_from_env(self, copilot_state_dir, monkeypatch):
         """ARIZE_PROJECT_NAME env var takes priority over cwd."""
@@ -159,12 +194,43 @@ class TestEnsureSessionInitialized:
         adapter.ensure_session_initialized(sm, {"cwd": "/home/user/my-project"})
         assert sm.get("project_name") == "my-project"
 
+    def test_project_name_fallback_to_os_cwd(self, copilot_state_dir, disable_env_vars):
+        """project_name falls back to os.getcwd() basename when no cwd in input."""
+        sm = self._make_state(copilot_state_dir, "proj-fallback")
+        adapter.ensure_session_initialized(sm, {})
+        # Should be basename of current working directory
+        assert sm.get("project_name") == os.path.basename(os.getcwd())
+
     def test_counters_start_at_zero(self, copilot_state_dir, disable_env_vars):
         """trace_count and tool_count start at '0'."""
         sm = self._make_state(copilot_state_dir, "counters")
         adapter.ensure_session_initialized(sm, {})
         assert sm.get("trace_count") == "0"
         assert sm.get("tool_count") == "0"
+
+    def test_user_id_from_env(self, copilot_state_dir, monkeypatch):
+        """user_id is taken from env.user_id."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.setenv("ARIZE_USER_ID", "env-user-42")
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        sm = self._make_state(copilot_state_dir, "user-env")
+        adapter.ensure_session_initialized(sm, {"session_id": "s1"})
+        assert sm.get("user_id") == "env-user-42"
+
+    def test_full_payload_schema(self, copilot_state_dir, disable_env_vars):
+        """Full verified payload schema (snake_case) works end-to-end."""
+        sm = self._make_state(copilot_state_dir, "full-schema")
+        payload = {
+            "cwd": "/Users/duncan/Documents/code/arize-agent-kit",
+            "hook_event_name": "SessionStart",
+            "session_id": "d4870649-2f69-472d-96a2-599e55ab13f0",
+            "timestamp": "2026-05-04T23:25:33.735Z",
+            "initial_prompt": "fix the bug",
+            "source": "new",
+        }
+        adapter.ensure_session_initialized(sm, payload)
+        assert sm.get("session_id") == "d4870649-2f69-472d-96a2-599e55ab13f0"
+        assert sm.get("project_name") == "arize-agent-kit"
 
 
 # ── gc_stale_state_files tests ───────────────────────────────────────────────
@@ -190,8 +256,8 @@ class TestGcStaleStateFiles:
         assert state_file.exists()
 
     def test_non_numeric_key_kept(self, copilot_state_dir, disable_env_vars):
-        """state file with non-numeric key (VS Code sessionId) is never GC'd."""
-        state_file = copilot_state_dir / "state_vscode-sess-abc123.yaml"
+        """state file with non-numeric key (UUID sessionId) is never GC'd."""
+        state_file = copilot_state_dir / "state_d4870649-2f69-472d-96a2-599e55ab13f0.yaml"
         state_file.write_text("{}")
         adapter.gc_stale_state_files()
         assert state_file.exists()

--- a/tests/test_copilot_adapter.py
+++ b/tests/test_copilot_adapter.py
@@ -30,31 +30,6 @@ def disable_env_vars(monkeypatch):
     monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
 
 
-# ── is_vscode_mode tests (kept — function still present) ─────────────────────
-
-
-class TestIsVscodeMode:
-    def test_true_with_session_id(self):
-        """Returns True when sessionId is present."""
-        assert adapter.is_vscode_mode({"sessionId": "abc-123"}) is True
-
-    def test_true_with_hook_event_name(self):
-        """Returns True when hookEventName is present."""
-        assert adapter.is_vscode_mode({"hookEventName": "PreToolUse"}) is True
-
-    def test_true_with_both(self):
-        """Returns True when both fields present."""
-        assert adapter.is_vscode_mode({"sessionId": "abc", "hookEventName": "Stop"}) is True
-
-    def test_false_when_absent(self):
-        """Returns False when neither field present (CLI mode)."""
-        assert adapter.is_vscode_mode({"prompt": "hello"}) is False
-
-    def test_false_with_empty_values(self):
-        """Returns False when fields are empty strings."""
-        assert adapter.is_vscode_mode({"sessionId": "", "hookEventName": ""}) is False
-
-
 # ── resolve_session tests ────────────────────────────────────────────────────
 
 

--- a/tests/test_copilot_hook.py
+++ b/tests/test_copilot_hook.py
@@ -21,7 +21,6 @@ from tracing.copilot.hooks.handlers import (
     _handle_pre_tool_use,
     _handle_session_end,
     _handle_session_start,
-    _handle_stop,
     _handle_subagent_stop,
     _handle_user_prompt_submitted,
     _print_response,
@@ -486,114 +485,97 @@ class TestPostToolUse:
 
 
 # ---------------------------------------------------------------------------
-# stop tests (VS Code only)
+# stop tests
 # ---------------------------------------------------------------------------
 
 
-class TestStop:
+class TestHandleStop:
 
-    def test_parses_transcript_and_builds_llm_span(self, mock_resolve, state, captured_spans, transcript_file):
-        """Parses transcript and builds LLM span with output and tokens."""
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "s" * 16)
-        state.set("current_trace_start_time", "1000")
-        state.set("current_trace_prompt", "fix the bug")
-        state.set("trace_start_line", "0")
-        _handle_stop({"transcript_path": transcript_file, "sessionId": "s1", "hookEventName": "Stop"})
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert "I found the issue." in attrs["output.value"]["stringValue"]
-        assert attrs["openinference.span.kind"]["stringValue"] == "LLM"
-        assert attrs["llm.model_name"]["stringValue"] == "gpt-4o"
-        # Token counts: input=100, cache_read=10, cache_creation=5 = 115
-        assert attrs["llm.token_count.prompt"]["intValue"] == 115
-        assert attrs["llm.token_count.completion"]["intValue"] == 50
-        assert attrs["llm.token_count.total"]["intValue"] == 165
+    def _seed_trace(self, tmp_path, monkeypatch, prompt="hi"):
+        from tracing.copilot.hooks import adapter as _adapter
 
-    def test_no_transcript_no_response(self, mock_resolve, state, captured_spans):
-        """No transcript → output is '(No response)'."""
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "s" * 16)
-        state.set("current_trace_start_time", "1000")
-        state.set("current_trace_prompt", "test")
-        state.set("trace_start_line", "0")
-        _handle_stop({"sessionId": "s1", "hookEventName": "Stop"})
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["output.value"]["stringValue"] == "(No response)"
+        monkeypatch.setattr(_adapter, "STATE_DIR", tmp_path)
+        from tracing.copilot.hooks.handlers import _handle_user_prompt_submitted
 
-    def test_cleans_up_trace_state(self, mock_resolve, state, captured_spans, transcript_file):
-        """Cleans up current_trace_* state keys after sending."""
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "s" * 16)
-        state.set("current_trace_start_time", "1000")
-        state.set("current_trace_prompt", "test")
-        state.set("trace_start_line", "0")
-        _handle_stop({"transcript_path": transcript_file, "sessionId": "s1"})
+        _handle_user_prompt_submitted(
+            {
+                "session_id": "sess-1",
+                "hook_event_name": "UserPromptSubmit",
+                "cwd": "/repo",
+                "prompt": prompt,
+            }
+        )
+
+    def test_emits_llm_span_with_model_from_transcript(self, tmp_path, monkeypatch):
+        self._seed_trace(tmp_path, monkeypatch, prompt="why?")
+        tpath = tmp_path / "events.jsonl"
+        tpath.write_text(
+            json.dumps({"type": "session.model_change", "data": {"newModel": "gpt-5-mini"}}) + "\n",
+            encoding="utf-8",
+        )
+
+        sent = []
+        from tracing.copilot.hooks import handlers as _handlers
+
+        monkeypatch.setattr(_handlers, "send_span", lambda s: sent.append(s))
+
+        _handlers._handle_stop(
+            {
+                "session_id": "sess-1",
+                "hook_event_name": "Stop",
+                "cwd": "/repo",
+                "stop_reason": "end_turn",
+                "transcript_path": str(tpath),
+            }
+        )
+
+        assert len(sent) == 1
+        attrs = _get_span_attrs(sent[0])
+        assert attrs["llm.model_name"]["stringValue"] == "gpt-5-mini"
+        assert attrs["input.value"]["stringValue"] == "why?"
+        meta = json.loads(attrs["metadata"]["stringValue"])
+        assert meta["stop_reason"] == "end_turn"
+
+    def test_emits_llm_span_without_transcript(self, tmp_path, monkeypatch):
+        self._seed_trace(tmp_path, monkeypatch, prompt="ping")
+        sent = []
+        from tracing.copilot.hooks import handlers as _handlers
+
+        monkeypatch.setattr(_handlers, "send_span", lambda s: sent.append(s))
+
+        _handlers._handle_stop(
+            {
+                "session_id": "sess-1",
+                "hook_event_name": "Stop",
+                "cwd": "/repo",
+                "stop_reason": "end_turn",
+            }
+        )
+
+        assert len(sent) == 1
+        attrs = _get_span_attrs(sent[0])
+        assert attrs["input.value"]["stringValue"] == "ping"
+        assert "llm.model_name" not in attrs
+
+    def test_clears_trace_state_after_emit(self, tmp_path, monkeypatch):
+        self._seed_trace(tmp_path, monkeypatch)
+        from tracing.copilot.hooks import handlers as _handlers
+
+        monkeypatch.setattr(_handlers, "send_span", lambda s: None)
+        from tracing.copilot.hooks.adapter import resolve_session
+
+        payload = {
+            "session_id": "sess-1",
+            "hook_event_name": "Stop",
+            "cwd": "/repo",
+            "stop_reason": "end_turn",
+        }
+        _handlers._handle_stop(payload)
+
+        state = resolve_session(payload)
         assert state.get("current_trace_id") is None
         assert state.get("current_trace_span_id") is None
-        assert state.get("current_trace_start_time") is None
         assert state.get("current_trace_prompt") is None
-
-    def test_gc_every_5_turns(self, mock_resolve, state, captured_spans):
-        """GC runs every 5 turns."""
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "s" * 16)
-        state.set("current_trace_start_time", "1000")
-        state.set("current_trace_prompt", "test")
-        state.set("trace_count", "5")
-        state.set("trace_start_line", "0")
-        with mock.patch("tracing.copilot.hooks.handlers.gc_stale_state_files") as gc_mock:
-            _handle_stop({"sessionId": "s1"})
-            gc_mock.assert_called_once()
-
-    def test_gc_not_called_off_cycle(self, mock_resolve, state, captured_spans):
-        """GC not called when trace_count is not multiple of 5."""
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "s" * 16)
-        state.set("current_trace_start_time", "1000")
-        state.set("current_trace_prompt", "test")
-        state.set("trace_count", "3")
-        state.set("trace_start_line", "0")
-        with mock.patch("tracing.copilot.hooks.handlers.gc_stale_state_files") as gc_mock:
-            _handle_stop({"sessionId": "s1"})
-            gc_mock.assert_not_called()
-
-    def test_no_trace_id_returns_early(self, mock_resolve, state, captured_spans):
-        """No current_trace_id → returns without sending."""
-        _handle_stop({"sessionId": "s1"})
-        assert len(captured_spans) == 0
-
-    def test_skips_lines_before_trace_start_line(self, mock_resolve, state, captured_spans, transcript_file):
-        """Skips transcript lines before trace_start_line."""
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "s" * 16)
-        state.set("current_trace_start_time", "1000")
-        state.set("current_trace_prompt", "test")
-        state.set("trace_start_line", "2")  # past all lines
-        _handle_stop({"transcript_path": transcript_file, "sessionId": "s1"})
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["output.value"]["stringValue"] == "(No response)"
-
-    def test_string_content_format(self, mock_resolve, state, captured_spans, tmp_path):
-        """Handles transcript with string content format."""
-        tf = tmp_path / "t.jsonl"
-        entry = {
-            "message": {
-                "role": "assistant",
-                "content": "Hello string",
-                "model": "gpt-4o",
-                "usage": {"input_tokens": 10, "output_tokens": 5},
-            }
-        }
-        tf.write_text(json.dumps(entry) + "\n")
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "s" * 16)
-        state.set("current_trace_start_time", "1000")
-        state.set("current_trace_prompt", "test")
-        state.set("trace_start_line", "0")
-        _handle_stop({"transcript_path": str(tf), "sessionId": "s1"})
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["output.value"]["stringValue"] == "Hello string"
 
 
 # ---------------------------------------------------------------------------
@@ -739,99 +721,48 @@ class TestSessionEnd:
 
 
 # ---------------------------------------------------------------------------
-# subagent_stop tests (VS Code only)
+# subagent_stop tests
 # ---------------------------------------------------------------------------
 
 
-class TestSubagentStop:
+class TestHandleSubagentStop:
 
-    def test_builds_llm_span_for_subagent(self, mock_resolve, state, captured_spans, transcript_file):
-        """Builds LLM span for subagent with agent_type using transcript_path (VS Code base field)."""
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "s" * 16)
-        inp = _vscode_base(
+    def test_emits_chain_span_with_agent_metadata(self, tmp_path, monkeypatch):
+        from tracing.copilot.hooks import adapter as _adapter
+
+        monkeypatch.setattr(_adapter, "STATE_DIR", tmp_path)
+        from tracing.copilot.hooks.handlers import _handle_user_prompt_submitted
+
+        _handle_user_prompt_submitted(
             {
-                "agent_type": "code-review",
-                "agent_id": "agent-1",
-                "transcript_path": transcript_file,
+                "session_id": "sess-X",
+                "hook_event_name": "UserPromptSubmit",
+                "cwd": "/repo",
+                "prompt": "p",
             }
         )
-        _handle_subagent_stop(inp)
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["openinference.span.kind"]["stringValue"] == "LLM"
-        assert attrs["copilot.agent.type"]["stringValue"] == "code-review"
-        assert attrs["subagent.type"]["stringValue"] == "code-review"
-        assert "I found the issue." in attrs["output.value"]["stringValue"]
 
-    def test_falls_back_to_agent_transcript_path(self, mock_resolve, state, captured_spans, transcript_file):
-        """Falls back to agent_transcript_path if transcript_path not present."""
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "s" * 16)
-        inp = _vscode_base(
+        sent = []
+        from tracing.copilot.hooks import handlers as _handlers
+
+        monkeypatch.setattr(_handlers, "send_span", lambda s: sent.append(s))
+
+        _handlers._handle_subagent_stop(
             {
-                "agent_type": "code-review",
-                "agent_id": "agent-1",
-                "agent_transcript_path": transcript_file,
+                "session_id": "sess-X",
+                "hook_event_name": "SubagentStop",
+                "cwd": "/repo",
+                "agent_id": "ag-7",
+                "agent_type": "research",
             }
         )
-        _handle_subagent_stop(inp)
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert "I found the issue." in attrs["output.value"]["stringValue"]
 
-    def test_skips_empty_agent_type(self, mock_resolve, state, captured_spans):
-        """Skips when agent_type is empty."""
-        state.set("current_trace_id", "t" * 32)
-        _handle_subagent_stop(_vscode_base({"agent_type": ""}))
-        assert len(captured_spans) == 0
-
-    def test_skips_unknown_agent_type(self, mock_resolve, state, captured_spans):
-        """Skips when agent_type is 'unknown'."""
-        state.set("current_trace_id", "t" * 32)
-        _handle_subagent_stop(_vscode_base({"agent_type": "unknown"}))
-        assert len(captured_spans) == 0
-
-    def test_skips_null_agent_type(self, mock_resolve, state, captured_spans):
-        """Skips when agent_type is 'null'."""
-        state.set("current_trace_id", "t" * 32)
-        _handle_subagent_stop(_vscode_base({"agent_type": "null"}))
-        assert len(captured_spans) == 0
-
-    def test_no_trace_id_returns_early(self, mock_resolve, state, captured_spans):
-        """No current_trace_id → returns without sending."""
-        _handle_subagent_stop(_vscode_base({"agent_type": "explorer"}))
-        assert len(captured_spans) == 0
-
-    def test_no_transcript_no_output(self, mock_resolve, state, captured_spans):
-        """No transcript → no output.value attribute."""
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "s" * 16)
-        inp = _vscode_base(
-            {
-                "agent_type": "explorer",
-                "agent_id": "a1",
-            }
-        )
-        _handle_subagent_stop(inp)
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert "output.value" not in attrs
-
-    def test_parent_span_id(self, mock_resolve, state, captured_spans):
-        """Subagent span has parent_span_id from current trace."""
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "parentspan1234567")
-        _handle_subagent_stop(
-            _vscode_base(
-                {
-                    "agent_type": "test-agent",
-                    "agent_id": "a1",
-                }
-            )
-        )
-        span = _get_span(captured_spans[0])
-        assert span.get("parentSpanId") == "parentspan1234567"
+        assert len(sent) == 1
+        attrs = _get_span_attrs(sent[0])
+        assert attrs["openinference.span.kind"]["stringValue"] == "CHAIN"
+        meta = json.loads(attrs["metadata"]["stringValue"])
+        assert meta["agent_id"] == "ag-7"
+        assert meta["agent_type"] == "research"
 
 
 # ---------------------------------------------------------------------------
@@ -1059,9 +990,7 @@ class TestProjectNameOnAllSpans:
         assert attrs["project.name"]["stringValue"] == "test-copilot-project"
 
     def test_subagent_span_has_project_name(self, mock_resolve, state, captured_spans):
-        """Subagent LLM spans include project.name."""
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "s" * 16)
+        """Subagent CHAIN spans include project.name."""
         inp = _vscode_base({"agent_type": "test-agent", "agent_id": "a1"})
         _handle_subagent_stop(inp)
         attrs = _get_span_attrs(captured_spans[0])

--- a/tests/test_copilot_hook.py
+++ b/tests/test_copilot_hook.py
@@ -2,7 +2,7 @@
 """Tests for tracing.copilot.hooks.handlers — Copilot hook handlers.
 
 Tests cover response printing, session/prompt/tool/stop handlers,
-deferred turn helpers, and all CLI entry points.
+and all CLI entry points.
 """
 
 import io
@@ -14,22 +14,15 @@ import pytest
 
 from core.common import StateManager
 from tracing.copilot.hooks.handlers import (
-    _clear_pending_turn,
-    _flush_pending_turn,
-    _handle_error_occurred,
     _handle_post_tool_use,
     _handle_pre_tool_use,
-    _handle_session_end,
     _handle_session_start,
     _handle_subagent_stop,
     _handle_user_prompt_submitted,
     _print_response,
     _read_stdin,
-    _save_pending_turn,
-    error_occurred,
     post_tool_use,
     pre_tool_use,
-    session_end,
     session_start,
     stop,
     subagent_stop,
@@ -39,22 +32,6 @@ from tracing.copilot.hooks.handlers import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _vscode_base(extra=None):
-    """Return a base VS Code mode payload with sessionId and hookEventName."""
-    d = {"sessionId": "sess-vscode-1", "hookEventName": "TestEvent", "cwd": "/tmp/project"}
-    if extra:
-        d.update(extra)
-    return d
-
-
-def _cli_base(extra=None):
-    """Return a base CLI mode payload (no sessionId, no hookEventName)."""
-    d = {"cwd": "/tmp/project"}
-    if extra:
-        d.update(extra)
-    return d
 
 
 def _get_span_attrs(span_payload):
@@ -150,8 +127,7 @@ class TestReadStdin:
 class TestPrintResponse:
 
     def test_pre_tool_use_emits_permission_decision(self, capsys):
-
-        _print_response({}, "PreToolUse")
+        _print_response("PreToolUse")
         out = capsys.readouterr().out.strip()
         payload = json.loads(out)
         assert payload == {
@@ -172,8 +148,7 @@ class TestPrintResponse:
         ],
     )
     def test_non_pre_tool_use_emits_continue(self, event, capsys):
-
-        _print_response({}, event)
+        _print_response(event)
         out = capsys.readouterr().out.strip()
         payload = json.loads(out)
         assert payload == {"continue": True}
@@ -579,148 +554,6 @@ class TestHandleStop:
 
 
 # ---------------------------------------------------------------------------
-# error_occurred tests
-# ---------------------------------------------------------------------------
-
-
-class TestErrorOccurred:
-
-    def test_cli_nested_error_object(self, mock_resolve, state, captured_spans):
-        """CLI mode extracts error from nested object."""
-        state.set("current_trace_id", "t" * 32)
-        state.set("current_trace_span_id", "s" * 16)
-        inp = _cli_base(
-            {
-                "error": {"message": "Something failed", "name": "TypeError", "stack": "at line 42"},
-            }
-        )
-        _handle_error_occurred(inp)
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["openinference.span.kind"]["stringValue"] == "CHAIN"
-        assert attrs["error.message"]["stringValue"] == "Something failed"
-        assert attrs["error.name"]["stringValue"] == "TypeError"
-        assert attrs["error.stack"]["stringValue"] == "at line 42"
-
-    def test_vscode_error(self, mock_resolve, state, captured_spans):
-        """VS Code error with nested error object."""
-        state.set("current_trace_id", "t" * 32)
-        inp = _vscode_base(
-            {
-                "error": {"message": "Oops", "name": "RuntimeError"},
-            }
-        )
-        _handle_error_occurred(inp)
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["error.message"]["stringValue"] == "Oops"
-        assert attrs["error.name"]["stringValue"] == "RuntimeError"
-
-    def test_fallback_top_level_fields(self, mock_resolve, state, captured_spans):
-        """Falls back to top-level fields when error object is missing."""
-        state.set("current_trace_id", "t" * 32)
-        inp = _cli_base({"message": "top-level msg", "name": "top-level name"})
-        _handle_error_occurred(inp)
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["error.message"]["stringValue"] == "top-level msg"
-        assert attrs["error.name"]["stringValue"] == "top-level name"
-
-    def test_no_session_id_returns_early(self, state, captured_spans):
-        """No session_id → no span sent."""
-        state.delete("session_id")
-        with mock.patch("tracing.copilot.hooks.handlers.resolve_session", return_value=state):
-            _handle_error_occurred(_cli_base({"error": {"message": "fail"}}))
-        assert len(captured_spans) == 0
-
-    def test_generates_trace_id_if_missing(self, mock_resolve, state, captured_spans):
-        """Generates trace_id if not set in state."""
-        # No current_trace_id set
-        inp = _cli_base({"error": {"message": "oops", "name": "Error"}})
-        _handle_error_occurred(inp)
-        assert len(captured_spans) == 1
-        span = _get_span(captured_spans[0])
-        assert len(span["traceId"]) == 32  # generated
-
-
-# ---------------------------------------------------------------------------
-# session_end tests
-# ---------------------------------------------------------------------------
-
-
-class TestSessionEnd:
-
-    def test_cli_flushes_pending_turn(self, mock_resolve, state, captured_spans):
-        """CLI session_end flushes any pending turn."""
-        state.set("pending_turn_prompt", "last prompt")
-        state.set("pending_turn_trace_id", "t" * 32)
-        state.set("pending_turn_span_id", "s" * 16)
-        state.set("pending_turn_start_time", "1000")
-        state.set("pending_turn_trace_count", "3")
-        with mock.patch("tracing.copilot.hooks.handlers.gc_stale_state_files"):
-            inp = _cli_base({"reason": "complete"})
-            _handle_session_end(inp)
-        # Pending turn was flushed
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["openinference.span.kind"]["stringValue"] == "CHAIN"
-        assert attrs["input.value"]["stringValue"] == "last prompt"
-
-    def test_vscode_does_not_flush_pending_turn(self, mock_resolve, state, captured_spans):
-        """VS Code session_end does NOT flush pending turns."""
-        state.set("pending_turn_prompt", "should not flush")
-        state.set("pending_turn_trace_id", "t" * 32)
-        state.set("pending_turn_span_id", "s" * 16)
-        with mock.patch("tracing.copilot.hooks.handlers.gc_stale_state_files"):
-            inp = _vscode_base({"reason": "complete"})
-            _handle_session_end(inp)
-        assert len(captured_spans) == 0
-
-    def test_logs_session_summary(self, mock_resolve, state):
-        """Logs session summary via error()."""
-        state.set("trace_count", "10")
-        state.set("tool_count", "25")
-        with (
-            mock.patch("tracing.copilot.hooks.handlers.error") as err_mock,
-            mock.patch("tracing.copilot.hooks.handlers.gc_stale_state_files"),
-        ):
-            _handle_session_end(_cli_base({"reason": "complete"}))
-        calls = [c[0][0] for c in err_mock.call_args_list]
-        assert any("10 traces" in c for c in calls)
-        assert any("25 tools" in c for c in calls)
-
-    def test_removes_state_file(self, mock_resolve, state, tmp_path):
-        """Removes state file."""
-        assert state.state_file.exists()
-        with (
-            mock.patch("tracing.copilot.hooks.handlers.error"),
-            mock.patch("tracing.copilot.hooks.handlers.gc_stale_state_files"),
-        ):
-            _handle_session_end(_cli_base({"reason": "complete"}))
-        assert not state.state_file.exists()
-
-    def test_calls_gc(self, mock_resolve, state):
-        """Calls gc_stale_state_files."""
-        with (
-            mock.patch("tracing.copilot.hooks.handlers.error"),
-            mock.patch("tracing.copilot.hooks.handlers.gc_stale_state_files") as gc_mock,
-        ):
-            _handle_session_end(_cli_base())
-        gc_mock.assert_called_once()
-
-    def test_no_session_id_returns_early(self, state):
-        """Returns early when session_id is None."""
-        state.delete("session_id")
-        with (
-            mock.patch("tracing.copilot.hooks.handlers.resolve_session", return_value=state),
-            mock.patch("tracing.copilot.hooks.handlers.error") as err_mock,
-            mock.patch("tracing.copilot.hooks.handlers.gc_stale_state_files") as gc_mock,
-        ):
-            _handle_session_end(_cli_base())
-        err_mock.assert_not_called()
-        gc_mock.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
 # subagent_stop tests
 # ---------------------------------------------------------------------------
 
@@ -766,26 +599,11 @@ class TestHandleSubagentStop:
 
 
 # ---------------------------------------------------------------------------
-# CLI deferred turn pattern integration tests
+# Consecutive prompts open fresh traces
 # ---------------------------------------------------------------------------
 
 
-class TestDeferredTurnPattern:
-    """Tests for deferred turn helpers (still used by _handle_session_end)."""
-
-    def test_flush_pending_turn_no_op_when_empty(self, state):
-        """_flush_pending_turn is no-op when no pending turn exists."""
-        with mock.patch("tracing.copilot.hooks.handlers.send_span") as send_mock:
-            _flush_pending_turn(state)
-        send_mock.assert_not_called()
-
-    def test_flush_pending_turn_clears_invalid(self, state):
-        """_flush_pending_turn clears invalid pending turn (no trace/span id)."""
-        state.set("pending_turn_prompt", "orphan")
-        with mock.patch("tracing.copilot.hooks.handlers.send_span") as send_mock:
-            _flush_pending_turn(state)
-        send_mock.assert_not_called()
-        assert state.get("pending_turn_prompt") is None
+class TestConsecutivePrompts:
 
     def test_consecutive_prompts_each_open_fresh_trace(self, mock_resolve, mock_ensure, state, captured_spans):
         """Each user_prompt_submitted opens a fresh trace without sending spans."""
@@ -797,39 +615,6 @@ class TestDeferredTurnPattern:
         assert state.get("current_trace_prompt") == "second"
         assert state.get("trace_count") == "2"
         assert len(captured_spans) == 0
-
-
-# ---------------------------------------------------------------------------
-# _save_pending_turn and _clear_pending_turn tests
-# ---------------------------------------------------------------------------
-
-
-class TestPendingTurnHelpers:
-
-    def test_save_pending_turn(self, state):
-        """_save_pending_turn sets all pending turn keys."""
-        _save_pending_turn(state, "hello world")
-        assert state.get("pending_turn_prompt") == "hello world"
-        assert state.get("pending_turn_trace_id") is not None
-        assert len(state.get("pending_turn_trace_id")) == 32
-        assert state.get("pending_turn_span_id") is not None
-        assert len(state.get("pending_turn_span_id")) == 16
-        assert state.get("pending_turn_start_time") is not None
-        assert state.get("pending_turn_trace_count") is not None
-        assert state.get("trace_count") == "1"
-        # current trace context set
-        assert state.get("current_trace_id") == state.get("pending_turn_trace_id")
-        assert state.get("current_trace_span_id") == state.get("pending_turn_span_id")
-
-    def test_clear_pending_turn(self, state):
-        """_clear_pending_turn removes all pending turn keys."""
-        _save_pending_turn(state, "test")
-        _clear_pending_turn(state)
-        assert state.get("pending_turn_prompt") is None
-        assert state.get("pending_turn_trace_id") is None
-        assert state.get("pending_turn_span_id") is None
-        assert state.get("pending_turn_start_time") is None
-        assert state.get("pending_turn_trace_count") is None
 
 
 # ---------------------------------------------------------------------------
@@ -865,7 +650,7 @@ class TestErrorHandling:
 
 
 # ---------------------------------------------------------------------------
-# Entry point tests (all 8 CLI wrappers)
+# Entry point tests (all 6 CLI wrappers)
 # ---------------------------------------------------------------------------
 
 ENTRY_POINTS = [
@@ -874,8 +659,6 @@ ENTRY_POINTS = [
     ("pre_tool_use", pre_tool_use, "_handle_pre_tool_use", "PreToolUse"),
     ("post_tool_use", post_tool_use, "_handle_post_tool_use", "PostToolUse"),
     ("stop", stop, "_handle_stop", "Stop"),
-    ("error_occurred", error_occurred, "_handle_error_occurred", "ErrorOccurred"),
-    ("session_end", session_end, "_handle_session_end", "SessionEnd"),
     ("subagent_stop", subagent_stop, "_handle_subagent_stop", "SubagentStop"),
 ]
 
@@ -885,7 +668,7 @@ class TestEntryPoints:
     @pytest.mark.parametrize("name,entry_fn,handler_name,event", ENTRY_POINTS)
     def test_happy_path_calls_handler(self, name, entry_fn, handler_name, event):
         """Entry point calls the corresponding _handle_* with parsed stdin JSON."""
-        input_data = {"sessionId": "s1", "hookEventName": event}
+        input_data = {"session_id": "s1", "hook_event_name": event}
         with (
             mock.patch("tracing.copilot.hooks.handlers.check_requirements", return_value=True),
             mock.patch("tracing.copilot.hooks.handlers._read_stdin", return_value=input_data),
@@ -906,7 +689,7 @@ class TestEntryPoints:
         ):
             entry_fn()
         handler_mock.assert_not_called()
-        pr_mock.assert_called_once_with({}, event)
+        pr_mock.assert_called_once_with(event)
 
     @pytest.mark.parametrize("name,entry_fn,handler_name,event", ENTRY_POINTS)
     def test_exception_caught_and_logged(self, name, entry_fn, handler_name, event, capsys):
@@ -920,12 +703,12 @@ class TestEntryPoints:
             entry_fn()  # should not raise
         captured = capsys.readouterr()
         assert "test-boom" in captured.err
-        pr_mock.assert_called_once_with({}, event)
+        pr_mock.assert_called_once_with(event)
 
     @pytest.mark.parametrize("name,entry_fn,handler_name,event", ENTRY_POINTS)
     def test_prints_response(self, name, entry_fn, handler_name, event):
         """Entry point calls _print_response with correct event name."""
-        input_data = {"sessionId": "s1", "hookEventName": event}
+        input_data = {"session_id": "s1", "hook_event_name": event}
         with (
             mock.patch("tracing.copilot.hooks.handlers.check_requirements", return_value=True),
             mock.patch("tracing.copilot.hooks.handlers._read_stdin", return_value=input_data),
@@ -933,7 +716,7 @@ class TestEntryPoints:
             mock.patch("tracing.copilot.hooks.handlers._print_response") as pr_mock,
         ):
             entry_fn()
-        pr_mock.assert_called_once_with(input_data, event)
+        pr_mock.assert_called_once_with(event)
 
     def test_pre_tool_use_prints_permission_on_exception(self, capsys):
         """pre_tool_use MUST print permission response even when handler crashes."""
@@ -944,8 +727,8 @@ class TestEntryPoints:
         ):
             pre_tool_use()
         out = capsys.readouterr().out.strip()
-        # CLI mode (empty input_json) → flat permission response
-        assert json.loads(out) == {"permissionDecision": "allow"}
+        payload = json.loads(out)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "allow"
 
     def test_pre_tool_use_prints_permission_when_disabled(self, capsys):
         """pre_tool_use MUST print permission response even when tracing disabled."""
@@ -955,7 +738,8 @@ class TestEntryPoints:
         ):
             pre_tool_use()
         out = capsys.readouterr().out.strip()
-        assert json.loads(out) == {"permissionDecision": "allow"}
+        payload = json.loads(out)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "allow"
 
 
 # ---------------------------------------------------------------------------
@@ -981,17 +765,9 @@ class TestProjectNameOnAllSpans:
         attrs = _get_span_attrs(captured_spans[0])
         assert attrs["project.name"]["stringValue"] == "test-copilot-project"
 
-    def test_error_span_has_project_name(self, mock_resolve, state, captured_spans):
-        """Error CHAIN spans include project.name."""
-        state.set("current_trace_id", "t" * 32)
-        inp = _cli_base({"error": {"message": "fail", "name": "Err"}})
-        _handle_error_occurred(inp)
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["project.name"]["stringValue"] == "test-copilot-project"
-
     def test_subagent_span_has_project_name(self, mock_resolve, state, captured_spans):
         """Subagent CHAIN spans include project.name."""
-        inp = _vscode_base({"agent_type": "test-agent", "agent_id": "a1"})
+        inp = {"session_id": "sess-1", "hook_event_name": "SubagentStop", "agent_type": "test-agent", "agent_id": "a1"}
         _handle_subagent_stop(inp)
         attrs = _get_span_attrs(captured_spans[0])
         assert attrs["project.name"]["stringValue"] == "test-copilot-project"

--- a/tests/test_copilot_hook.py
+++ b/tests/test_copilot_hook.py
@@ -151,50 +151,34 @@ class TestReadStdin:
 
 class TestPrintResponse:
 
-    def test_vscode_pre_tool_use(self, capsys):
-        """VS Code PreToolUse prints wrapped permission response."""
-        _print_response(_vscode_base(), "PreToolUse")
-        out = json.loads(capsys.readouterr().out.strip())
-        assert out == {
+    def test_pre_tool_use_emits_permission_decision(self, capsys):
+
+        _print_response({}, "PreToolUse")
+        out = capsys.readouterr().out.strip()
+        payload = json.loads(out)
+        assert payload == {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
                 "permissionDecision": "allow",
             }
         }
 
-    def test_cli_pre_tool_use(self, capsys):
-        """CLI preToolUse prints flat permission response."""
-        _print_response(_cli_base(), "PreToolUse")
-        out = json.loads(capsys.readouterr().out.strip())
-        assert out == {"permissionDecision": "allow"}
+    @pytest.mark.parametrize(
+        "event",
+        [
+            "SessionStart",
+            "UserPromptSubmit",
+            "PostToolUse",
+            "Stop",
+            "SubagentStop",
+        ],
+    )
+    def test_non_pre_tool_use_emits_continue(self, event, capsys):
 
-    def test_cli_pre_tool_use_lowercase(self, capsys):
-        """CLI preToolUse (lowercase event) prints flat permission response."""
-        _print_response(_cli_base(), "preToolUse")
-        out = json.loads(capsys.readouterr().out.strip())
-        assert out == {"permissionDecision": "allow"}
-
-    def test_vscode_non_pre_tool_use(self, capsys):
-        """VS Code non-PreToolUse event prints {"continue": true}."""
-        _print_response(_vscode_base(), "SessionStart")
-        out = json.loads(capsys.readouterr().out.strip())
-        assert out == {"continue": True}
-
-    def test_vscode_stop_event(self, capsys):
-        """VS Code Stop event prints {"continue": true}."""
-        _print_response(_vscode_base(), "Stop")
-        out = json.loads(capsys.readouterr().out.strip())
-        assert out == {"continue": True}
-
-    def test_cli_non_pre_tool_use_prints_nothing(self, capsys):
-        """CLI non-preToolUse prints nothing."""
-        _print_response(_cli_base(), "SessionStart")
-        assert capsys.readouterr().out == ""
-
-    def test_cli_session_end_prints_nothing(self, capsys):
-        """CLI sessionEnd prints nothing."""
-        _print_response(_cli_base(), "SessionEnd")
-        assert capsys.readouterr().out == ""
+        _print_response({}, event)
+        out = capsys.readouterr().out.strip()
+        payload = json.loads(out)
+        assert payload == {"continue": True}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_copilot_hook.py
+++ b/tests/test_copilot_hook.py
@@ -255,26 +255,39 @@ class TestUserPromptSubmitted:
 
 class TestPreToolUse:
 
-    def test_vscode_records_tool_start(self, mock_resolve, state):
-        """VS Code mode records tool_{id}_start in state."""
-        inp = _vscode_base({"tool_use_id": "tool-42", "tool_name": "Bash", "tool_input": {}})
+    def test_records_tool_start_by_tool_use_id(self, mock_resolve, state):
+        """Records tool_{tool_use_id}_start when tool_use_id is present."""
+        inp = {
+            "cwd": "/repo",
+            "hook_event_name": "PreToolUse",
+            "session_id": "sess-1",
+            "tool_use_id": "tool-42",
+            "tool_name": "bash",
+            "tool_input": {"command": "ls"},
+        }
         _handle_pre_tool_use(inp)
         val = state.get("tool_tool-42_start")
         assert val is not None
         assert int(val) > 0
 
-    def test_cli_records_tool_start_by_name(self, mock_resolve, state):
-        """CLI mode uses toolName as the key for start time."""
-        inp = _cli_base({"toolName": "Bash", "toolArgs": '{"command": "ls"}'})
+    def test_records_tool_start_by_tool_name(self, mock_resolve, state):
+        """Falls back to tool_name when tool_use_id is absent."""
+        inp = {
+            "cwd": "/repo",
+            "hook_event_name": "PreToolUse",
+            "session_id": "sess-1",
+            "tool_name": "bash",
+            "tool_input": {"command": "ls"},
+        }
         _handle_pre_tool_use(inp)
-        val = state.get("tool_Bash_start")
+        val = state.get("tool_bash_start")
         assert val is not None
         assert int(val) > 0
 
     def test_missing_tool_id_generates_fallback(self, mock_resolve, state):
-        """Missing tool_use_id generates a fallback ID."""
+        """Missing tool_use_id and tool_name generates a fallback ID."""
         with mock.patch("tracing.copilot.hooks.handlers.generate_trace_id", return_value="gen-id-123"):
-            inp = _vscode_base({})
+            inp = {"cwd": "/repo", "hook_event_name": "PreToolUse", "session_id": "sess-1"}
             _handle_pre_tool_use(inp)
         val = state.get("tool_gen-id-123_start")
         assert val is not None
@@ -287,121 +300,108 @@ class TestPreToolUse:
 
 class TestPostToolUse:
 
-    def test_vscode_builds_tool_span(self, mock_resolve, state, captured_spans):
-        """VS Code mode builds a TOOL span with correct attributes."""
+    def test_emits_bash_tool_span(self, mock_resolve, state, captured_spans):
+        """Builds a TOOL span for bash with command enrichment."""
         state.set("current_trace_id", "trace-abc")
         state.set("current_trace_span_id", "span-parent")
-        inp = _vscode_base(
-            {
-                "tool_name": "Read",
-                "tool_use_id": "t1",
-                "tool_input": {"file_path": "/foo/bar.py"},
-                "tool_response": "file content",
-            }
-        )
+        inp = {
+            "session_id": "sess-1",
+            "hook_event_name": "PostToolUse",
+            "cwd": "/repo",
+            "tool_name": "bash",
+            "tool_input": {"command": "ls -la", "description": "list"},
+            "tool_result": {"result_type": "success", "text_result_for_llm": "out"},
+        }
         _handle_post_tool_use(inp)
         assert len(captured_spans) == 1
         attrs = _get_span_attrs(captured_spans[0])
         assert attrs["openinference.span.kind"]["stringValue"] == "TOOL"
-        assert attrs["tool.name"]["stringValue"] == "Read"
-        assert attrs["tool.file_path"]["stringValue"] == "/foo/bar.py"
-        assert attrs["output.value"]["stringValue"] == "file content"
-
-    def test_cli_builds_tool_span_with_json_args(self, mock_resolve, state, captured_spans):
-        """CLI mode parses toolArgs JSON string and builds TOOL span."""
-        state.set("current_trace_id", "trace-abc")
-        state.set("current_trace_span_id", "span-parent")
-        inp = _cli_base(
-            {
-                "toolName": "Bash",
-                "toolArgs": '{"command": "ls -la"}',
-                "toolResult": {"resultType": "success", "textResultForLlm": "total 42"},
-            }
-        )
-        _handle_post_tool_use(inp)
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["openinference.span.kind"]["stringValue"] == "TOOL"
-        assert attrs["tool.name"]["stringValue"] == "Bash"
+        assert attrs["tool.name"]["stringValue"] == "bash"
+        assert "ls -la" in attrs["input.value"]["stringValue"]
+        assert attrs["output.value"]["stringValue"] == "out"
         assert attrs["tool.command"]["stringValue"] == "ls -la"
-        assert attrs["output.value"]["stringValue"] == "total 42"
+        assert attrs["tool.description"]["stringValue"] == "ls -la"
         assert attrs["tool.result_type"]["stringValue"] == "success"
 
-    def test_cli_extracts_text_result_for_llm(self, mock_resolve, state, captured_spans):
-        """CLI mode extracts textResultForLlm from nested toolResult."""
+    def test_emits_span_for_unknown_tool(self, mock_resolve, state, captured_spans):
+        """Builds a TOOL span for an unrecognized tool name."""
         state.set("current_trace_id", "trace-abc")
         state.set("current_trace_span_id", "span-parent")
-        inp = _cli_base(
-            {
-                "toolName": "Read",
-                "toolArgs": '{"file_path": "/foo.py"}',
-                "toolResult": {"resultType": "success", "textResultForLlm": "file contents here"},
-            }
-        )
+        inp = {
+            "session_id": "sess-1",
+            "hook_event_name": "PostToolUse",
+            "cwd": "/repo",
+            "tool_name": "report_intent",
+            "tool_input": {"intent": "checking copilot"},
+            "tool_result": {"result_type": "success", "text_result_for_llm": "ack"},
+        }
+        _handle_post_tool_use(inp)
+        assert len(captured_spans) == 1
+        attrs = _get_span_attrs(captured_spans[0])
+        assert attrs["tool.name"]["stringValue"] == "report_intent"
+        assert attrs["output.value"]["stringValue"] == "ack"
+        assert attrs["tool.description"]["stringValue"]  # non-empty
+
+    def test_extracts_text_result_for_llm(self, mock_resolve, state, captured_spans):
+        """Extracts text_result_for_llm from tool_result."""
+        state.set("current_trace_id", "trace-abc")
+        state.set("current_trace_span_id", "span-parent")
+        inp = {
+            "session_id": "sess-1",
+            "hook_event_name": "PostToolUse",
+            "cwd": "/repo",
+            "tool_name": "read",
+            "tool_input": {"file_path": "/foo.py"},
+            "tool_result": {"result_type": "success", "text_result_for_llm": "file contents here"},
+        }
         _handle_post_tool_use(inp)
         attrs = _get_span_attrs(captured_spans[0])
         assert attrs["output.value"]["stringValue"] == "file contents here"
 
-    def test_cli_result_type_attribute(self, mock_resolve, state, captured_spans):
-        """CLI mode sets tool.result_type from toolResult.resultType."""
+    def test_result_type_attribute(self, mock_resolve, state, captured_spans):
+        """Sets tool.result_type from tool_result.result_type."""
         state.set("current_trace_id", "trace-abc")
         state.set("current_trace_span_id", "span-parent")
-        inp = _cli_base(
-            {
-                "toolName": "Edit",
-                "toolArgs": "{}",
-                "toolResult": {"resultType": "failure", "textResultForLlm": "error"},
-            }
-        )
+        inp = {
+            "session_id": "sess-1",
+            "hook_event_name": "PostToolUse",
+            "cwd": "/repo",
+            "tool_name": "edit",
+            "tool_input": {},
+            "tool_result": {"result_type": "failure", "text_result_for_llm": "error"},
+        }
         _handle_post_tool_use(inp)
         attrs = _get_span_attrs(captured_spans[0])
         assert attrs["tool.result_type"]["stringValue"] == "failure"
 
-    def test_vscode_no_result_type(self, mock_resolve, state, captured_spans):
-        """VS Code mode does not set tool.result_type."""
+    def test_no_result_type_when_empty(self, mock_resolve, state, captured_spans):
+        """Does not set tool.result_type when result_type is empty."""
         state.set("current_trace_id", "trace-abc")
         state.set("current_trace_span_id", "span-parent")
-        inp = _vscode_base(
-            {
-                "tool_name": "Bash",
-                "tool_use_id": "t1",
-                "tool_input": {"command": "echo hi"},
-                "tool_response": "hi",
-            }
-        )
+        inp = {
+            "session_id": "sess-1",
+            "hook_event_name": "PostToolUse",
+            "cwd": "/repo",
+            "tool_name": "bash",
+            "tool_input": {"command": "echo hi"},
+            "tool_result": {"text_result_for_llm": "hi"},
+        }
         _handle_post_tool_use(inp)
         attrs = _get_span_attrs(captured_spans[0])
         assert "tool.result_type" not in attrs
 
-    def test_cli_malformed_tool_args(self, mock_resolve, state, captured_spans):
-        """CLI mode handles malformed toolArgs gracefully."""
+    def test_case_insensitive_bash_enrichment(self, mock_resolve, state, captured_spans):
+        """Bash tool enrichment works regardless of tool name casing."""
         state.set("current_trace_id", "trace-abc")
         state.set("current_trace_span_id", "span-parent")
-        inp = _cli_base(
-            {
-                "toolName": "CustomTool",
-                "toolArgs": "not valid json",
-                "toolResult": {"textResultForLlm": "result"},
-            }
-        )
-        _handle_post_tool_use(inp)
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["tool.name"]["stringValue"] == "CustomTool"
-        assert attrs["input.value"]["stringValue"] == "not valid json"
-
-    def test_vscode_bash_tool_description(self, mock_resolve, state, captured_spans):
-        """VS Code Bash tool sets command and description."""
-        state.set("current_trace_id", "trace-abc")
-        state.set("current_trace_span_id", "span-parent")
-        inp = _vscode_base(
-            {
-                "tool_name": "Bash",
-                "tool_use_id": "t1",
-                "tool_input": {"command": "git status"},
-                "tool_response": "clean",
-            }
-        )
+        inp = {
+            "session_id": "sess-1",
+            "hook_event_name": "PostToolUse",
+            "cwd": "/repo",
+            "tool_name": "Bash",
+            "tool_input": {"command": "git status"},
+            "tool_result": {"result_type": "success", "text_result_for_llm": "clean"},
+        }
         _handle_post_tool_use(inp)
         attrs = _get_span_attrs(captured_spans[0])
         assert attrs["tool.command"]["stringValue"] == "git status"
@@ -411,39 +411,39 @@ class TestPostToolUse:
         """If session_id is None, returns without sending span."""
         state.delete("session_id")
         with mock.patch("tracing.copilot.hooks.handlers.resolve_session", return_value=state):
-            _handle_post_tool_use(_vscode_base({"tool_name": "Bash", "tool_use_id": "t1"}))
+            _handle_post_tool_use({"tool_name": "bash", "tool_input": {"command": "ls"}})
         assert len(captured_spans) == 0
 
     def test_uses_pre_tool_start_time(self, mock_resolve, state, captured_spans):
         """Timing uses pre_tool_use start time if available in state."""
         state.set("current_trace_id", "trace-abc")
         state.set("current_trace_span_id", "span-parent")
-        state.set("tool_t7_start", "1000000")
-        inp = _vscode_base(
-            {
-                "tool_name": "Read",
-                "tool_use_id": "t7",
-                "tool_input": {"file_path": "/a.py"},
-                "tool_response": "content",
-            }
-        )
+        state.set("tool_read_start", "1000000")
+        inp = {
+            "session_id": "sess-1",
+            "hook_event_name": "PostToolUse",
+            "cwd": "/repo",
+            "tool_name": "read",
+            "tool_input": {"file_path": "/a.py"},
+            "tool_result": {"text_result_for_llm": "content"},
+        }
         _handle_post_tool_use(inp)
         span = _get_span(captured_spans[0])
         assert span["startTimeUnixNano"] == "1000000000000"
-        assert state.get("tool_t7_start") is None
+        assert state.get("tool_read_start") is None
 
     def test_grep_tool_enrichment(self, mock_resolve, state, captured_spans):
         """Grep tool sets query, file_path, and description."""
         state.set("current_trace_id", "trace-abc")
         state.set("current_trace_span_id", "span-parent")
-        inp = _vscode_base(
-            {
-                "tool_name": "Grep",
-                "tool_use_id": "t1",
-                "tool_input": {"pattern": "TODO", "path": "/src"},
-                "tool_response": "matches",
-            }
-        )
+        inp = {
+            "session_id": "sess-1",
+            "hook_event_name": "PostToolUse",
+            "cwd": "/repo",
+            "tool_name": "grep",
+            "tool_input": {"pattern": "TODO", "path": "/src"},
+            "tool_result": {"text_result_for_llm": "matches"},
+        }
         _handle_post_tool_use(inp)
         attrs = _get_span_attrs(captured_spans[0])
         assert attrs["tool.query"]["stringValue"] == "TODO"
@@ -451,37 +451,38 @@ class TestPostToolUse:
         assert attrs["tool.description"]["stringValue"].startswith("grep: ")
 
     def test_webfetch_tool_enrichment(self, mock_resolve, state, captured_spans):
-        """WebFetch tool sets url."""
+        """WebFetch tool sets url (case-insensitive match)."""
         state.set("current_trace_id", "trace-abc")
         state.set("current_trace_span_id", "span-parent")
-        inp = _vscode_base(
-            {
-                "tool_name": "WebFetch",
-                "tool_use_id": "t1",
-                "tool_input": {"url": "https://example.com"},
-                "tool_response": "page",
-            }
-        )
+        inp = {
+            "session_id": "sess-1",
+            "hook_event_name": "PostToolUse",
+            "cwd": "/repo",
+            "tool_name": "WebFetch",
+            "tool_input": {"url": "https://example.com"},
+            "tool_result": {"text_result_for_llm": "page"},
+        }
         _handle_post_tool_use(inp)
         attrs = _get_span_attrs(captured_spans[0])
         assert attrs["tool.url"]["stringValue"] == "https://example.com"
 
-    def test_cli_input_value_normalized_like_vscode(self, mock_resolve, state, captured_spans):
-        """CLI mode re-serializes parsed toolArgs so input.value matches VS Code json.dumps format."""
+    def test_read_tool_file_path_enrichment(self, mock_resolve, state, captured_spans):
+        """Read tool sets file_path and description."""
         state.set("current_trace_id", "trace-abc")
         state.set("current_trace_span_id", "span-parent")
-        tool_dict = {"file_path": "/foo.py"}
-        inp = _cli_base(
-            {
-                "toolName": "Read",
-                "toolArgs": json.dumps(tool_dict),
-                "toolResult": {"textResultForLlm": "ok"},
-            }
-        )
+        inp = {
+            "session_id": "sess-1",
+            "hook_event_name": "PostToolUse",
+            "cwd": "/repo",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/foo/bar.py"},
+            "tool_result": {"result_type": "success", "text_result_for_llm": "file content"},
+        }
         _handle_post_tool_use(inp)
         attrs = _get_span_attrs(captured_spans[0])
-        # Should match json.dumps of the parsed dict (same as VS Code mode)
-        assert attrs["input.value"]["stringValue"] == json.dumps(tool_dict)
+        assert attrs["tool.name"]["stringValue"] == "Read"
+        assert attrs["tool.file_path"]["stringValue"] == "/foo/bar.py"
+        assert attrs["output.value"]["stringValue"] == "file content"
 
 
 # ---------------------------------------------------------------------------
@@ -1037,14 +1038,14 @@ class TestProjectNameOnAllSpans:
         """TOOL spans include project.name."""
         state.set("current_trace_id", "trace-abc")
         state.set("current_trace_span_id", "span-parent")
-        inp = _vscode_base(
-            {
-                "tool_name": "Bash",
-                "tool_use_id": "t1",
-                "tool_input": {"command": "ls"},
-                "tool_response": "output",
-            }
-        )
+        inp = {
+            "session_id": "sess-1",
+            "hook_event_name": "PostToolUse",
+            "cwd": "/repo",
+            "tool_name": "bash",
+            "tool_input": {"command": "ls"},
+            "tool_result": {"text_result_for_llm": "output"},
+        }
         _handle_post_tool_use(inp)
         attrs = _get_span_attrs(captured_spans[0])
         assert attrs["project.name"]["stringValue"] == "test-copilot-project"

--- a/tests/test_copilot_hook.py
+++ b/tests/test_copilot_hook.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""Tests for tracing.copilot.hooks.handlers — the 8 Copilot hook handlers.
+"""Tests for tracing.copilot.hooks.handlers — Copilot hook handlers.
 
-Tests cover both VS Code mode (sessionId-based) and CLI mode (PID-based),
-dual-mode detection, response printing, deferred turn flushing, and all
-entry points.
+Tests cover response printing, session/prompt/tool/stop handlers,
+deferred turn helpers, and all CLI entry points.
 """
 
 import io
@@ -188,25 +187,27 @@ class TestPrintResponse:
 
 class TestSessionStart:
 
-    def test_vscode_mode_saves_source(self, mock_resolve, mock_ensure, state, captured_spans):
-        """VS Code mode saves source to state."""
-        inp = _vscode_base({"source": "new"})
-        _handle_session_start(inp)
-        assert state.get("source") == "new"
+    def test_initializes_state_from_snake_case_payload(self, tmp_path, monkeypatch):
+        from tracing.copilot.hooks import adapter as _adapter
 
-    def test_cli_mode_saves_initial_prompt_as_pending_turn(self, mock_resolve, mock_ensure, state, captured_spans):
-        """CLI mode saves initialPrompt as pending turn."""
-        inp = _cli_base({"source": "new", "initialPrompt": "hello"})
-        _handle_session_start(inp)
-        assert state.get("pending_turn_prompt") == "hello"
-        assert state.get("pending_turn_trace_id") is not None
-        assert state.get("trace_count") == "1"
+        monkeypatch.setattr(_adapter, "STATE_DIR", tmp_path)
 
-    def test_cli_mode_no_initial_prompt(self, mock_resolve, mock_ensure, state, captured_spans):
-        """CLI mode with no initialPrompt does not create pending turn."""
-        inp = _cli_base({"source": "new"})
-        _handle_session_start(inp)
-        assert state.get("pending_turn_prompt") is None
+        payload = {
+            "cwd": "/some/repo",
+            "hook_event_name": "SessionStart",
+            "session_id": "sess-123",
+            "initial_prompt": "kick off",
+            "source": "new",
+            "timestamp": "2026-05-04T00:00:00Z",
+        }
+        _handle_session_start(payload)
+
+        from tracing.copilot.hooks.adapter import resolve_session
+
+        state = resolve_session(payload)
+        assert state.get("session_id") == "sess-123"
+        assert state.get("project_name") == "repo"
+        assert state.get("trace_count") == "0"
 
 
 # ---------------------------------------------------------------------------
@@ -216,72 +217,35 @@ class TestSessionStart:
 
 class TestUserPromptSubmitted:
 
-    def test_vscode_sets_trace_state(self, mock_resolve, mock_ensure, state, captured_spans):
-        """VS Code mode sets current_trace_id, span_id, start_time, prompt."""
-        inp = _vscode_base({"prompt": "explain this code"})
-        _handle_user_prompt_submitted(inp)
-        assert state.get("current_trace_id") is not None
-        assert len(state.get("current_trace_id")) == 32
-        assert state.get("current_trace_span_id") is not None
-        assert state.get("current_trace_prompt") == "explain this code"
+    def test_creates_trace_root(self, tmp_path, monkeypatch):
+        from tracing.copilot.hooks import adapter as _adapter
+
+        monkeypatch.setattr(_adapter, "STATE_DIR", tmp_path)
+
+        payload = {
+            "cwd": "/some/repo",
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "sess-abc",
+            "prompt": "what is the capital of France?",
+            "timestamp": "2026-05-04T00:00:00Z",
+        }
+        _handle_user_prompt_submitted(payload)
+
+        from tracing.copilot.hooks.adapter import resolve_session
+
+        state = resolve_session(payload)
+        assert state.get("current_trace_id") not in (None, "")
+        assert state.get("current_trace_span_id") not in (None, "")
+        assert state.get("current_trace_prompt") == "what is the capital of France?"
         assert state.get("trace_count") == "1"
+        assert state.get("tool_count") == "0"
 
-    def test_vscode_records_transcript_position(
-        self, mock_resolve, mock_ensure, state, captured_spans, transcript_file
-    ):
-        """VS Code mode records transcript line count as trace_start_line."""
-        inp = _vscode_base({"prompt": "test", "transcript_path": transcript_file})
+    def test_returns_early_without_session_id(self, mock_resolve, mock_ensure, state, captured_spans):
+        """Returns early when session_id is None."""
+        state.delete("session_id")
+        inp = {"cwd": "/tmp/project", "hook_event_name": "UserPromptSubmit", "prompt": "hello"}
         _handle_user_prompt_submitted(inp)
-        assert state.get("trace_start_line") == "2"  # 2 lines in our transcript fixture
-
-    def test_vscode_no_transcript_sets_zero(self, mock_resolve, mock_ensure, state, captured_spans):
-        """Missing transcript sets trace_start_line to 0."""
-        inp = _vscode_base({"prompt": "test"})
-        _handle_user_prompt_submitted(inp)
-        assert state.get("trace_start_line") == "0"
-
-    def test_vscode_failsafe_closes_orphan(self, mock_resolve, mock_ensure, state, captured_spans):
-        """If current_trace_id already in state, sends fail-safe LLM span."""
-        state.set("current_trace_id", "old-trace-id-00000000000000000000")
-        state.set("current_trace_span_id", "old-span-1234567")
-        state.set("current_trace_start_time", "999000")
-        state.set("current_trace_prompt", "old prompt")
-        inp = _vscode_base({"prompt": "new prompt"})
-        _handle_user_prompt_submitted(inp)
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["openinference.span.kind"]["stringValue"] == "LLM"
-        assert "fail-safe" in attrs["output.value"]["stringValue"]
-        assert state.get("current_trace_id") != "old-trace-id-00000000000000000000"
-
-    def test_cli_flushes_previous_pending_turn(self, mock_resolve, mock_ensure, state, captured_spans):
-        """CLI mode: second user_prompt_submitted flushes the first pending turn."""
-        # First prompt
-        inp1 = _cli_base({"prompt": "first prompt"})
-        _handle_user_prompt_submitted(inp1)
-        assert state.get("pending_turn_prompt") == "first prompt"
-        assert state.get("trace_count") == "1"
-
-        # Second prompt — should flush first
-        inp2 = _cli_base({"prompt": "second prompt"})
-        _handle_user_prompt_submitted(inp2)
-
-        # First turn should have been flushed as a CHAIN span
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["openinference.span.kind"]["stringValue"] == "CHAIN"
-        assert attrs["input.value"]["stringValue"] == "first prompt"
-
-        # Second prompt is now pending
-        assert state.get("pending_turn_prompt") == "second prompt"
-        assert state.get("trace_count") == "2"
-
-    def test_cli_first_prompt_no_flush(self, mock_resolve, mock_ensure, state, captured_spans):
-        """CLI mode: first prompt has nothing to flush."""
-        inp = _cli_base({"prompt": "only prompt"})
-        _handle_user_prompt_submitted(inp)
-        assert len(captured_spans) == 0
-        assert state.get("pending_turn_prompt") == "only prompt"
+        assert state.get("current_trace_id") is None
 
 
 # ---------------------------------------------------------------------------
@@ -875,37 +839,10 @@ class TestSubagentStop:
 
 
 class TestDeferredTurnPattern:
-
-    def test_two_prompts_flushes_first(self, mock_resolve, mock_ensure, state, captured_spans):
-        """Two user_prompt_submitted calls flush the first as a CHAIN span."""
-        _handle_user_prompt_submitted(_cli_base({"prompt": "first"}))
-        _handle_user_prompt_submitted(_cli_base({"prompt": "second"}))
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["input.value"]["stringValue"] == "first"
-        assert attrs["openinference.span.kind"]["stringValue"] == "CHAIN"
-
-    def test_session_end_flushes_last(self, mock_resolve, mock_ensure, state, captured_spans):
-        """session_end flushes the last pending turn."""
-        _handle_user_prompt_submitted(_cli_base({"prompt": "the prompt"}))
-        assert len(captured_spans) == 0
-
-        with mock.patch("tracing.copilot.hooks.handlers.gc_stale_state_files"):
-            _handle_session_end(_cli_base({"reason": "complete"}))
-        assert len(captured_spans) == 1
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["input.value"]["stringValue"] == "the prompt"
-
-    def test_no_output_value_in_cli_chain(self, mock_resolve, mock_ensure, state, captured_spans):
-        """CLI deferred CHAIN spans have no output.value (CLI doesn't expose response)."""
-        _handle_user_prompt_submitted(_cli_base({"prompt": "first"}))
-        _handle_user_prompt_submitted(_cli_base({"prompt": "second"}))
-        attrs = _get_span_attrs(captured_spans[0])
-        assert "output.value" not in attrs
+    """Tests for deferred turn helpers (still used by _handle_session_end)."""
 
     def test_flush_pending_turn_no_op_when_empty(self, state):
         """_flush_pending_turn is no-op when no pending turn exists."""
-        # Should not raise or send anything
         with mock.patch("tracing.copilot.hooks.handlers.send_span") as send_mock:
             _flush_pending_turn(state)
         send_mock.assert_not_called()
@@ -913,11 +850,21 @@ class TestDeferredTurnPattern:
     def test_flush_pending_turn_clears_invalid(self, state):
         """_flush_pending_turn clears invalid pending turn (no trace/span id)."""
         state.set("pending_turn_prompt", "orphan")
-        # No trace_id or span_id set
         with mock.patch("tracing.copilot.hooks.handlers.send_span") as send_mock:
             _flush_pending_turn(state)
         send_mock.assert_not_called()
         assert state.get("pending_turn_prompt") is None
+
+    def test_consecutive_prompts_each_open_fresh_trace(self, mock_resolve, mock_ensure, state, captured_spans):
+        """Each user_prompt_submitted opens a fresh trace without sending spans."""
+        _handle_user_prompt_submitted({"cwd": "/tmp/project", "prompt": "first"})
+        first_trace = state.get("current_trace_id")
+        _handle_user_prompt_submitted({"cwd": "/tmp/project", "prompt": "second"})
+        second_trace = state.get("current_trace_id")
+        assert first_trace != second_trace
+        assert state.get("current_trace_prompt") == "second"
+        assert state.get("trace_count") == "2"
+        assert len(captured_spans) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -1119,13 +1066,11 @@ class TestProjectNameOnAllSpans:
         attrs = _get_span_attrs(captured_spans[0])
         assert attrs["project.name"]["stringValue"] == "test-copilot-project"
 
-    def test_failsafe_span_has_project_name(self, mock_resolve, mock_ensure, state, captured_spans):
-        """Fail-safe LLM span includes project.name."""
-        state.set("current_trace_id", "old-trace-id-00000000000000000000")
-        state.set("current_trace_span_id", "old-span-1234567")
-        state.set("current_trace_start_time", "999000")
-        state.set("current_trace_prompt", "old prompt")
-        inp = _vscode_base({"prompt": "new prompt"})
+    def test_user_prompt_sets_trace_state(self, mock_resolve, mock_ensure, state, captured_spans):
+        """user_prompt_submitted sets trace state with project context."""
+        inp = {"cwd": "/tmp/project", "prompt": "new prompt"}
         _handle_user_prompt_submitted(inp)
-        attrs = _get_span_attrs(captured_spans[0])
-        assert attrs["project.name"]["stringValue"] == "test-copilot-project"
+        assert state.get("current_trace_id") is not None
+        assert state.get("current_trace_prompt") == "new prompt"
+        assert state.get("trace_count") == "1"
+        assert state.get("tool_count") == "0"

--- a/tests/test_copilot_install.py
+++ b/tests/test_copilot_install.py
@@ -23,7 +23,7 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 
 
 class TestCopilotEntryPoints:
-    """Verify all 9 Copilot entry points (8 hooks + 1 setup) in pyproject.toml."""
+    """Verify all 7 Copilot entry points (6 hooks + 1 setup) in pyproject.toml."""
 
     @pytest.fixture(autouse=True)
     def _load_pyproject(self):
@@ -47,27 +47,19 @@ class TestCopilotEntryPoints:
     def test_subagent_stop_entry_point(self):
         assert 'arize-hook-copilot-subagent-stop = "tracing.copilot.hooks.handlers:subagent_stop"' in self.text
 
-    def test_error_entry_point(self):
-        assert 'arize-hook-copilot-error = "tracing.copilot.hooks.handlers:error_occurred"' in self.text
-
-    def test_session_end_entry_point(self):
-        assert 'arize-hook-copilot-session-end = "tracing.copilot.hooks.handlers:session_end"' in self.text
-
     def test_setup_entry_point(self):
         assert 'arize-setup-copilot = "core.setup.copilot:main"' in self.text
 
-    def test_exactly_8_hook_entry_points(self):
-        """There should be exactly 8 copilot hook entry points."""
+    def test_exactly_6_hook_entry_points(self):
+        """There should be exactly 6 copilot hook entry points."""
         count = self.text.count("arize-hook-copilot-")
-        assert count == 8, f"Expected 8 copilot hook entries, got {count}"
+        assert count == 6, f"Expected 6 copilot hook entries, got {count}"
 
     def test_entry_points_importable(self):
         """All referenced handler functions should be importable."""
         from tracing.copilot.hooks.handlers import (
-            error_occurred,
             post_tool_use,
             pre_tool_use,
-            session_end,
             session_start,
             stop,
             subagent_stop,
@@ -81,7 +73,5 @@ class TestCopilotEntryPoints:
             post_tool_use,
             stop,
             subagent_stop,
-            error_occurred,
-            session_end,
         ]:
             assert callable(fn)

--- a/tests/test_copilot_readme_and_skill.py
+++ b/tests/test_copilot_readme_and_skill.py
@@ -472,26 +472,15 @@ class TestCopilotSkillDecisionTree:
 
 
 class TestCopilotSkillHookEvents:
-    """Skill must document hook events for both VS Code and CLI."""
+    """Skill must document hook events."""
 
     @pytest.fixture(autouse=True)
     def _load(self):
         self.text = SKILL_PATH.read_text()
 
-    def test_vscode_events_documented(self):
-        for event in ["SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "SubagentStop"]:
-            assert event in self.text, f"Missing VS Code event '{event}' in SKILL.md"
-
-    def test_cli_events_documented(self):
-        for event in [
-            "sessionStart",
-            "userPromptSubmitted",
-            "preToolUse",
-            "postToolUse",
-            "errorOccurred",
-            "sessionEnd",
-        ]:
-            assert event in self.text, f"Missing CLI event '{event}' in SKILL.md"
+    def test_hook_events_documented(self):
+        for event in ("SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "SubagentStop"):
+            assert event in self.text, f"Missing event '{event}' in SKILL.md"
 
     def test_pre_tool_permission_response_documented(self):
         """Must document the permission response format."""

--- a/tests/test_copilot_transcript.py
+++ b/tests/test_copilot_transcript.py
@@ -84,3 +84,129 @@ class TestParseTranscriptDefensive:
         _write_jsonl(f, [{"type": "something.exotic", "data": {"x": 1}}])
         s = parse_transcript(f)
         assert s["events_seen"] == 1
+
+    def test_null_data_field_does_not_crash(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        _write_jsonl(f, [{"type": "session.start", "data": None}])
+        s = parse_transcript(f)
+        assert s["events_seen"] == 1
+        assert s["copilot_version"] == ""
+
+    def test_missing_type_field_does_not_crash(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        _write_jsonl(f, [{"data": {"something": "here"}}])
+        s = parse_transcript(f)
+        assert s["events_seen"] == 1
+
+
+class TestParseTranscriptOverwriteSemantics:
+    def test_last_model_change_wins(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        _write_jsonl(
+            f,
+            [
+                {"type": "session.model_change", "data": {"newModel": "gpt-4"}},
+                {"type": "session.model_change", "data": {"newModel": "gpt-5-mini"}},
+            ],
+        )
+        s = parse_transcript(f)
+        assert s["model_name"] == "gpt-5-mini"
+
+    def test_last_user_prompt_wins(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        _write_jsonl(
+            f,
+            [
+                {
+                    "type": "hook.start",
+                    "data": {
+                        "hookType": "userPromptSubmitted",
+                        "input": {"prompt": "first prompt"},
+                    },
+                },
+                {
+                    "type": "hook.start",
+                    "data": {
+                        "hookType": "userPromptSubmitted",
+                        "input": {"prompt": "second prompt"},
+                    },
+                },
+            ],
+        )
+        s = parse_transcript(f)
+        assert s["input_text"] == "second prompt"
+
+    def test_empty_model_name_does_not_overwrite(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        _write_jsonl(
+            f,
+            [
+                {"type": "session.model_change", "data": {"newModel": "gpt-4"}},
+                {"type": "session.model_change", "data": {"newModel": ""}},
+            ],
+        )
+        s = parse_transcript(f)
+        assert s["model_name"] == "gpt-4"
+
+    def test_empty_prompt_does_not_overwrite(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        _write_jsonl(
+            f,
+            [
+                {
+                    "type": "hook.start",
+                    "data": {
+                        "hookType": "userPromptSubmitted",
+                        "input": {"prompt": "real prompt"},
+                    },
+                },
+                {
+                    "type": "hook.start",
+                    "data": {
+                        "hookType": "userPromptSubmitted",
+                        "input": {"prompt": ""},
+                    },
+                },
+            ],
+        )
+        s = parse_transcript(f)
+        assert s["input_text"] == "real prompt"
+
+
+class TestParseTranscriptReturnShape:
+    def test_all_expected_keys_present(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        _write_jsonl(f, [{"type": "session.start", "data": {}}])
+        s = parse_transcript(f)
+        assert set(s.keys()) == {
+            "model_name",
+            "copilot_version",
+            "input_text",
+            "output_text",
+            "tool_count",
+            "events_seen",
+        }
+
+    def test_output_text_always_empty_string(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        _write_jsonl(
+            f,
+            [
+                {"type": "session.start", "data": {"copilotVersion": "1.0.40"}},
+                {"type": "session.model_change", "data": {"newModel": "gpt-5-mini"}},
+                {
+                    "type": "hook.start",
+                    "data": {
+                        "hookType": "userPromptSubmitted",
+                        "input": {"prompt": "hello"},
+                    },
+                },
+            ],
+        )
+        s = parse_transcript(f)
+        assert s["output_text"] == ""
+
+    def test_missing_file_returns_truly_empty_dict(self, tmp_path):
+        s = parse_transcript(tmp_path / "nonexistent.jsonl")
+        assert s == {}
+        assert len(s) == 0

--- a/tests/test_copilot_transcript.py
+++ b/tests/test_copilot_transcript.py
@@ -1,0 +1,86 @@
+"""Tests for tracing.copilot.hooks.transcript.parse_transcript."""
+
+from __future__ import annotations
+
+import json
+
+from tracing.copilot.hooks.transcript import parse_transcript
+
+
+def _write_jsonl(path, events):
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+
+class TestParseTranscriptHappyPath:
+    def test_extracts_model_from_session_model_change(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        _write_jsonl(
+            f,
+            [
+                {"type": "session.start", "data": {"copilotVersion": "1.0.40"}},
+                {"type": "session.model_change", "data": {"newModel": "gpt-5-mini"}},
+            ],
+        )
+        s = parse_transcript(f)
+        assert s["model_name"] == "gpt-5-mini"
+        assert s["copilot_version"] == "1.0.40"
+
+    def test_extracts_user_prompt_from_hook_start(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        _write_jsonl(
+            f,
+            [
+                {
+                    "type": "hook.start",
+                    "data": {
+                        "hookType": "userPromptSubmitted",
+                        "input": {"prompt": "do the thing"},
+                    },
+                },
+            ],
+        )
+        s = parse_transcript(f)
+        assert s["input_text"] == "do the thing"
+
+    def test_counts_pretool_use_events(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        _write_jsonl(
+            f,
+            [
+                {"type": "hook.start", "data": {"hookType": "preToolUse", "input": {}}},
+                {"type": "hook.start", "data": {"hookType": "preToolUse", "input": {}}},
+                {"type": "hook.start", "data": {"hookType": "postToolUse", "input": {}}},
+            ],
+        )
+        s = parse_transcript(f)
+        assert s["tool_count"] == 2
+
+
+class TestParseTranscriptDefensive:
+    def test_missing_file_returns_empty_dict(self, tmp_path):
+        assert parse_transcript(tmp_path / "nope.jsonl") == {}
+
+    def test_blank_file_returns_zeroed_summary(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        f.write_text("", encoding="utf-8")
+        s = parse_transcript(f)
+        assert s["events_seen"] == 0
+        assert s["model_name"] == ""
+
+    def test_malformed_lines_are_skipped(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        f.write_text(
+            "not json\n"
+            + json.dumps({"type": "session.model_change", "data": {"newModel": "gpt-5"}})
+            + "\nalso not json\n",
+            encoding="utf-8",
+        )
+        s = parse_transcript(f)
+        assert s["model_name"] == "gpt-5"
+        assert s["events_seen"] == 1
+
+    def test_unknown_event_kinds_do_not_crash(self, tmp_path):
+        f = tmp_path / "events.jsonl"
+        _write_jsonl(f, [{"type": "something.exotic", "data": {"x": 1}}])
+        s = parse_transcript(f)
+        assert s["events_seen"] == 1

--- a/tests/test_wire_entry_points.py
+++ b/tests/test_wire_entry_points.py
@@ -50,8 +50,6 @@ EXPECTED_HARNESS_ENTRY_POINTS = {
     "arize-hook-copilot-pre-tool": "tracing.copilot.hooks.handlers:pre_tool_use",
     "arize-hook-copilot-post-tool": "tracing.copilot.hooks.handlers:post_tool_use",
     "arize-hook-copilot-stop": "tracing.copilot.hooks.handlers:stop",
-    "arize-hook-copilot-error": "tracing.copilot.hooks.handlers:error_occurred",
-    "arize-hook-copilot-session-end": "tracing.copilot.hooks.handlers:session_end",
     "arize-hook-copilot-subagent-stop": "tracing.copilot.hooks.handlers:subagent_stop",
     # Gemini hooks
     "arize-hook-gemini-session-start": "tracing.gemini.hooks.handlers:session_start",
@@ -127,7 +125,7 @@ class TestPyprojectEntryPointsUpdated:
         assert "core.codex_buffer_ctl" not in self.pyproject_text
 
     def test_total_entry_point_count(self):
-        """Should have exactly 27 entry points (23 harness + 4 setup + arize-config)."""
+        """Entry point count should match expected harness + setup + arize-config."""
         expected_count = (
             len(EXPECTED_HARNESS_ENTRY_POINTS) + len(EXPECTED_SETUP_ENTRY_POINTS) + 1
         )  # +1 for arize-config

--- a/tracing/copilot/hooks/adapter.py
+++ b/tracing/copilot/hooks/adapter.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
-"""Copilot adapter — dual-mode session resolution (VS Code + CLI), initialization, and GC.
+"""Copilot adapter — single-mode session resolution, initialization, and GC.
 
-Supports two modes:
-- VS Code Copilot: uses sessionId from payload for session keys
-- Copilot CLI: uses PID-based session keys (grandparent PID, like Claude)
-
-Mode is auto-detected by checking for VS Code-specific fields in the hook payload.
+The Copilot hook payload schema is unified across VS Code Copilot Chat and
+`gh copilot` CLI: snake_case fields with a top-level `session_id`. We use
+that as the session key directly.
 """
 import os
 import platform
@@ -105,16 +103,11 @@ def _is_pid_alive(pid: int) -> bool:
 def resolve_session(input_json: dict) -> StateManager:
     """Resolve the per-session state file from hook input JSON.
 
-    Dual-mode session key resolution:
-    1. VS Code mode: use sessionId from the payload directly
-    2. CLI mode: use grandparent PID (same approach as Claude adapter)
-
-    Returns a StateManager instance with state_file and lock_path set.
-    Calls init_state() to ensure the file exists.
+    The hook payload always carries `session_id` (snake_case). Use it directly.
+    Defensive fallback to grandparent PID when the payload is malformed.
     """
-    if is_vscode_mode(input_json):
-        session_key = input_json["sessionId"]
-    else:
+    session_key = input_json.get("session_id") or ""
+    if not session_key:
         if platform.system() == "Windows":
             session_key = str(os.getppid())
         else:
@@ -133,27 +126,22 @@ def resolve_session(input_json: dict) -> StateManager:
 
 
 def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
-    """Idempotent session initialization. No-op if session_id already in state.
+    """Idempotent session init. No-op if session_id already in state.
 
-    Sets the following state keys:
-    - session_id: from input_json sessionId (VS Code) or generate_trace_id()
-    - session_start_time: get_timestamp_ms() as string
-    - project_name: from ARIZE_PROJECT_NAME env, or basename of input_json["cwd"], or cwd
-    - trace_count: "0"
-    - tool_count: "0"
-    - user_id: from env.user_id, then ""
+    State keys set:
+      session_id          -- input_json["session_id"] (always populated by Copilot)
+      session_start_time  -- get_timestamp_ms() as string
+      project_name        -- env.project_name, else basename(input_json["cwd"]),
+                             else basename(getcwd())
+      trace_count         -- "0"
+      tool_count          -- "0"
+      user_id             -- env.user_id (Copilot does not pass user_id in payload)
     """
-    # Skip if already initialized
-    existing = state.get("session_id")
-    if existing is not None:
+    if state.get("session_id") is not None:
         return
 
-    # session_id: prefer sessionId from VS Code payload, else generate
-    session_id = input_json.get("sessionId", "")
-    if not session_id:
-        session_id = generate_trace_id()
+    session_id = input_json.get("session_id", "") or generate_trace_id()
 
-    # project_name
     project_name = env.project_name
     if not project_name:
         cwd = input_json.get("cwd", "")
@@ -164,10 +152,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     state.set("project_name", project_name)
     state.set("trace_count", "0")
     state.set("tool_count", "0")
-
-    # user_id from env (Copilot hooks don't pass user_id in payload)
-    user_id = env.user_id
-    state.set("user_id", user_id)
+    state.set("user_id", env.user_id)
 
     log(f"Session initialized: {session_id}")
 

--- a/tracing/copilot/hooks/adapter.py
+++ b/tracing/copilot/hooks/adapter.py
@@ -22,14 +22,6 @@ STATE_DIR = STATE_BASE_DIR / _HARNESS["state_subdir"]  # ~/.arize/harness/state/
 os.environ.setdefault("ARIZE_LOG_FILE", str(_HARNESS["default_log_file"]))
 
 
-def is_vscode_mode(input_json: dict) -> bool:
-    """Detect VS Code Copilot by presence of sessionId or hookEventName.
-
-    VS Code Copilot hooks always include these base fields. Copilot CLI does not.
-    """
-    return bool(input_json.get("sessionId") or input_json.get("hookEventName"))
-
-
 def _get_grandparent_pid() -> str:
     """Get the grandparent PID for session key derivation.
 

--- a/tracing/copilot/hooks/handlers.py
+++ b/tracing/copilot/hooks/handlers.py
@@ -56,32 +56,25 @@ def _read_stdin(event: str) -> dict:
 
 
 def _print_response(input_json: dict, event: str) -> None:
-    """Print appropriate response to stdout based on mode and event.
+    """Print the hook's stdout response.
 
-    VS Code mode: {"continue": true} for most events.
-    PreToolUse VS Code: wrapped permission response.
-    PreToolUse CLI: flat permission response.
-    CLI mode (non-preToolUse): print nothing.
+    PreToolUse must emit a permission decision; all other events emit a
+    `{"continue": true}` marker so the agent does not block.
     """
-    vscode = is_vscode_mode(input_json)
-
-    if event == "PreToolUse" or event == "preToolUse":
-        if vscode:
-            print(
-                json.dumps(
-                    {
-                        "hookSpecificOutput": {
-                            "hookEventName": "PreToolUse",
-                            "permissionDecision": "allow",
-                        }
+    del input_json  # signature kept for compatibility with existing callers
+    if event == "PreToolUse":
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "allow",
                     }
-                )
+                }
             )
-        else:
-            print(json.dumps({"permissionDecision": "allow"}))
-    elif vscode:
+        )
+    else:
         print(json.dumps({"continue": True}))
-    # CLI mode, non-preToolUse: print nothing
 
 
 def _flush_pending_turn(state: StateManager) -> None:

--- a/tracing/copilot/hooks/handlers.py
+++ b/tracing/copilot/hooks/handlers.py
@@ -197,14 +197,7 @@ def _handle_user_prompt_submitted(input_json: dict) -> None:
 def _handle_pre_tool_use(input_json: dict) -> None:
     """Handle pre_tool_use: record tool start time."""
     state = resolve_session(input_json)
-
-    vscode = is_vscode_mode(input_json)
-    if vscode:
-        tool_id = input_json.get("tool_use_id") or generate_trace_id()
-    else:
-        # CLI: no tool_use_id; use toolName as key fallback
-        tool_id = input_json.get("toolName", "") or generate_trace_id()
-
+    tool_id = input_json.get("tool_use_id") or input_json.get("tool_name", "") or generate_trace_id()
     state.set(f"tool_{tool_id}_start", str(get_timestamp_ms()))
 
 
@@ -219,55 +212,38 @@ def _handle_post_tool_use(input_json: dict) -> None:
     parent_span_id = state.get("current_trace_span_id")
     state.increment("tool_count")
 
-    vscode = is_vscode_mode(input_json)
+    tool_name = input_json.get("tool_name", "unknown")
+    tool_id = input_json.get("tool_use_id") or tool_name or generate_trace_id()
+    tool_input_raw = input_json.get("tool_input") or {}
+    tool_input = json.dumps(tool_input_raw) if isinstance(tool_input_raw, dict) else str(tool_input_raw)
 
-    # Normalize tool info from VS Code or CLI format
-    if vscode:
-        tool_name = input_json.get("tool_name", "unknown")
-        tool_id = input_json.get("tool_use_id", "")
-        tool_input_raw = input_json.get("tool_input", {})
-        tool_input = json.dumps(tool_input_raw) if isinstance(tool_input_raw, dict) else str(tool_input_raw)
-        tool_response = str(input_json.get("tool_response", ""))
-    else:
-        tool_name = input_json.get("toolName", "unknown")
-        tool_id = tool_name  # CLI uses toolName as key (matches pre_tool_use)
-        # toolArgs is a JSON string in CLI mode
-        tool_args_raw = input_json.get("toolArgs", "")
-        if isinstance(tool_args_raw, str):
-            try:
-                tool_input_raw = json.loads(tool_args_raw)
-                tool_input = json.dumps(tool_input_raw)
-            except (json.JSONDecodeError, TypeError):
-                tool_input_raw = {}
-                tool_input = tool_args_raw
-        else:
-            tool_input_raw = tool_args_raw or {}
-            tool_input = json.dumps(tool_input_raw)
-        # toolResult is a nested object with resultType and textResultForLlm
-        tool_result = input_json.get("toolResult", {}) or {}
-        tool_response = str(tool_result.get("textResultForLlm", ""))
+    tool_result_obj = input_json.get("tool_result") or {}
+    tool_response = str(tool_result_obj.get("text_result_for_llm", ""))
+    result_type = tool_result_obj.get("result_type", "")
 
-    # Tool-specific metadata (same enrichment as Claude)
+    # Tool-specific enrichment. Match case-insensitively because Copilot uses
+    # lowercase tool names (`bash`, `read`) where Claude Code uses TitleCase.
     tool_command = ""
     tool_file_path = ""
     tool_url = ""
     tool_query = ""
     tool_description = ""
+    tool_name_lc = tool_name.lower()
 
     if isinstance(tool_input_raw, dict):
-        if tool_name == "Bash":
+        if tool_name_lc == "bash":
             tool_command = tool_input_raw.get("command", "")
             tool_description = tool_command[:200]
-        elif tool_name in ("Read", "Write", "Edit", "Glob"):
+        elif tool_name_lc in ("read", "write", "edit", "glob"):
             tool_file_path = tool_input_raw.get("file_path") or tool_input_raw.get("pattern", "")
             tool_description = tool_file_path[:200]
-        elif tool_name == "WebSearch":
+        elif tool_name_lc == "websearch":
             tool_query = tool_input_raw.get("query", "")
             tool_description = tool_query[:200]
-        elif tool_name == "WebFetch":
+        elif tool_name_lc == "webfetch":
             tool_url = tool_input_raw.get("url", "")
             tool_description = tool_url[:200]
-        elif tool_name == "Grep":
+        elif tool_name_lc == "grep":
             tool_query = tool_input_raw.get("pattern", "")
             tool_file_path = tool_input_raw.get("path", "")
             tool_description = f"grep: {tool_query[:100]}"
@@ -281,8 +257,7 @@ def _handle_post_tool_use(input_json: dict) -> None:
     end_time = str(get_timestamp_ms())
     state.delete(f"tool_{tool_id}_start")
 
-    # Redaction: tool input/output may contain raw file contents or command output;
-    # tool_command/file_path/url/query/description describe what was requested.
+    # Redaction
     tool_input = redact_content(env.log_tool_content, tool_input)
     tool_response = redact_content(env.log_tool_content, tool_response)
     tool_description = redact_content(env.log_tool_details, tool_description)
@@ -317,13 +292,8 @@ def _handle_post_tool_use(input_json: dict) -> None:
         attrs["tool.url"] = tool_url
     if tool_query:
         attrs["tool.query"] = tool_query
-
-    # CLI-specific: result type
-    if not vscode:
-        tool_result = input_json.get("toolResult", {}) or {}
-        result_type = tool_result.get("resultType", "")
-        if result_type:
-            attrs["tool.result_type"] = result_type
+    if result_type:
+        attrs["tool.result_type"] = result_type
 
     span = build_span(
         tool_name,

--- a/tracing/copilot/hooks/handlers.py
+++ b/tracing/copilot/hooks/handlers.py
@@ -8,7 +8,6 @@ import json
 import sys
 
 from core.common import (
-    StateManager,
     build_span,
     debug_dump,
     env,
@@ -26,7 +25,6 @@ from tracing.copilot.hooks.adapter import (
     check_requirements,
     ensure_session_initialized,
     gc_stale_state_files,
-    is_vscode_mode,
     resolve_session,
 )
 from tracing.copilot.hooks.transcript import parse_transcript
@@ -52,13 +50,12 @@ def _read_stdin(event: str) -> dict:
     return data
 
 
-def _print_response(input_json: dict, event: str) -> None:
+def _print_response(event: str) -> None:
     """Print the hook's stdout response.
 
     PreToolUse must emit a permission decision; all other events emit a
-    `{"continue": true}` marker so the agent does not block.
+    ``{"continue": true}`` marker so the agent does not block.
     """
-    del input_json  # signature kept for compatibility with existing callers
     if event == "PreToolUse":
         print(
             json.dumps(
@@ -72,86 +69,6 @@ def _print_response(input_json: dict, event: str) -> None:
         )
     else:
         print(json.dumps({"continue": True}))
-
-
-def _flush_pending_turn(state: StateManager) -> None:
-    """CLI mode only: if a pending_turn exists in state, build and send
-    the root CHAIN span, then clear it.
-
-    The root span has input.value (prompt) but no output.value
-    (CLI doesn't expose agent response).
-    """
-    prompt = state.get("pending_turn_prompt")
-    if prompt is None:
-        return
-
-    trace_id = state.get("pending_turn_trace_id")
-    span_id = state.get("pending_turn_span_id")
-    start_time = state.get("pending_turn_start_time")
-    trace_count = state.get("pending_turn_trace_count")
-
-    if not trace_id or not span_id:
-        # Clean up invalid pending turn
-        _clear_pending_turn(state)
-        return
-
-    session_id = state.get("session_id") or ""
-    project_name = state.get("project_name") or ""
-    user_id = state.get("user_id") or ""
-
-    attrs = {
-        "session.id": session_id,
-        "openinference.span.kind": "CHAIN",
-        "project.name": project_name,
-        "input.value": redact_content(env.log_prompts, prompt),
-    }
-    if user_id:
-        attrs["user.id"] = user_id
-
-    span = build_span(
-        f"Turn {trace_count}",
-        "CHAIN",
-        span_id,
-        trace_id,
-        "",
-        start_time or str(get_timestamp_ms()),
-        str(get_timestamp_ms()),
-        attrs,
-        SERVICE_NAME,
-        SCOPE_NAME,
-    )
-    send_span(span)
-
-    _clear_pending_turn(state)
-
-
-def _clear_pending_turn(state: StateManager) -> None:
-    """Remove all pending_turn keys from state."""
-    for key in (
-        "pending_turn_prompt",
-        "pending_turn_trace_id",
-        "pending_turn_span_id",
-        "pending_turn_start_time",
-        "pending_turn_trace_count",
-    ):
-        state.delete(key)
-
-
-def _save_pending_turn(state: StateManager, prompt: str) -> None:
-    """CLI mode: save a new prompt as a pending turn for deferred sending.
-
-    Stores the RAW prompt; redaction happens at span build time.
-    """
-    state.increment("trace_count")
-    trace_count = state.get("trace_count") or "1"
-    state.set("pending_turn_prompt", prompt)
-    state.set("pending_turn_trace_id", generate_trace_id())
-    state.set("pending_turn_span_id", generate_span_id())
-    state.set("pending_turn_start_time", str(get_timestamp_ms()))
-    state.set("pending_turn_trace_count", trace_count)
-    # Set current trace context for child spans (tool spans, etc.)
-    state.set("current_trace_id", state.get("pending_turn_trace_id") or "")
-    state.set("current_trace_span_id", state.get("pending_turn_span_id") or "")
 
 
 # ---------------------------------------------------------------------------
@@ -377,105 +294,6 @@ def _handle_stop(input_json: dict) -> None:
     state.delete("current_trace_prompt")
 
 
-def _handle_error_occurred(input_json: dict) -> None:
-    """Handle error: build and send an error CHAIN span."""
-    state = resolve_session(input_json)
-    session_id = state.get("session_id")
-    if session_id is None:
-        return
-
-    trace_id = state.get("current_trace_id")
-    parent_span_id = state.get("current_trace_span_id")
-
-    # Try both field patterns (VS Code may vary, CLI has nested error object)
-    error_obj = input_json.get("error", {})
-    if isinstance(error_obj, dict):
-        error_message = error_obj.get("message", "")
-        error_name = error_obj.get("name", "")
-        error_stack = error_obj.get("stack", "")
-    else:
-        error_message = str(error_obj)
-        error_name = ""
-        error_stack = ""
-
-    # Fallback: check top-level fields
-    if not error_message:
-        error_message = input_json.get("message", "") or input_json.get("error_message", "")
-    if not error_name:
-        error_name = input_json.get("name", "") or input_json.get("error_name", "")
-    if not error_stack:
-        error_stack = input_json.get("stack", "") or input_json.get("error_stack", "")
-
-    user_id = state.get("user_id") or ""
-    project_name = state.get("project_name") or ""
-    attrs = {
-        "session.id": session_id,
-        "openinference.span.kind": "CHAIN",
-        "project.name": project_name,
-        "error.message": error_message,
-        "error.name": error_name,
-    }
-    if error_stack:
-        attrs["error.stack"] = error_stack
-    if error_message:
-        attrs["input.value"] = error_message
-    if user_id:
-        attrs["user.id"] = user_id
-
-    now = str(get_timestamp_ms())
-    span = build_span(
-        f"Error: {error_name or 'unknown'}",
-        "CHAIN",
-        generate_span_id(),
-        trace_id or generate_trace_id(),
-        parent_span_id or "",
-        now,
-        now,
-        attrs,
-        SERVICE_NAME,
-        SCOPE_NAME,
-    )
-    send_span(span)
-
-
-def _handle_session_end(input_json: dict) -> None:
-    """Handle session end: flush pending turn (CLI), log summary, clean up."""
-    state = resolve_session(input_json)
-    session_id = state.get("session_id")
-    if session_id is None:
-        return
-
-    vscode = is_vscode_mode(input_json)
-
-    # CLI mode: flush any pending turn as root span
-    if not vscode:
-        _flush_pending_turn(state)
-
-    reason = input_json.get("reason", "")
-    trace_count = state.get("trace_count") or "0"
-    tool_count = state.get("tool_count") or "0"
-
-    error(f"Session complete: {trace_count} traces, {tool_count} tools (reason={reason})")
-    error(f"View in Arize/Phoenix: session.id = {session_id}")
-
-    # Clean up state file and lock
-    if state.state_file is not None:
-        state.state_file.unlink(missing_ok=True)
-    if state._lock_path is not None:
-        if state._lock_path.is_dir():
-            try:
-                state._lock_path.rmdir()
-            except OSError:
-                pass
-        elif state._lock_path.is_file():
-            try:
-                state._lock_path.unlink(missing_ok=True)
-            except OSError:
-                pass
-
-    gc_stale_state_files()
-
-
 def _handle_subagent_stop(input_json: dict) -> None:
     """Handle subagent_stop: build and send CHAIN span for subagent."""
     state = resolve_session(input_json)
@@ -529,7 +347,6 @@ def _handle_subagent_stop(input_json: dict) -> None:
 
 def session_start():
     """Entry point for arize-hook-copilot-session-start."""
-    input_json = {}
     try:
         input_json = _read_stdin("session_start")
         if check_requirements():
@@ -537,12 +354,11 @@ def session_start():
     except Exception as e:
         error(f"copilot session_start hook failed: {e}")
     finally:
-        _print_response(input_json, "SessionStart")
+        _print_response("SessionStart")
 
 
 def user_prompt_submitted():
     """Entry point for arize-hook-copilot-user-prompt."""
-    input_json = {}
     try:
         input_json = _read_stdin("user_prompt_submitted")
         if check_requirements():
@@ -550,12 +366,11 @@ def user_prompt_submitted():
     except Exception as e:
         error(f"copilot user_prompt_submitted hook failed: {e}")
     finally:
-        _print_response(input_json, "UserPromptSubmit")
+        _print_response("UserPromptSubmit")
 
 
 def pre_tool_use():
     """Entry point for arize-hook-copilot-pre-tool."""
-    input_json = {}
     try:
         input_json = _read_stdin("pre_tool_use")
         if check_requirements():
@@ -563,12 +378,11 @@ def pre_tool_use():
     except Exception as e:
         error(f"copilot pre_tool_use hook failed: {e}")
     finally:
-        _print_response(input_json, "PreToolUse")
+        _print_response("PreToolUse")
 
 
 def post_tool_use():
     """Entry point for arize-hook-copilot-post-tool."""
-    input_json = {}
     try:
         input_json = _read_stdin("post_tool_use")
         if check_requirements():
@@ -576,12 +390,11 @@ def post_tool_use():
     except Exception as e:
         error(f"copilot post_tool_use hook failed: {e}")
     finally:
-        _print_response(input_json, "PostToolUse")
+        _print_response("PostToolUse")
 
 
 def stop():
     """Entry point for arize-hook-copilot-stop."""
-    input_json = {}
     try:
         input_json = _read_stdin("stop")
         if check_requirements():
@@ -589,38 +402,11 @@ def stop():
     except Exception as e:
         error(f"copilot stop hook failed: {e}")
     finally:
-        _print_response(input_json, "Stop")
-
-
-def error_occurred():
-    """Entry point for arize-hook-copilot-error."""
-    input_json = {}
-    try:
-        input_json = _read_stdin("error_occurred")
-        if check_requirements():
-            _handle_error_occurred(input_json)
-    except Exception as e:
-        error(f"copilot error_occurred hook failed: {e}")
-    finally:
-        _print_response(input_json, "ErrorOccurred")
-
-
-def session_end():
-    """Entry point for arize-hook-copilot-session-end."""
-    input_json = {}
-    try:
-        input_json = _read_stdin("session_end")
-        if check_requirements():
-            _handle_session_end(input_json)
-    except Exception as e:
-        error(f"copilot session_end hook failed: {e}")
-    finally:
-        _print_response(input_json, "SessionEnd")
+        _print_response("Stop")
 
 
 def subagent_stop():
     """Entry point for arize-hook-copilot-subagent-stop."""
-    input_json = {}
     try:
         input_json = _read_stdin("subagent_stop")
         if check_requirements():
@@ -628,4 +414,4 @@ def subagent_stop():
     except Exception as e:
         error(f"copilot subagent_stop hook failed: {e}")
     finally:
-        _print_response(input_json, "SubagentStop")
+        _print_response("SubagentStop")

--- a/tracing/copilot/hooks/handlers.py
+++ b/tracing/copilot/hooks/handlers.py
@@ -6,7 +6,6 @@ and delegates to the corresponding _handle_* implementation.
 """
 import json
 import sys
-from pathlib import Path
 
 from core.common import (
     StateManager,
@@ -30,6 +29,7 @@ from tracing.copilot.hooks.adapter import (
     is_vscode_mode,
     resolve_session,
 )
+from tracing.copilot.hooks.transcript import parse_transcript
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -311,7 +311,7 @@ def _handle_post_tool_use(input_json: dict) -> None:
 
 
 def _handle_stop(input_json: dict) -> None:
-    """Handle stop: VS Code only. Parse transcript and send LLM span for the completed turn."""
+    """Handle stop: parse transcript and send LLM span for the completed turn."""
     state = resolve_session(input_json)
     session_id = state.get("session_id")
     trace_id = state.get("current_trace_id")
@@ -322,107 +322,59 @@ def _handle_stop(input_json: dict) -> None:
     trace_start_time = state.get("current_trace_start_time") or str(get_timestamp_ms())
     user_prompt = state.get("current_trace_prompt") or ""
     project_name = state.get("project_name") or ""
-    trace_count = state.get("trace_count") or "0"
     user_id = state.get("user_id") or ""
 
-    # Parse transcript
     transcript_path = input_json.get("transcript_path", "")
-    output = ""
-    model = ""
-    in_tokens = 0
-    out_tokens = 0
+    summary = parse_transcript(transcript_path) if transcript_path else {}
 
-    if transcript_path and Path(transcript_path).is_file():
-        start_line = int(state.get("trace_start_line") or "0")
-        with open(transcript_path) as f:
-            for i, line in enumerate(f):
-                if i < start_line:
-                    continue
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if entry.get("message", {}).get("role") != "assistant":
-                    continue
-                # Extract text from message.content
-                content = entry.get("message", {}).get("content")
-                if isinstance(content, list):
-                    text = "\n".join(
-                        item.get("text", "")
-                        for item in content
-                        if isinstance(item, dict) and item.get("type") == "text"
-                    )
-                elif isinstance(content, str):
-                    text = content
-                else:
-                    text = ""
-                if text:
-                    output = f"{output}\n{text}" if output else text
-                # Extract model
-                model = entry.get("message", {}).get("model", "") or model
-                # Accumulate tokens
-                usage = entry.get("message", {}).get("usage", {})
-                for key in ("input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"):
-                    val = usage.get(key, 0)
-                    if isinstance(val, int):
-                        in_tokens += val
-                val = usage.get("output_tokens", 0)
-                if isinstance(val, int):
-                    out_tokens += val
+    model_name = summary.get("model_name", "")
+    # TODO(transcript): extract assistant turn text once events.jsonl assistant
+    # event shape is captured. Until then, output_text is empty.
+    output_text = summary.get("output_text", "")
+    tool_count = state.get("tool_count") or "0"
 
-    output = output or "(No response)"
-    total_tokens = in_tokens + out_tokens
+    end_time = str(get_timestamp_ms())
 
-    # Build and send LLM span. Redact at emit time, not at state-write time.
-    redacted_prompt = redact_content(env.log_prompts, user_prompt)
-    redacted_output = redact_content(env.log_prompts, output)
-    output_messages = [{"message.role": "assistant", "message.content": redacted_output}]
+    user_prompt = redact_content(env.log_prompts, user_prompt)
+    output_text = redact_content(env.log_tool_content, output_text)
+
     attrs = {
         "session.id": session_id,
-        "trace.number": trace_count,
-        "project.name": project_name,
         "openinference.span.kind": "LLM",
-        "llm.model_name": model,
-        "llm.token_count.prompt": in_tokens,
-        "llm.token_count.completion": out_tokens,
-        "llm.token_count.total": total_tokens,
-        "input.value": redacted_prompt,
-        "output.value": redacted_output,
-        "llm.output_messages": json.dumps(output_messages),
+        "project.name": project_name,
+        "input.value": user_prompt,
+        "output.value": output_text,
+        "metadata": json.dumps(
+            {
+                "stop_reason": input_json.get("stop_reason", ""),
+                "tool_count": int(tool_count or 0),
+            }
+        ),
     }
+    if model_name:
+        attrs["llm.model_name"] = model_name
     if user_id:
         attrs["user.id"] = user_id
 
     span = build_span(
-        f"Turn {trace_count}",
+        "Agent Stop",
         "LLM",
         trace_span_id,
         trace_id,
         "",
         trace_start_time,
-        str(get_timestamp_ms()),
+        end_time,
         attrs,
         SERVICE_NAME,
         SCOPE_NAME,
     )
     send_span(span)
 
-    # Clean up state
+    # Clear per-turn state so the next user prompt starts a fresh trace
     state.delete("current_trace_id")
     state.delete("current_trace_span_id")
     state.delete("current_trace_start_time")
     state.delete("current_trace_prompt")
-
-    # Periodic GC
-    try:
-        tc = int(trace_count or "0")
-    except (ValueError, TypeError):
-        tc = 0
-    if tc % 5 == 0:
-        gc_stale_state_files()
 
 
 def _handle_error_occurred(input_json: dict) -> None:
@@ -525,101 +477,43 @@ def _handle_session_end(input_json: dict) -> None:
 
 
 def _handle_subagent_stop(input_json: dict) -> None:
-    """Handle subagent_stop: VS Code only. Build and send LLM span for subagent."""
+    """Handle subagent_stop: build and send CHAIN span for subagent."""
     state = resolve_session(input_json)
-    trace_id = state.get("current_trace_id")
-    if trace_id is None:
+    session_id = state.get("session_id")
+    if session_id is None:
         return
 
-    session_id = state.get("session_id")
     agent_id = input_json.get("agent_id", "")
     agent_type = input_json.get("agent_type", "")
+    transcript_path = input_json.get("transcript_path", "")
 
-    if not agent_type or agent_type in ("unknown", "null"):
-        return
-
-    span_id = generate_span_id()
-    end_time = str(get_timestamp_ms())
-    parent = state.get("current_trace_span_id")
-
-    # Parse subagent transcript
-    output = ""
-    model = ""
-    in_tokens = 0
-    out_tokens = 0
-    start_time = end_time
-
-    transcript_path = input_json.get("transcript_path", "") or input_json.get("agent_transcript_path", "")
-    if transcript_path and Path(transcript_path).is_file():
-        p = Path(transcript_path)
-        st = p.stat()
-        # st_birthtime is macOS/BSD only; fall back to ctime elsewhere.
-        birth = getattr(st, "st_birthtime", st.st_ctime)
-        start_ms = int(birth * 1000)
-        start_time = str(start_ms)
-
-        with open(transcript_path) as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if entry.get("message", {}).get("role") != "assistant":
-                    continue
-                content = entry.get("message", {}).get("content")
-                if isinstance(content, list):
-                    text = "\n".join(
-                        item.get("text", "")
-                        for item in content
-                        if isinstance(item, dict) and item.get("type") == "text"
-                    )
-                elif isinstance(content, str):
-                    text = content
-                else:
-                    text = ""
-                if text:
-                    output = f"{output}\n{text}" if output else text
-                model = entry.get("message", {}).get("model", "") or model
-                usage = entry.get("message", {}).get("usage", {})
-                for key in ("input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"):
-                    val = usage.get(key, 0)
-                    if isinstance(val, int):
-                        in_tokens += val
-                val = usage.get("output_tokens", 0)
-                if isinstance(val, int):
-                    out_tokens += val
-
-    total_tokens = in_tokens + out_tokens
+    summary = parse_transcript(transcript_path) if transcript_path else {}
+    model_name = summary.get("model_name", "")
 
     project_name = state.get("project_name") or ""
+    user_id = state.get("user_id") or ""
+    end_time = str(get_timestamp_ms())
+
     attrs = {
         "session.id": session_id,
-        "openinference.span.kind": "LLM",
+        "openinference.span.kind": "CHAIN",
         "project.name": project_name,
-        "copilot.agent.type": agent_type,
-        "subagent.id": agent_id,
-        "subagent.type": agent_type,
-        "llm.model_name": model,
-        "llm.token_count.prompt": in_tokens,
-        "llm.token_count.completion": out_tokens,
-        "llm.token_count.total": total_tokens,
+        "metadata": json.dumps({"agent_type": agent_type, "agent_id": agent_id}),
     }
-    if output:
-        attrs["output.value"] = output
-    user_id = state.get("user_id") or ""
+    if model_name:
+        attrs["llm.model_name"] = model_name
     if user_id:
         attrs["user.id"] = user_id
 
+    span_name = f"Subagent: {agent_id}" if agent_id else "Subagent"
+
     span = build_span(
-        f"Subagent: {agent_type}",
-        "LLM",
-        span_id,
-        trace_id,
-        parent or "",
-        start_time,
+        span_name,
+        "CHAIN",
+        generate_span_id(),
+        state.get("current_trace_id") or generate_trace_id(),
+        state.get("current_trace_span_id") or "",
+        end_time,
         end_time,
         attrs,
         SERVICE_NAME,

--- a/tracing/copilot/hooks/handlers.py
+++ b/tracing/copilot/hooks/handlers.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 """Copilot hook handlers. One exported function per hook event.
 
-Supports dual-mode operation:
-- VS Code Copilot: sessionId-based, full event set (8 events)
-- Copilot CLI: PID-based sessions, minimal event set (6 events)
-
-Each entry point reads stdin JSON, detects mode, and adapts behavior accordingly.
+Each entry point reads stdin JSON (snake_case schema), resolves session state,
+and delegates to the corresponding _handle_* implementation.
 """
 import json
 import sys
@@ -166,83 +163,35 @@ def _handle_session_start(input_json: dict) -> None:
     """Handle session start: initialize session."""
     state = resolve_session(input_json)
     ensure_session_initialized(state, input_json)
+    gc_stale_state_files()
 
     source = input_json.get("source", "")
-    if source:
-        state.set("source", source)
-
-    vscode = is_vscode_mode(input_json)
-    initial_prompt = input_json.get("initialPrompt", "")
-    if initial_prompt and not vscode:
-        # CLI: save as pending turn for deferred sending
-        _save_pending_turn(state, initial_prompt)
-
-    log(f"Session started: {state.get('session_id')} (mode={'vscode' if vscode else 'cli'})")
+    initial_prompt = input_json.get("initial_prompt", "")
+    log(f"copilot session_start: source={source!r} prompt_len={len(initial_prompt)}")
 
 
 def _handle_user_prompt_submitted(input_json: dict) -> None:
-    """Handle user prompt submission."""
+    """Handle user prompt submission: open a fresh trace."""
     state = resolve_session(input_json)
     ensure_session_initialized(state, input_json)
+    session_id = state.get("session_id")
+    if session_id is None:
+        return
 
     prompt = input_json.get("prompt", "") or ""
-    vscode = is_vscode_mode(input_json)
 
-    if vscode:
-        # VS Code mode: set up new trace (close orphaned turn first)
-        prev_trace_id = state.get("current_trace_id")
-        prev_span_id = state.get("current_trace_span_id")
-        if prev_trace_id and prev_span_id:
-            prev_start = state.get("current_trace_start_time") or str(get_timestamp_ms())
-            prev_prompt = state.get("current_trace_prompt") or ""
-            prev_count = state.get("trace_count") or "?"
-            session_id = state.get("session_id") or ""
-            project_name = state.get("project_name") or ""
-            failsafe_attrs = {
-                "session.id": session_id,
-                "openinference.span.kind": "LLM",
-                "project.name": project_name,
-                "input.value": redact_content(env.log_prompts, prev_prompt),
-                "output.value": "(Turn closed by fail-safe: Stop hook did not fire)",
-            }
-            user_id = state.get("user_id") or ""
-            if user_id:
-                failsafe_attrs["user.id"] = user_id
-            failsafe_span = build_span(
-                f"Turn {prev_count}",
-                "LLM",
-                prev_span_id,
-                prev_trace_id,
-                "",
-                prev_start,
-                str(get_timestamp_ms()),
-                failsafe_attrs,
-                SERVICE_NAME,
-                SCOPE_NAME,
-            )
-            send_span(failsafe_span)
-            log(f"Fail-safe: closed orphaned Turn {prev_count}")
+    trace_id = generate_trace_id()
+    span_id = generate_span_id()
+    now_ms = get_timestamp_ms()
 
-        state.increment("trace_count")
-        state.set("current_trace_id", generate_trace_id())
-        state.set("current_trace_span_id", generate_span_id())
-        state.set("current_trace_start_time", str(get_timestamp_ms()))
-        # Store RAW prompt in state; redact only at span build time so the
-        # redaction toggle is read at emit time, not baked into the state file.
-        state.set("current_trace_prompt", prompt)
+    state.set("current_trace_id", trace_id)
+    state.set("current_trace_span_id", span_id)
+    state.set("current_trace_start_time", str(now_ms))
+    state.set("current_trace_prompt", prompt)
+    state.increment("trace_count")
+    state.set("tool_count", "0")
 
-        # Track transcript position
-        transcript = input_json.get("transcript_path", "")
-        if transcript and Path(transcript).is_file():
-            with open(transcript) as f:
-                line_count = sum(1 for _ in f)
-            state.set("trace_start_line", str(line_count))
-        else:
-            state.set("trace_start_line", "0")
-    else:
-        # CLI mode: flush previous pending turn, save new one
-        _flush_pending_turn(state)
-        _save_pending_turn(state, prompt)
+    log(f"copilot user_prompt_submitted: prompt_len={len(prompt)}")
 
 
 def _handle_pre_tool_use(input_json: dict) -> None:

--- a/tracing/copilot/hooks/transcript.py
+++ b/tracing/copilot/hooks/transcript.py
@@ -1,0 +1,87 @@
+"""Parser for Copilot session-state transcript (events.jsonl).
+
+The Stop hook payload supplies `transcript_path` pointing at a JSONL file with
+one event per line. Each line is:
+
+    {"type": "<kind>", "data": {...}, "id": "<uuid>",
+     "timestamp": "<iso>", "parentId": "<uuid|null>"}
+
+We extract the latest model name and a textual summary of the most recent turn
+so the Stop span can carry meaningful `llm.model_name`, `input.value`, and
+`output.value` attributes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def parse_transcript(path: str | Path) -> dict[str, Any]:
+    """Parse the events.jsonl at *path* and return a summary dict.
+
+    Returns a dict with the following keys (all optional — missing keys mean
+    the transcript did not provide that info):
+
+      model_name        -- str: latest model from `session.model_change` or
+                           `session.start`. Defaults to "" when absent.
+      copilot_version   -- str: from `session.start.data.copilotVersion`.
+      input_text        -- str: the most recent user prompt extracted from
+                           `hook.start` events with hookType "userPromptSubmitted".
+      output_text       -- str: best-effort assistant-turn text. Until we
+                           confirm assistant-event types, this is "" — leave
+                           the field present so the caller can branch on it.
+      tool_count        -- int: number of `hook.start` events with hookType
+                           "preToolUse".
+      events_seen       -- int: total parsed events (debug aid).
+
+    On a missing file or unreadable path, returns {} (the caller treats that as
+    "no transcript data" and falls back to state-only attributes).
+    """
+    p = Path(path).expanduser()
+    if not p.is_file():
+        return {}
+
+    summary: dict[str, Any] = {
+        "model_name": "",
+        "copilot_version": "",
+        "input_text": "",
+        "output_text": "",
+        "tool_count": 0,
+        "events_seen": 0,
+    }
+
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                summary["events_seen"] += 1
+                kind = ev.get("type", "")
+                data = ev.get("data") or {}
+
+                if kind == "session.start":
+                    summary["copilot_version"] = data.get("copilotVersion", "") or summary["copilot_version"]
+                elif kind == "session.model_change":
+                    new_model = data.get("newModel", "")
+                    if new_model:
+                        summary["model_name"] = new_model
+                elif kind == "hook.start":
+                    hook_type = data.get("hookType", "")
+                    inp = data.get("input") or {}
+                    if hook_type == "userPromptSubmitted":
+                        prompt = inp.get("prompt", "")
+                        if prompt:
+                            summary["input_text"] = prompt
+                    elif hook_type == "preToolUse":
+                        summary["tool_count"] += 1
+    except OSError:
+        return {}
+
+    return summary

--- a/tracing/copilot/skills/manage-copilot-tracing/SKILL.md
+++ b/tracing/copilot/skills/manage-copilot-tracing/SKILL.md
@@ -1,30 +1,25 @@
 ---
 name: manage-copilot-tracing
-description: Set up and configure Arize tracing for GitHub Copilot sessions (VS Code Copilot and Copilot CLI). Use when users want to set up tracing, configure Arize AX or Phoenix for Copilot, enable/disable tracing, or troubleshoot tracing issues. Triggers on "set up copilot tracing", "configure Arize for Copilot", "configure Phoenix for Copilot", "enable copilot tracing", "setup-copilot-tracing", or any request about connecting GitHub Copilot (VS Code or CLI) to Arize or Phoenix for observability.
+description: Set up and configure Arize tracing for GitHub Copilot sessions. Use when users want to set up tracing, configure Arize AX or Phoenix for Copilot, enable/disable tracing, or troubleshoot tracing issues. Triggers on "set up copilot tracing", "configure Arize for Copilot", "configure Phoenix for Copilot", "enable copilot tracing", "setup-copilot-tracing", or any request about connecting GitHub Copilot to Arize or Phoenix for observability.
 ---
 
 # Setup Copilot Tracing
 
-Configure OpenInference tracing for **GitHub Copilot** sessions (VS Code Copilot and Copilot CLI) to Arize AX (cloud) or Phoenix (self-hosted). Spans are sent directly to the backend from hooks -- no background process or backend-specific dependencies are needed in the user's environment. A single handler auto-detects which platform is calling.
+Configure OpenInference tracing for **GitHub Copilot** in VS Code Copilot. Spans are sent directly to the backend from hooks -- no background process or backend-specific dependencies are needed in the user's environment.
 
 ## How to Use This Skill
 
 **This skill follows a decision tree workflow.** Start by asking the user where they are in the setup process:
 
-1. **Which Copilot platform are they using?**
-   - VS Code Copilot -> Note this for the [Activate Copilot hooks](#activate-copilot-hooks) step
-   - Copilot CLI -> Note this for the [Activate Copilot hooks](#activate-copilot-hooks) step
-   - Both -> Configure both hook registrations in the same step
-
-2. **Do they already have credentials?**
+1. **Do they already have credentials?**
    - Yes -> Jump to [Configure Settings](#configure-settings)
-   - No -> Continue to step 3
+   - No -> Continue to step 2
 
-3. **Which backend do they want to use?**
+2. **Which backend do they want to use?**
    - Phoenix (self-hosted) -> Go to [Set Up Phoenix](#set-up-phoenix)
    - Arize AX (cloud) -> Go to [Set Up Arize AX](#set-up-arize-ax)
 
-4. **Are they troubleshooting?**
+3. **Are they troubleshooting?**
    - Yes -> Jump to [Troubleshoot](#troubleshoot)
 
 **Important:** Only follow the relevant path for the user's needs. Don't go through all sections.
@@ -79,7 +74,7 @@ Walk the user through finding their credentials:
 
 Both `api_key` and `space_id` are required for the shared config.
 
-**No Python dependencies are needed.** Both Phoenix and Arize AX use HTTP/JSON — no additional Python dependencies are needed.
+**No Python dependencies are needed.** Both Phoenix and Arize AX use HTTP/JSON -- no additional Python dependencies are needed.
 
 Then proceed to [Configure Settings](#configure-settings). If the user is on an on-prem instance, remind them to provide their custom endpoint.
 
@@ -89,14 +84,13 @@ Then proceed to [Configure Settings](#configure-settings). If the user is on an 
 
 ### Ask the user for:
 
-1. **Platform**: VS Code Copilot, Copilot CLI, or both
-2. **Backend choice**: Phoenix or Arize AX
-3. **Credentials** (only if no existing config):
+1. **Backend choice**: Phoenix or Arize AX
+2. **Credentials** (only if no existing config):
    - Phoenix: endpoint URL (default: `http://localhost:6006`), optional API key
    - Arize AX: API key and Space ID
-4. **OTLP Endpoint** (Arize AX only, optional): For hosted Arize instances using a custom endpoint. Defaults to `otlp.arize.com:443`.
-5. **Project name** (optional): defaults to `"copilot"`, stored under `harnesses.copilot.project_name`
-6. **User ID** (optional): Set `ARIZE_USER_ID` env var to identify spans by user (useful for teams)
+3. **OTLP Endpoint** (Arize AX only, optional): For hosted Arize instances using a custom endpoint. Defaults to `otlp.arize.com:443`.
+4. **Project name** (optional): defaults to `"copilot"`, stored under `harnesses.copilot.project_name`
+5. **User ID** (optional): Set `ARIZE_USER_ID` env var to identify spans by user (useful for teams)
 
 ### Write the config
 
@@ -127,150 +121,76 @@ harnesses:
 
 If the user has a custom OTLP endpoint, set it in `harnesses.copilot.endpoint`.
 
-### Activate Copilot hooks
+## Activate Copilot hooks
 
-Copilot has two hook registration formats depending on the platform. The handler auto-detects which platform is calling, so both can coexist in the same project.
-
-#### VS Code Copilot
-
-VS Code uses **individual JSON files** in `.github/hooks/`, one per event. Create six files (or merge Arize entries into them if they already exist):
-
-**`.github/hooks/session-start.json`**
-```json
-{
-  "hooks": [
-    {
-      "event": "SessionStart",
-      "command": "~/.arize/harness/venv/bin/arize-hook-copilot-session-start"
-    }
-  ]
-}
-```
-
-Register the remaining five events the same way, each in its own file:
-
-| File | `event` | `command` |
-|------|---------|-----------|
-| `user-prompt.json` | `UserPromptSubmit` | `arize-hook-copilot-user-prompt` |
-| `pre-tool.json` | `PreToolUse` | `arize-hook-copilot-pre-tool` |
-| `post-tool.json` | `PostToolUse` | `arize-hook-copilot-post-tool` |
-| `stop.json` | `Stop` | `arize-hook-copilot-stop` |
-| `subagent-stop.json` | `SubagentStop` | `arize-hook-copilot-subagent-stop` |
-
-All `command` values should be absolute paths to the venv binary (e.g. `~/.arize/harness/venv/bin/arize-hook-copilot-<event>`).
-
-#### Copilot CLI
-
-Copilot CLI uses a **single `.github/hooks/hooks.json`** file with version 1 format. Note the `bash` field (not `command`) and camelCase event names:
+Copilot hooks are registered in a single `.github/hooks/hooks.json` file. Create it (or merge Arize entries into it if it already exists):
 
 ```json
 {
-  "version": 1,
   "hooks": {
-    "sessionStart": [
-      { "bash": "~/.arize/harness/venv/bin/arize-hook-copilot-session-start" }
-    ],
-    "userPromptSubmitted": [
-      { "bash": "~/.arize/harness/venv/bin/arize-hook-copilot-user-prompt" }
-    ],
-    "preToolUse": [
-      { "bash": "~/.arize/harness/venv/bin/arize-hook-copilot-pre-tool" }
-    ],
-    "postToolUse": [
-      { "bash": "~/.arize/harness/venv/bin/arize-hook-copilot-post-tool" }
-    ],
-    "errorOccurred": [
-      { "bash": "~/.arize/harness/venv/bin/arize-hook-copilot-error" }
-    ],
-    "sessionEnd": [
-      { "bash": "~/.arize/harness/venv/bin/arize-hook-copilot-session-end" }
-    ]
+    "SessionStart":      [{"type": "command", "command": "~/.arize/harness/venv/bin/arize-hook-copilot-session-start"}],
+    "UserPromptSubmit":  [{"type": "command", "command": "~/.arize/harness/venv/bin/arize-hook-copilot-user-prompt"}],
+    "PreToolUse":        [{"type": "command", "command": "~/.arize/harness/venv/bin/arize-hook-copilot-pre-tool"}],
+    "PostToolUse":       [{"type": "command", "command": "~/.arize/harness/venv/bin/arize-hook-copilot-post-tool"}],
+    "Stop":              [{"type": "command", "command": "~/.arize/harness/venv/bin/arize-hook-copilot-stop"}],
+    "SubagentStop":      [{"type": "command", "command": "~/.arize/harness/venv/bin/arize-hook-copilot-subagent-stop"}]
   }
 }
 ```
 
-If the user already has a `.github/hooks/hooks.json` with other hooks, merge the Arize entries into the existing arrays for each event.
+All `command` values should be absolute paths to the venv binary (e.g. `~/.arize/harness/venv/bin/arize-hook-copilot-<event>`).
 
-### Validate
+## Validate
 
 1. **Config exists**: Run `cat ~/.arize/harness/config.yaml` to verify the config file exists and has correct backend credentials.
 2. **Phoenix** (if applicable): Run `curl -sf <endpoint>/v1/traces >/dev/null` to check connectivity.
-3. **VS Code hooks active**: Verify `.github/hooks/*.json` files exist in the project root (one per event) and each `command` path is the absolute venv binary path.
-4. **CLI hooks active**: Verify `.github/hooks/hooks.json` exists with `version: 1`, uses the `bash` field, and camelCase event names.
-5. **Quick dry-run test** (optional):
+3. **Hooks active**: Verify `.github/hooks/hooks.json` exists in the project root and each `command` path is the absolute venv binary path.
+4. **Quick dry-run test** (optional):
    ```bash
    echo '{"hookEventName":"PreToolUse","tool_name":"test"}' | ARIZE_DRY_RUN=true arize-hook-copilot-pre-tool
    ```
 
-### Confirm
+## Confirm
 
 Tell the user:
 - Config saved to `~/.arize/harness/config.yaml`
-- Copilot hooks activated via `.github/hooks/` (individual files for VS Code, single `hooks.json` for CLI)
-- Spans are sent directly to the backend from hooks — no background process needed
+- Copilot hooks activated via `.github/hooks/hooks.json`
+- Spans are sent directly to the backend from hooks -- no background process needed
 - After saving, open a new Copilot session and traces will appear in their Phoenix UI or Arize AX dashboard under the project name
 - Mention `ARIZE_DRY_RUN=true` to test without sending data (set as env var before launching Copilot)
 - Mention `ARIZE_VERBOSE=true` for debug output
 - Hook logs are written to `~/.arize/harness/logs/copilot.log`
-- CLI mode is "input-only" -- agent response text and token counts are not exposed by Copilot CLI, so those fields will be absent on CLI spans
 
 ## Hook Events
 
-Copilot fires 6 events in VS Code mode and 6 events in CLI mode from a single handler. The handler auto-detects the platform by checking for VS Code-only base fields (`sessionId`, `hookEventName`).
+Copilot fires 6 hook events. Each event maps to a span:
 
-| VS Code Event | CLI Event | Span Name | Kind | Description |
-|---------------|-----------|-----------|------|-------------|
-| `SessionStart` | `sessionStart` | Session Start | CHAIN | Session initialization |
-| `UserPromptSubmit` | `userPromptSubmitted` | User Prompt | CHAIN | User prompt text; in CLI mode also flushes the previous deferred turn |
-| `PreToolUse` | `preToolUse` | Tool: {name} | TOOL | Tool start; **must print permission response to stdout** |
-| `PostToolUse` | `postToolUse` | Tool: {name} | TOOL | Tool result |
-| `Stop` | -- | Agent Stop | LLM | VS Code only: per-turn completion; parses `transcript_path` for full input/output/tokens |
-| `SubagentStop` | -- | Subagent: {id} | CHAIN | VS Code only: subagent completion |
-| -- | `errorOccurred` | Error | CHAIN | CLI only: error event |
-| -- | `sessionEnd` | Session End | CHAIN | CLI only: session termination; flushes the deferred turn |
+| Event | Span Name | Kind | Description |
+|-------|-----------|------|-------------|
+| `SessionStart` | `Session Start` | CHAIN | Session initialization |
+| `UserPromptSubmit` | `User Prompt` | CHAIN | User prompt text |
+| `PreToolUse` | `Tool: {name}` | TOOL | Tool start; **must print permission response to stdout** |
+| `PostToolUse` | `Tool: {name}` | TOOL | Tool result |
+| `Stop` | `Agent Stop` | LLM | Per-turn completion; transcript at `~/.copilot/session-state/<session_id>/events.jsonl` is parsed for model name, prompt, and tool-call count |
+| `SubagentStop` | `Subagent: {id}` | CHAIN | Subagent completion |
 
-**Key mode differences:**
-- **VS Code mode** receives `sessionId` and a `transcript_path` at `Stop`, enabling full input/output/token extraction.
-- **CLI mode** has no transcript access -- turns are deferred and flushed at the next `userPromptSubmitted` or `sessionEnd` with input only (no agent output, no tokens, no model name).
+### PreToolUse permission response
 
-### `PreToolUse` / `preToolUse` permission response
+The pre-tool handler must print a permission response to stdout:
 
-The pre-tool handler must print a permission response to stdout. The format differs by mode:
+```json
+{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}
+```
 
-- **VS Code**: `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}`
-- **CLI**: `{"permissionDecision": "allow"}`
-
-All other handlers print `{"continue": true}` in VS Code mode and nothing in CLI mode.
+All other handlers print `{"continue": true}`.
 
 ## Troubleshoot
-
-Common issues and fixes, split by platform:
-
-### VS Code Copilot
 
 | Problem | Fix |
 |---------|-----|
 | Traces not appearing | Verify config exists: `cat ~/.arize/harness/config.yaml`. Check hook log: `tail -20 ~/.arize/harness/logs/copilot.log` |
-| Spans missing output/tokens | Verify `.github/hooks/stop.json` is registered and `transcript_path` appears in the payload -- transcript parsing is required for full I/O capture |
-| Hooks not firing | Verify each `.github/hooks/*.json` file exists in the project root and `command` uses the absolute venv binary path |
+| Hooks not firing | Verify `.github/hooks/hooks.json` exists in the project root and each `command` path is the absolute venv binary path |
 | `PreToolUse` blocking tools | Check the handler prints the correct permission JSON. Test: `echo '{"hookEventName":"PreToolUse","tool_name":"test"}' \| arize-hook-copilot-pre-tool` |
-| Subagent spans missing | `SubagentStop` is VS Code only -- verify `.github/hooks/subagent-stop.json` is registered |
-
-### Copilot CLI
-
-| Problem | Fix |
-|---------|-----|
-| Traces not appearing | Verify `.github/hooks/hooks.json` exists with `version: 1`. Check hook log: `tail -20 ~/.arize/harness/logs/copilot.log` |
-| No output on spans | Expected -- Copilot CLI does not expose agent responses, so CLI spans have input only |
-| No token counts | Expected -- CLI payloads do not include model name or token usage |
-| Hooks not firing | Verify `.github/hooks/hooks.json` uses the `bash` field (not `command`) and camelCase event names |
-| `preToolUse` blocking tools | Check the handler prints `{"permissionDecision": "allow"}`. Test: `echo '{"toolName":"test","toolArgs":"{}"}' \| arize-hook-copilot-pre-tool` |
-| Deferred turns not flushing | Turns flush at the next `userPromptSubmitted` or `sessionEnd`. If the CLI exits abnormally, the last turn may be lost |
-
-### General
-
-| Problem | Fix |
-|---------|-----|
 | Config missing | Run the installer or create `~/.arize/harness/config.yaml` manually (include `harnesses.copilot` section) |
 | Phoenix unreachable | Verify Phoenix is running: `curl -sf <endpoint>/v1/traces` |
 | Want to test without sending | Set `ARIZE_DRY_RUN=true` env var before launching Copilot |


### PR DESCRIPTION
## Summary

The Copilot harness was producing empty TOOL spans (`name="unknown"`, empty input/output) because the handlers assumed a dual-mode payload schema (VS Code camelCase vs. CLI camelCase) that does not exist. Verified against live `gh copilot` v1.0.40 stdin captures, the real schema is **single-mode snake_case** for both VS Code Copilot Chat and the CLI.

This branch drops the dual-mode fiction, reads the verified schema, parses the Stop transcript at `~/.copilot/session-state/<session_id>/events.jsonl` for model name and turn metadata, and removes dead code paths for events Copilot does not actually emit.

Implemented per [.workbench/fix-copilot-payload-schema.md](.workbench/fix-copilot-payload-schema.md) across 13 commits in five waves.

### Schema (verified)

All events: `cwd`, `hook_event_name`, `session_id` (UUID with dashes), `timestamp` (ISO 8601). Per-event additions:
- `SessionStart`: `initial_prompt`, `source`
- `UserPromptSubmit`: `prompt`
- `PreToolUse` / `PostToolUse`: `tool_name`, `tool_input` (object), and on Post: `tool_result.{result_type, text_result_for_llm}`
- `Stop`: `stop_reason`, `transcript_path`

### Changes

- **Adapter** ([tracing/copilot/hooks/adapter.py](tracing/copilot/hooks/adapter.py)): `resolve_session` reads `session_id` from the payload directly; PID fallback only when malformed. `is_vscode_mode` removed.
- **Handlers** ([tracing/copilot/hooks/handlers.py](tracing/copilot/hooks/handlers.py)): single-mode reads throughout; `_handle_post_tool_use` pulls output from `tool_result.text_result_for_llm`; `_handle_stop` uses the new transcript parser. Dead `_handle_error_occurred`, `_handle_session_end`, and pending-turn helpers removed.
- **Transcript parser** ([tracing/copilot/hooks/transcript.py](tracing/copilot/hooks/transcript.py)): new module that parses `events.jsonl` for model name, prompt, and tool-call count.
- **pyproject.toml**: drops `arize-hook-copilot-error` and `arize-hook-copilot-session-end` entry points.
- **SKILL.md**: rewritten to single-mode; matching test assertions updated.
- **Tests**: `test_copilot_transcript.py` added (parser coverage); `test_copilot_hook.py`, `test_copilot_adapter.py`, `test_copilot_install.py`, `test_wire_entry_points.py`, `test_copilot_readme_and_skill.py` updated to the snake_case schema.

## Test plan

- [ ] `python -m pytest tests/ -q` — full suite passes
- [ ] `python -m pip install -e . && ls ~/.arize/harness/venv/bin/arize-hook-copilot-*` — exactly six entry points (no `-error`, no `-session-end`)
- [ ] Trigger a `gh copilot` session with `ARIZE_TRACE_DEBUG=true ARIZE_VERBOSE=true`; confirm `~/.arize/harness/state/debug/copilot_*.yaml` shows snake_case payloads and that the resulting spans in Arize/Phoenix carry non-empty `tool.name`, `input.value`, `output.value`, and `tool.result_type` attributes
- [ ] Confirm the Stop span carries `llm.model_name` (e.g. `gpt-5-mini`) when a `transcript_path` is supplied

🤖 Generated with [Claude Code](https://claude.com/claude-code)