### PR TITLE
Kiro vscode integration

### DIFF
--- a/core/vscode_bridge/cli.py
+++ b/core/vscode_bridge/cli.py
@@ -60,6 +60,17 @@ def _build_parser() -> argparse.ArgumentParser:
     install_p.add_argument("--log-prompts", choices=("true", "false"), default=None, help="Log prompts")
     install_p.add_argument("--log-tool-details", choices=("true", "false"), default=None, help="Log tool details")
     install_p.add_argument("--log-tool-content", choices=("true", "false"), default=None, help="Log tool content")
+    install_p.add_argument(
+        "--agent-name",
+        default=None,
+        help="Kiro: agent name to install hooks into (default arize-traced)",
+    )
+    install_p.add_argument(
+        "--set-default",
+        action="store_true",
+        default=False,
+        help="Kiro: set the chosen agent as Kiro's default after install",
+    )
 
     # uninstall
     uninstall_p = sub.add_parser("uninstall", help="Uninstall tracing for a harness")
@@ -121,6 +132,15 @@ def _run_install(args: argparse.Namespace) -> int:
         )
         return _drain_logs_and_emit(result)
 
+    kiro_options = None
+    if args.harness == "kiro" and (args.agent_name or args.set_default):
+        from core.vscode_bridge.models import build_kiro_options
+
+        kiro_options = build_kiro_options(
+            agent_name=args.agent_name or "arize-traced",
+            set_default=args.set_default,
+        )
+
     request = build_install_request(
         harness=args.harness,
         backend=backend,
@@ -128,6 +148,7 @@ def _run_install(args: argparse.Namespace) -> int:
         user_id=args.user_id,
         with_skills=args.with_skills,
         logging=_build_logging_block(args),
+        kiro_options=kiro_options,
     )
     result = install(request)
     return _drain_logs_and_emit(result)

--- a/core/vscode_bridge/install.py
+++ b/core/vscode_bridge/install.py
@@ -16,6 +16,7 @@ _HARNESS_MODULES = {
     "cursor": "tracing.cursor.install",
     "copilot": "tracing.copilot.install",
     "gemini": "tracing.gemini.install",
+    "kiro": "tracing.kiro.install",
 }
 
 
@@ -72,6 +73,11 @@ def install(request: Dict[str, Any]) -> Dict[str, Any]:
     # Build logging block if provided.
     logging_block = request.get("logging")
 
+    extra_kwargs: Dict[str, Any] = {}
+    if harness == "kiro" and request.get("kiro_options"):
+        extra_kwargs["agent_name"] = request["kiro_options"]["agent_name"]
+        extra_kwargs["set_default"] = request["kiro_options"]["set_default"]
+
     try:
         mod = _import_installer(harness)
         logs = _capture_output(
@@ -82,6 +88,7 @@ def install(request: Dict[str, Any]) -> Dict[str, Any]:
             user_id=request.get("user_id") or "",
             with_skills=request.get("with_skills", False),
             logging_block=logging_block,
+            **extra_kwargs,
         )
     except Exception:
         tb = traceback.format_exc()

--- a/core/vscode_bridge/models.py
+++ b/core/vscode_bridge/models.py
@@ -21,6 +21,7 @@ HarnessStatusItem = {
     "project_name": str | None,
     "backend": Backend | None,
     "scope": str | None,           # currently always None; reserved
+    "kiro_options": {"agent_name": str, "set_default": bool} | None,
 }
 
 StatusPayload = {
@@ -39,6 +40,7 @@ InstallRequest = {
     "user_id": str | None,
     "with_skills": bool,
     "logging": {"prompts": bool, "tool_details": bool, "tool_content": bool} | None,
+    "kiro_options": {"agent_name": str, "set_default": bool} | None,
 }
 
 OperationResult = {
@@ -64,7 +66,7 @@ from typing import Any, Dict, List, Optional
 
 # ---- constants ----
 
-HARNESS_KEYS = ("claude-code", "codex", "cursor", "copilot", "gemini")
+HARNESS_KEYS = ("claude-code", "codex", "cursor", "copilot", "gemini", "kiro")
 
 _VALID_TARGETS = ("arize", "phoenix")
 _VALID_CODEX_STATES = ("running", "stopped", "stale", "unknown")
@@ -135,21 +137,50 @@ def build_backend(
     }
 
 
+def build_kiro_options(
+    agent_name: str,
+    set_default: bool = False,
+) -> Dict[str, Any]:
+    """Build a KiroOptions dict.
+
+    Shape:
+      { "agent_name": str, "set_default": bool }
+
+    agent_name must be a non-empty string. Allowed character set is enforced
+    by tracing.kiro.install at write-time, NOT here — this builder only checks
+    non-emptiness so we don't double-validate.
+    """
+    _require_str(agent_name, "agent_name")
+    return {
+        "agent_name": agent_name,
+        "set_default": bool(set_default),
+    }
+
+
 def build_harness_status_item(
     name: str,
     configured: bool = False,
     project_name: Optional[str] = None,
     backend: Optional[Dict[str, Any]] = None,
     scope: Optional[str] = None,
+    kiro_options: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build a HarnessStatusItem dict."""
     _validate_harness(name)
+    if kiro_options is not None and name != "kiro":
+        raise ValueError("kiro_options only valid when harness is 'kiro'")
+    if kiro_options is not None:
+        kiro_options = build_kiro_options(
+            kiro_options.get("agent_name", ""),
+            kiro_options.get("set_default", False),
+        )
     return {
         "name": name,
         "configured": bool(configured),
         "project_name": project_name,
         "backend": backend,
         "scope": scope,
+        "kiro_options": kiro_options,
     }
 
 
@@ -163,7 +194,8 @@ def build_status(
 ) -> Dict[str, Any]:
     """Build a StatusPayload dict.
 
-    *harnesses* defaults to all five harnesses unconfigured when omitted.
+    *harnesses* defaults to all harnesses in :data:`HARNESS_KEYS` unconfigured
+    when omitted.
     """
     if harnesses is None:
         harnesses = [build_harness_status_item(name=k) for k in HARNESS_KEYS]
@@ -184,10 +216,18 @@ def build_install_request(
     user_id: Optional[str] = None,
     with_skills: bool = False,
     logging: Optional[Dict[str, bool]] = None,
+    kiro_options: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build an InstallRequest dict."""
     _validate_harness(harness)
     _require_str(project_name, "project_name")
+    if kiro_options is not None and harness != "kiro":
+        raise ValueError("kiro_options only valid when harness is 'kiro'")
+    if kiro_options is not None:
+        kiro_options = build_kiro_options(
+            kiro_options.get("agent_name", ""),
+            kiro_options.get("set_default", False),
+        )
     return {
         "harness": harness,
         "backend": backend,
@@ -195,6 +235,7 @@ def build_install_request(
         "user_id": user_id,
         "with_skills": bool(with_skills),
         "logging": _normalize_logging(logging),
+        "kiro_options": kiro_options,
     }
 
 

--- a/core/vscode_bridge/status.py
+++ b/core/vscode_bridge/status.py
@@ -11,7 +11,13 @@ from typing import Any, Dict, Optional
 
 from core.config import load_config
 from core.constants import CONFIG_FILE
-from core.vscode_bridge.models import HARNESS_KEYS, build_backend, build_harness_status_item, build_status
+from core.vscode_bridge.models import (
+    HARNESS_KEYS,
+    build_backend,
+    build_harness_status_item,
+    build_kiro_options,
+    build_status,
+)
 
 
 def _extract_backend(entry: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -38,11 +44,21 @@ def _extract_harness_item(name: str, entry: Any) -> Dict[str, Any]:
     if not isinstance(entry, dict):
         return build_harness_status_item(name=name)
 
+    kiro_options = None
+    if name == "kiro":
+        agent_name = entry.get("agent_name")
+        if isinstance(agent_name, str) and agent_name:
+            kiro_options = build_kiro_options(
+                agent_name=agent_name,
+                set_default=False,
+            )
+
     return build_harness_status_item(
         name=name,
         configured=True,
         project_name=entry.get("project_name"),
         backend=_extract_backend(entry),
+        kiro_options=kiro_options,
     )
 
 

--- a/tests/test_kiro_install_noninteractive.py
+++ b/tests/test_kiro_install_noninteractive.py
@@ -78,7 +78,6 @@ def kiro_env(tmp_path, monkeypatch):
 
     # Also patch install module bindings
     monkeypatch.setattr(inst, "INSTALL_DIR", harness_dir)
-    monkeypatch.setattr(inst, "CONFIG_FILE", harness_dir / "config.yaml")
 
     # Patch CONFIG_FILE in core.config so load_config/save_config use temp path
     import core.config as config_mod

--- a/tests/test_kiro_install_noninteractive.py
+++ b/tests/test_kiro_install_noninteractive.py
@@ -1,0 +1,299 @@
+"""Tests for tracing.kiro.install.install_noninteractive / uninstall_noninteractive."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from tracing.kiro.constants import HOOK_EVENTS  # noqa: E402
+
+FAKE_VENV_BIN = Path("/fake/venv/bin/arize-hook-kiro")
+HOOK_CMD = str(FAKE_VENV_BIN)
+FAKE_KIRO_CLI = "/fake/bin/kiro-cli"
+
+PHOENIX_CREDS = {"endpoint": "http://x", "api_key": ""}
+
+
+def _fail_if_called(*args, **kwargs):
+    raise AssertionError("Interactive prompt was called in noninteractive path")
+
+
+@pytest.fixture(autouse=True)
+def _block_interactive(monkeypatch):
+    """Noninteractive path must never reach a prompt."""
+    monkeypatch.setattr("builtins.input", _fail_if_called)
+    monkeypatch.setattr("getpass.getpass", _fail_if_called)
+
+
+@pytest.fixture(autouse=True)
+def _fake_stdout(monkeypatch):
+    """Suppress TTY detection so info() doesn't emit ANSI codes."""
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+
+
+@pytest.fixture(autouse=True)
+def _mock_venv_bin(monkeypatch):
+    monkeypatch.setattr("tracing.kiro.install.venv_bin", lambda name: FAKE_VENV_BIN)
+
+
+@pytest.fixture(autouse=True)
+def _no_dry_run(monkeypatch):
+    monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
+
+
+@pytest.fixture()
+def kiro_env(tmp_path, monkeypatch):
+    """Isolated environment: ~/.kiro/agents and ~/.arize/harness/ in tmp_path,
+    with a fake kiro-cli resolvable on PATH and patched subprocess.run."""
+    home = tmp_path / "home"
+    home.mkdir()
+    kiro_agents_dir = home / ".kiro" / "agents"
+    kiro_agents_dir.mkdir(parents=True)
+    harness_dir = home / ".arize" / "harness"
+    harness_dir.mkdir(parents=True)
+
+    # Redirect KIRO_AGENTS_DIR inside install module
+    import tracing.kiro.install as inst
+
+    monkeypatch.setattr(inst, "KIRO_AGENTS_DIR", kiro_agents_dir)
+
+    # Patch core.setup paths
+    import core.setup as setup
+
+    monkeypatch.setattr(setup, "INSTALL_DIR", harness_dir)
+    monkeypatch.setattr(setup, "CONFIG_FILE", harness_dir / "config.yaml")
+    monkeypatch.setattr(setup, "VENV_DIR", harness_dir / "venv")
+    monkeypatch.setattr(setup, "BIN_DIR", harness_dir / "bin")
+    monkeypatch.setattr(setup, "RUN_DIR", harness_dir / "run")
+    monkeypatch.setattr(setup, "LOG_DIR", harness_dir / "logs")
+    monkeypatch.setattr(setup, "STATE_DIR", harness_dir / "state")
+
+    # Also patch install module bindings
+    monkeypatch.setattr(inst, "INSTALL_DIR", harness_dir)
+    monkeypatch.setattr(inst, "CONFIG_FILE", harness_dir / "config.yaml")
+
+    # Patch CONFIG_FILE in core.config so load_config/save_config use temp path
+    import core.config as config_mod
+
+    monkeypatch.setattr(config_mod, "CONFIG_FILE", str(harness_dir / "config.yaml"))
+
+    # Default: kiro-cli is on PATH
+    monkeypatch.setattr(inst.shutil, "which", lambda name: FAKE_KIRO_CLI if name == "kiro-cli" else None)
+    monkeypatch.setattr(inst, "_macos_app_kiro_path", lambda: None)
+
+    # Default: subprocess.run is a no-op success
+    subproc = mock.MagicMock(return_value=mock.MagicMock(returncode=0, stderr="", stdout=""))
+    monkeypatch.setattr(inst.subprocess, "run", subproc)
+
+    return {
+        "home": home,
+        "agents_dir": kiro_agents_dir,
+        "harness_dir": harness_dir,
+        "config_file": harness_dir / "config.yaml",
+        "subprocess_run": subproc,
+    }
+
+
+def _load_config(harness_dir: Path) -> dict:
+    config_path = harness_dir / "config.yaml"
+    if not config_path.exists():
+        return {}
+    with open(config_path) as f:
+        return yaml.safe_load(f) or {}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_install_noninteractive_writes_agent_file_with_hooks(kiro_env):
+    from tracing.kiro.install import install_noninteractive
+
+    install_noninteractive(
+        target="phoenix",
+        credentials=PHOENIX_CREDS,
+        project_name="proj",
+        agent_name="my-agent",
+    )
+
+    agent_path = kiro_env["agents_dir"] / "my-agent.json"
+    assert agent_path.exists()
+    data = json.loads(agent_path.read_text())
+    assert isinstance(data["hooks"], dict)
+    assert set(data["hooks"].keys()) == set(HOOK_EVENTS)
+    for event in HOOK_EVENTS:
+        entries = data["hooks"][event]
+        assert len(entries) == 1
+        assert entries[0]["command"] == HOOK_CMD
+
+
+def test_install_noninteractive_defaults_agent_name(kiro_env):
+    from tracing.kiro.install import install_noninteractive
+
+    install_noninteractive(
+        target="phoenix",
+        credentials=PHOENIX_CREDS,
+        project_name="proj",
+    )
+
+    agent_path = kiro_env["agents_dir"] / "arize-traced.json"
+    assert agent_path.exists()
+    data = json.loads(agent_path.read_text())
+    assert set(data["hooks"].keys()) == set(HOOK_EVENTS)
+
+
+def test_install_noninteractive_persists_agent_name_in_config(kiro_env):
+    from tracing.kiro.install import install_noninteractive
+
+    install_noninteractive(
+        target="phoenix",
+        credentials=PHOENIX_CREDS,
+        project_name="proj",
+        agent_name="custom",
+    )
+
+    config = _load_config(kiro_env["harness_dir"])
+    assert config["harnesses"]["kiro"]["agent_name"] == "custom"
+
+
+def test_install_noninteractive_calls_set_default_when_flag_true(kiro_env):
+    from tracing.kiro.install import install_noninteractive
+
+    install_noninteractive(
+        target="phoenix",
+        credentials=PHOENIX_CREDS,
+        project_name="proj",
+        agent_name="chosen",
+        set_default=True,
+    )
+
+    matching = [
+        call
+        for call in kiro_env["subprocess_run"].call_args_list
+        if list(call[0][0]) == [FAKE_KIRO_CLI, "agent", "set-default", "chosen"]
+    ]
+    assert len(matching) == 1
+
+
+def test_install_noninteractive_skips_set_default_when_flag_false(kiro_env):
+    from tracing.kiro.install import install_noninteractive
+
+    install_noninteractive(
+        target="phoenix",
+        credentials=PHOENIX_CREDS,
+        project_name="proj",
+        agent_name="chosen",
+        set_default=False,
+    )
+
+    set_default_calls = [
+        call
+        for call in kiro_env["subprocess_run"].call_args_list
+        if len(call[0]) > 0 and "set-default" in list(call[0][0])
+    ]
+    assert set_default_calls == []
+
+
+def test_install_noninteractive_unregisters_existing_hooks_before_install(kiro_env):
+    from tracing.kiro.install import install_noninteractive
+
+    old_path = kiro_env["agents_dir"] / "old-agent.json"
+    old_path.write_text(
+        json.dumps(
+            {
+                "name": "old-agent",
+                "description": "user-defined",
+                "hooks": {
+                    "stop": [{"command": HOOK_CMD}],
+                },
+            }
+        )
+    )
+
+    install_noninteractive(
+        target="phoenix",
+        credentials=PHOENIX_CREDS,
+        project_name="proj",
+        agent_name="new-agent",
+    )
+
+    new_path = kiro_env["agents_dir"] / "new-agent.json"
+    assert new_path.exists()
+    new_data = json.loads(new_path.read_text())
+    assert set(new_data["hooks"].keys()) == set(HOOK_EVENTS)
+    for event in HOOK_EVENTS:
+        entries = new_data["hooks"][event]
+        assert any(h.get("command") == HOOK_CMD for h in entries)
+
+    # Old agent either gone, or no longer has our hook command.
+    if old_path.exists():
+        old_data = json.loads(old_path.read_text())
+        old_hooks = old_data.get("hooks", {})
+        for event_list in old_hooks.values():
+            for h in event_list:
+                assert h.get("command") != HOOK_CMD
+
+
+def test_install_noninteractive_fails_when_kiro_cli_missing(kiro_env, monkeypatch):
+    import tracing.kiro.install as inst
+
+    monkeypatch.setattr(inst.shutil, "which", lambda name: None)
+    monkeypatch.setattr(inst, "_macos_app_kiro_path", lambda: None)
+
+    from tracing.kiro.install import install_noninteractive
+
+    with pytest.raises(RuntimeError, match="kiro-cli"):
+        install_noninteractive(
+            target="phoenix",
+            credentials=PHOENIX_CREDS,
+            project_name="proj",
+            agent_name="any",
+        )
+
+    agents = list(kiro_env["agents_dir"].iterdir())
+    assert agents == []
+
+
+def test_install_noninteractive_rejects_unsafe_agent_name(kiro_env):
+    from tracing.kiro.install import install_noninteractive
+
+    with pytest.raises(ValueError):
+        install_noninteractive(
+            target="phoenix",
+            credentials=PHOENIX_CREDS,
+            project_name="proj",
+            agent_name="../escape",
+        )
+
+    # No file written outside the agents directory or anywhere under home.
+    home = kiro_env["home"]
+    escapes = list(home.rglob("escape*"))
+    assert escapes == []
+
+
+def test_uninstall_noninteractive_removes_harness_entry(kiro_env):
+    from tracing.kiro.install import install_noninteractive, uninstall_noninteractive
+
+    install_noninteractive(
+        target="phoenix",
+        credentials=PHOENIX_CREDS,
+        project_name="proj",
+        agent_name="my-agent",
+    )
+
+    config = _load_config(kiro_env["harness_dir"])
+    assert "kiro" in config.get("harnesses", {})
+
+    uninstall_noninteractive()
+
+    config = _load_config(kiro_env["harness_dir"])
+    assert "kiro" not in config.get("harnesses", {})

--- a/tests/test_vscode_bridge_cli.py
+++ b/tests/test_vscode_bridge_cli.py
@@ -269,6 +269,126 @@ class TestInstall:
 
 
 # ---------------------------------------------------------------------------
+# Install subcommand — Kiro-specific flags
+# ---------------------------------------------------------------------------
+
+
+class TestInstallKiroFlags:
+    @mock.patch("core.vscode_bridge.install.install")
+    def test_install_kiro_with_agent_name_flag(self, mock_install, monkeypatch):
+        mock_install.return_value = {
+            "success": True,
+            "error": None,
+            "harness": "kiro",
+            "logs": [],
+        }
+        argv = [
+            "install",
+            "--harness",
+            "kiro",
+            "--target",
+            "phoenix",
+            "--endpoint",
+            "http://x",
+            "--api-key",
+            "",
+            "--project-name",
+            "p",
+            "--agent-name",
+            "my-agent",
+        ]
+        code, lines, stderr = _run(argv, monkeypatch)
+        assert code == 0
+        call_args = mock_install.call_args[0][0]
+        assert call_args["kiro_options"] is not None
+        assert call_args["kiro_options"]["agent_name"] == "my-agent"
+        assert call_args["kiro_options"]["set_default"] is False
+
+    @mock.patch("core.vscode_bridge.install.install")
+    def test_install_kiro_with_set_default_flag(self, mock_install, monkeypatch):
+        mock_install.return_value = {
+            "success": True,
+            "error": None,
+            "harness": "kiro",
+            "logs": [],
+        }
+        argv = [
+            "install",
+            "--harness",
+            "kiro",
+            "--target",
+            "phoenix",
+            "--endpoint",
+            "http://x",
+            "--api-key",
+            "",
+            "--project-name",
+            "p",
+            "--set-default",
+        ]
+        code, lines, stderr = _run(argv, monkeypatch)
+        assert code == 0
+        call_args = mock_install.call_args[0][0]
+        assert call_args["kiro_options"] is not None
+        assert call_args["kiro_options"]["set_default"] is True
+        assert call_args["kiro_options"]["agent_name"] == "arize-traced"
+
+    @mock.patch("core.vscode_bridge.install.install")
+    def test_install_kiro_without_flags_omits_options(self, mock_install, monkeypatch):
+        mock_install.return_value = {
+            "success": True,
+            "error": None,
+            "harness": "kiro",
+            "logs": [],
+        }
+        argv = [
+            "install",
+            "--harness",
+            "kiro",
+            "--target",
+            "phoenix",
+            "--endpoint",
+            "http://x",
+            "--api-key",
+            "",
+            "--project-name",
+            "p",
+        ]
+        code, lines, stderr = _run(argv, monkeypatch)
+        assert code == 0
+        call_args = mock_install.call_args[0][0]
+        assert call_args["kiro_options"] is None
+
+    @mock.patch("core.vscode_bridge.install.install")
+    def test_install_non_kiro_ignores_kiro_flags(self, mock_install, monkeypatch):
+        mock_install.return_value = {
+            "success": True,
+            "error": None,
+            "harness": "codex",
+            "logs": [],
+        }
+        argv = [
+            "install",
+            "--harness",
+            "codex",
+            "--target",
+            "phoenix",
+            "--endpoint",
+            "http://x",
+            "--api-key",
+            "",
+            "--project-name",
+            "p",
+            "--agent-name",
+            "my-agent",
+        ]
+        code, lines, stderr = _run(argv, monkeypatch)
+        assert code == 0
+        call_args = mock_install.call_args[0][0]
+        assert call_args["kiro_options"] is None
+
+
+# ---------------------------------------------------------------------------
 # Uninstall subcommand
 # ---------------------------------------------------------------------------
 

--- a/tests/test_vscode_bridge_install.py
+++ b/tests/test_vscode_bridge_install.py
@@ -205,6 +205,71 @@ def test_install_passes_correct_kwargs():
 
 
 # ---------------------------------------------------------------------------
+# Install — kiro_options pass-through
+# ---------------------------------------------------------------------------
+
+
+def test_install_kiro_with_kiro_options_passes_them_through():
+    captured = {}
+
+    def _spy(**kwargs):
+        captured.update(kwargs)
+
+    fake = _fake_module()
+    fake.install_noninteractive = _spy
+
+    req = _base_request(
+        harness="kiro",
+        kiro_options={"agent_name": "custom", "set_default": True},
+    )
+
+    with mock.patch("core.vscode_bridge.install._import_installer", return_value=fake):
+        result = install(req)
+
+    assert result["success"] is True
+    assert captured["agent_name"] == "custom"
+    assert captured["set_default"] is True
+
+
+def test_install_kiro_without_kiro_options_omits_them():
+    captured = {}
+
+    def _spy(**kwargs):
+        captured.update(kwargs)
+
+    fake = _fake_module()
+    fake.install_noninteractive = _spy
+
+    req = _base_request(harness="kiro", kiro_options=None)
+
+    with mock.patch("core.vscode_bridge.install._import_installer", return_value=fake):
+        result = install(req)
+
+    assert result["success"] is True
+    assert "agent_name" not in captured
+    assert "set_default" not in captured
+
+
+def test_install_non_kiro_does_not_receive_kiro_kwargs():
+    captured = {}
+
+    def _spy(**kwargs):
+        captured.update(kwargs)
+
+    fake = _fake_module()
+    fake.install_noninteractive = _spy
+
+    req = _base_request(harness="codex", kiro_options=None)
+
+    with mock.patch("core.vscode_bridge.install._import_installer", return_value=fake):
+        result = install(req)
+
+    assert result["success"] is True
+    assert "agent_name" not in captured
+    assert "set_default" not in captured
+
+
+# ---------------------------------------------------------------------------
 # Uninstall — success per harness
 # ---------------------------------------------------------------------------
 

--- a/tests/test_vscode_bridge_models.py
+++ b/tests/test_vscode_bridge_models.py
@@ -10,6 +10,7 @@ from core.vscode_bridge.models import (
     build_codex_buffer,
     build_harness_status_item,
     build_install_request,
+    build_kiro_options,
     build_operation_result,
     build_status,
 )
@@ -74,6 +75,7 @@ class TestBuildHarnessStatusItem:
             "project_name": None,
             "backend": None,
             "scope": None,
+            "kiro_options": None,
         }
 
     def test_configured(self):
@@ -94,7 +96,29 @@ class TestBuildHarnessStatusItem:
 
     def test_exact_keys(self):
         h = build_harness_status_item("gemini")
-        assert set(h.keys()) == {"name", "configured", "project_name", "backend", "scope"}
+        assert set(h.keys()) == {
+            "name",
+            "configured",
+            "project_name",
+            "backend",
+            "scope",
+            "kiro_options",
+        }
+
+    def test_kiro_options_for_kiro(self):
+        h = build_harness_status_item(
+            "kiro",
+            configured=True,
+            kiro_options=build_kiro_options("my-agent"),
+        )
+        assert h["kiro_options"] == {"agent_name": "my-agent", "set_default": False}
+
+    def test_kiro_options_rejected_for_other_harness(self):
+        with pytest.raises(ValueError, match="kiro_options only valid"):
+            build_harness_status_item(
+                "codex",
+                kiro_options={"agent_name": "x", "set_default": False},
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -108,7 +132,7 @@ class TestBuildStatus:
         assert s["success"] is True
         assert s["error"] is None
         assert s["user_id"] is None
-        assert len(s["harnesses"]) == 5
+        assert len(s["harnesses"]) == 6
         assert s["logging"] is None
         assert s["codex_buffer"] is None
         names = [h["name"] for h in s["harnesses"]]
@@ -166,6 +190,7 @@ class TestBuildInstallRequest:
             "user_id": None,
             "with_skills": False,
             "logging": None,
+            "kiro_options": None,
         }
 
     def test_full(self):
@@ -202,7 +227,35 @@ class TestBuildInstallRequest:
             "user_id",
             "with_skills",
             "logging",
+            "kiro_options",
         }
+
+    def test_kiro_options_for_kiro(self):
+        backend = build_backend("phoenix", "http://localhost:6006")
+        r = build_install_request(
+            "kiro",
+            backend,
+            "proj",
+            kiro_options=build_kiro_options("x", set_default=True),
+        )
+        assert r["kiro_options"] == {"agent_name": "x", "set_default": True}
+
+    def test_kiro_options_rejected_for_other_harness(self):
+        backend = build_backend("phoenix", "http://localhost:6006")
+        with pytest.raises(ValueError, match="kiro_options only valid"):
+            build_install_request(
+                "codex",
+                backend,
+                "proj",
+                kiro_options={"agent_name": "x", "set_default": False},
+            )
+
+    def test_kiro_options_default_none(self):
+        backend = build_backend("phoenix", "http://localhost:6006")
+        for harness in HARNESS_KEYS:
+            r = build_install_request(harness, backend, "proj")
+            assert "kiro_options" in r
+            assert r["kiro_options"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -317,11 +370,44 @@ class TestJsonRoundTrip:
 
 
 class TestHarnessKeys:
-    def test_all_five_present(self):
-        assert len(HARNESS_KEYS) == 5
+    def test_all_six_present(self):
+        assert len(HARNESS_KEYS) == 6
 
     def test_is_tuple(self):
         assert isinstance(HARNESS_KEYS, tuple)
 
     def test_expected_values(self):
-        assert set(HARNESS_KEYS) == {"claude-code", "codex", "cursor", "copilot", "gemini"}
+        assert set(HARNESS_KEYS) == {
+            "claude-code",
+            "codex",
+            "cursor",
+            "copilot",
+            "gemini",
+            "kiro",
+        }
+
+    def test_contains_kiro(self):
+        assert "kiro" in HARNESS_KEYS
+
+
+# ---------------------------------------------------------------------------
+# KiroOptions
+# ---------------------------------------------------------------------------
+
+
+class TestBuildKiroOptions:
+    def test_valid(self):
+        assert build_kiro_options("my-agent", set_default=True) == {
+            "agent_name": "my-agent",
+            "set_default": True,
+        }
+
+    def test_default_set_default(self):
+        assert build_kiro_options("my-agent") == {
+            "agent_name": "my-agent",
+            "set_default": False,
+        }
+
+    def test_rejects_empty_name(self):
+        with pytest.raises(ValueError, match="agent_name"):
+            build_kiro_options("")

--- a/tests/test_vscode_bridge_status.py
+++ b/tests/test_vscode_bridge_status.py
@@ -320,3 +320,68 @@ def test_numeric_user_id(config_dir):
     _write_yaml(config_dir, {"user_id": 12345})
     result = load_status()
     assert result["user_id"] == "12345"
+
+
+# ---- kiro_options ----
+
+
+def test_status_includes_kiro_agent_name_when_configured(config_dir):
+    """Kiro entry with agent_name → kiro_options surfaces it, set_default is False."""
+    _write_yaml(
+        config_dir,
+        {
+            "harnesses": {
+                "kiro": {
+                    "project_name": "p",
+                    "target": "phoenix",
+                    "endpoint": "http://x",
+                    "api_key": "",
+                    "agent_name": "my-agent",
+                },
+            },
+        },
+    )
+    result = load_status()
+    kiro = {h["name"]: h for h in result["harnesses"]}["kiro"]
+    assert kiro["kiro_options"] is not None
+    assert kiro["kiro_options"]["agent_name"] == "my-agent"
+    assert kiro["kiro_options"]["set_default"] is False
+
+
+def test_status_omits_kiro_options_when_no_agent_name(config_dir):
+    """Kiro entry without agent_name → kiro_options is None."""
+    _write_yaml(
+        config_dir,
+        {
+            "harnesses": {
+                "kiro": {
+                    "project_name": "p",
+                    "target": "phoenix",
+                    "endpoint": "http://x",
+                    "api_key": "",
+                },
+            },
+        },
+    )
+    result = load_status()
+    kiro = {h["name"]: h for h in result["harnesses"]}["kiro"]
+    assert kiro["kiro_options"] is None
+
+
+def test_status_other_harnesses_have_null_kiro_options(config_dir):
+    """Every non-kiro harness item has kiro_options=None."""
+    harnesses = {}
+    for i, key in enumerate(HARNESS_KEYS):
+        harnesses[key] = {
+            "project_name": f"proj-{key}",
+            "target": "phoenix",
+            "endpoint": "http://x",
+            "api_key": "",
+        }
+    harnesses["kiro"]["agent_name"] = "k-agent"
+    _write_yaml(config_dir, {"harnesses": harnesses})
+
+    result = load_status()
+    for h in result["harnesses"]:
+        if h["name"] != "kiro":
+            assert h["kiro_options"] is None

--- a/tests/test_vscode_bridge_status.py
+++ b/tests/test_vscode_bridge_status.py
@@ -102,7 +102,7 @@ def test_one_harness_configured(config_dir):
     assert result["success"] is True
 
     by_name = {h["name"]: h for h in result["harnesses"]}
-    assert len(by_name) == 5
+    assert len(by_name) == len(HARNESS_KEYS)
 
     cc = by_name["claude-code"]
     assert cc["configured"] is True
@@ -112,7 +112,7 @@ def test_one_harness_configured(config_dir):
     assert cc["backend"]["api_key"] == "key123"
     assert cc["backend"]["space_id"] == "sp-1"
 
-    for name in ("codex", "cursor", "copilot", "gemini"):
+    for name in ("codex", "cursor", "copilot", "gemini", "kiro"):
         assert by_name[name]["configured"] is False
         assert by_name[name]["backend"] is None
 
@@ -385,3 +385,86 @@ def test_status_other_harnesses_have_null_kiro_options(config_dir):
     for h in result["harnesses"]:
         if h["name"] != "kiro":
             assert h["kiro_options"] is None
+
+
+def test_status_kiro_options_when_agent_name_empty_string(config_dir):
+    """Kiro entry with agent_name='' → kiro_options is None (not a usable name)."""
+    _write_yaml(
+        config_dir,
+        {
+            "harnesses": {
+                "kiro": {
+                    "project_name": "p",
+                    "target": "phoenix",
+                    "endpoint": "http://x",
+                    "api_key": "",
+                    "agent_name": "",
+                },
+            },
+        },
+    )
+    result = load_status()
+    kiro = {h["name"]: h for h in result["harnesses"]}["kiro"]
+    assert kiro["kiro_options"] is None
+
+
+def test_status_kiro_options_when_agent_name_not_string(config_dir):
+    """Kiro entry with non-string agent_name → kiro_options is None."""
+    _write_yaml(
+        config_dir,
+        {
+            "harnesses": {
+                "kiro": {
+                    "project_name": "p",
+                    "target": "phoenix",
+                    "endpoint": "http://x",
+                    "api_key": "",
+                    "agent_name": 42,
+                },
+            },
+        },
+    )
+    result = load_status()
+    kiro = {h["name"]: h for h in result["harnesses"]}["kiro"]
+    assert kiro["kiro_options"] is None
+
+
+def test_status_kiro_configured_unaffected_by_kiro_options(config_dir):
+    """Kiro item still reports configured=True, project_name, and backend
+    regardless of whether kiro_options is populated."""
+    _write_yaml(
+        config_dir,
+        {
+            "harnesses": {
+                "kiro": {
+                    "project_name": "kiro-proj",
+                    "target": "phoenix",
+                    "endpoint": "http://x",
+                    "api_key": "",
+                    "agent_name": "kagent",
+                },
+            },
+        },
+    )
+    result = load_status()
+    kiro = {h["name"]: h for h in result["harnesses"]}["kiro"]
+    assert kiro["configured"] is True
+    assert kiro["project_name"] == "kiro-proj"
+    assert kiro["backend"]["target"] == "phoenix"
+    assert kiro["kiro_options"]["agent_name"] == "kagent"
+
+
+def test_status_kiro_no_options_when_entry_not_dict(config_dir):
+    """Non-dict kiro entry → kiro_options is None (handled by early return)."""
+    _write_yaml(
+        config_dir,
+        {
+            "harnesses": {
+                "kiro": "not-a-dict",
+            },
+        },
+    )
+    result = load_status()
+    kiro = {h["name"]: h for h in result["harnesses"]}["kiro"]
+    assert kiro["configured"] is False
+    assert kiro["kiro_options"] is None

--- a/tracing/kiro/README.md
+++ b/tracing/kiro/README.md
@@ -10,6 +10,15 @@ curl -sSL https://raw.githubusercontent.com/Arize-ai/arize-agent-kit/main/instal
 ./install.sh kiro
 ```
 
+## VS Code integration
+
+Kiro is selectable in the Arize Tracing sidebar alongside the other supported harnesses. The setup wizard asks for:
+
+- **Agent name** — which `~/.kiro/agents/<name>.json` to install hooks into (default: `arize-traced`).
+- **Set as default** — optional checkbox that runs `kiro-cli agent set-default <name>` after install.
+
+Only one Kiro agent is traced at a time. Reconfiguring with a different agent name moves tracing to the new agent rather than layering it. If `kiro-cli` is not on `PATH`, the install fails before any files are written, with a clear error in the wizard.
+
 ## What gets installed
 
 - Hook entries written into `~/.kiro/agents/<agent>.json` (default agent: `arize-traced`)

--- a/tracing/kiro/install.py
+++ b/tracing/kiro/install.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import copy
 import json
+import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
-from core.config import get_value, load_config
+from core.config import get_value, load_config, save_config, set_value
 from core.setup import (
     INSTALL_DIR,
     dry_run,
@@ -40,16 +41,35 @@ from tracing.kiro.constants import (
     KIRO_AGENTS_DIR,
 )
 
+_VALID_AGENT_NAME_RE = re.compile(r"[A-Za-z0-9_.-]+")
 
-def install(with_skills: bool = False, agent_name: str | None = None) -> None:
-    """Install Kiro tracing: configure backend, write hooks into an agent config."""
-    if not ensure_harness_installed(DISPLAY_NAME, home_subdir=HARNESS_HOME, bin_name=HARNESS_BIN):
-        info("Aborted.")
-        return
+
+def _resolve_kiro_bin() -> str | None:
+    """Return path to kiro-cli binary, or None if not findable."""
+    return shutil.which(HARNESS_BIN) or _macos_app_kiro_path()
+
+
+def install_noninteractive(
+    *,
+    target: str,
+    credentials: dict,
+    project_name: str,
+    user_id: str = "",
+    with_skills: bool = False,
+    logging_block: "dict | None" = None,
+    agent_name: str | None = None,
+    set_default: bool = False,
+) -> None:
+    """Install Kiro tracing with no prompts. All decisions made by caller."""
+    chosen_name = agent_name or DEFAULT_AGENT_NAME
+    if not _VALID_AGENT_NAME_RE.fullmatch(chosen_name):
+        raise ValueError("invalid agent name")
+
+    if _resolve_kiro_bin() is None:
+        raise RuntimeError("kiro-cli not found; install the Kiro CLI before configuring Arize tracing for Kiro")
 
     ensure_shared_runtime()
 
-    # Per-harness state dir
     state_dir = INSTALL_DIR / "state" / HARNESS_NAME
     if dry_run():
         info(f"would create {state_dir}")
@@ -58,45 +78,128 @@ def install(with_skills: bool = False, agent_name: str | None = None) -> None:
 
     config = load_config()
     existing_entry = get_value(config, f"harnesses.{HARNESS_NAME}")
-    if not existing_entry:
-        existing_harnesses = config.get("harnesses") if config else None
-        target, credentials = prompt_backend(existing_harnesses)
-        project_name = prompt_project_name(HARNESS_NAME)
-        user_id = prompt_user_id()
+
+    if existing_entry:
+        merge_harness_entry(HARNESS_NAME, project_name)
+    else:
         if not dry_run():
             write_config(target, credentials, HARNESS_NAME, project_name, user_id=user_id)
         else:
             info("would write config.yaml with backend credentials")
-    else:
-        project_name = prompt_project_name(get_value(config, f"harnesses.{HARNESS_NAME}.project_name") or HARNESS_NAME)
-        merge_harness_entry(HARNESS_NAME, project_name)
 
+    # Persist agent_name under harnesses.kiro.agent_name
+    if not dry_run():
+        config = load_config()
+        set_value(config, f"harnesses.{HARNESS_NAME}.agent_name", chosen_name)
+        save_config(config)
+    else:
+        info(f"would set harnesses.{HARNESS_NAME}.agent_name = {chosen_name}")
+
+    # Logging: only write when absent from config.
+    config = load_config()
     if (config.get("logging") if config else None) is None:
-        logging_block = prompt_content_logging()
-        write_logging_config(logging_block)
-    else:
-        info("Using existing logging settings from config.yaml")
+        effective_logging = (
+            logging_block
+            if logging_block is not None
+            else {
+                "prompts": True,
+                "tool_details": True,
+                "tool_content": True,
+            }
+        )
+        write_logging_config(effective_logging)
 
-    chosen = agent_name or _prompt_agent_name()
-    agent_path = _resolve_agent_path(chosen)
-    _register_kiro_hooks(agent_path, chosen)
+    # Single-agent-traced semantics: clear our hooks from every existing agent
+    # before installing fresh into the chosen one.
+    _unregister_all_kiro_hooks()
 
+    agent_path = _resolve_agent_path(chosen_name)
+    _register_kiro_hooks(agent_path, chosen_name)
     info(f"Hooks registered in {agent_path}")
-    _maybe_set_default(chosen)
+
+    if set_default and not dry_run():
+        kiro_bin = _resolve_kiro_bin()
+        if kiro_bin:
+            result = subprocess.run(
+                [kiro_bin, "agent", "set-default", chosen_name],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                info(f"'{chosen_name}' is now Kiro's default agent")
+            else:
+                info(f"Failed to set default: {result.stderr.strip() or result.stdout.strip()}")
 
     if with_skills:
         symlink_skills(HARNESS_NAME)
 
-    info(f"Kiro tracing installed.\n" f"  Agent file: {agent_path}\n" f"  Run:        kiro-cli chat --agent {chosen}\n")
+    info(
+        f"Kiro tracing installed.\n"
+        f"  Agent file: {agent_path}\n"
+        f"  Run:        kiro-cli chat --agent {chosen_name}\n"
+    )
+
+
+def uninstall_noninteractive() -> None:
+    """Remove Kiro tracing with no prompts."""
+    _unregister_all_kiro_hooks()
+    remove_harness_entry(HARNESS_NAME)
+    unlink_skills(HARNESS_NAME)
+    info("Kiro tracing uninstalled")
+
+
+def install(with_skills: bool = False, agent_name: str | None = None) -> None:
+    """Install Kiro tracing: configure backend, write hooks into an agent config."""
+    if not ensure_harness_installed(DISPLAY_NAME, home_subdir=HARNESS_HOME, bin_name=HARNESS_BIN):
+        info("Aborted.")
+        return
+
+    config = load_config()
+    existing_entry = get_value(config, f"harnesses.{HARNESS_NAME}")
+
+    if existing_entry:
+        project_name = prompt_project_name(get_value(config, f"harnesses.{HARNESS_NAME}.project_name") or HARNESS_NAME)
+        target = existing_entry.get("target", "phoenix")
+        credentials = {
+            "endpoint": existing_entry.get("endpoint", ""),
+            "api_key": existing_entry.get("api_key", ""),
+        }
+        if existing_entry.get("space_id"):
+            credentials["space_id"] = existing_entry["space_id"]
+        user_id = ""
+    else:
+        existing_harnesses = config.get("harnesses") if config else None
+        target, credentials = prompt_backend(existing_harnesses)
+        project_name = prompt_project_name(HARNESS_NAME)
+        user_id = prompt_user_id()
+
+    logging_block = None
+    if (config.get("logging") if config else None) is None:
+        logging_block = prompt_content_logging()
+    else:
+        info("Using existing logging settings from config.yaml")
+
+    chosen = agent_name or _prompt_agent_name()
+
+    install_noninteractive(
+        target=target,
+        credentials=credentials,
+        project_name=project_name,
+        user_id=user_id,
+        with_skills=with_skills,
+        logging_block=logging_block,
+        agent_name=chosen,
+        set_default=False,
+    )
+
+    _maybe_set_default(chosen)
 
 
 def uninstall() -> None:
     """Remove our hooks from every Kiro agent file. Delete the agent file
     only when we created it (matches AGENT_SKELETON description)."""
-    _unregister_all_kiro_hooks()
-    remove_harness_entry(HARNESS_NAME)
-    unlink_skills(HARNESS_NAME)
-    info("Kiro tracing uninstalled")
+    uninstall_noninteractive()
 
 
 def _prompt_agent_name() -> str:
@@ -147,7 +250,7 @@ def _register_kiro_hooks(agent_path: Path, name: str) -> None:
     _save_agent(agent_path, data)
 
     # Best-effort validation; non-fatal if Kiro CLI isn't on PATH.
-    kiro_bin = shutil.which(HARNESS_BIN) or _macos_app_kiro_path()
+    kiro_bin = _resolve_kiro_bin()
     if kiro_bin:
         result = subprocess.run(
             [kiro_bin, "agent", "validate", "--path", str(agent_path)],
@@ -212,7 +315,7 @@ def _maybe_set_default(name: str) -> None:
     if dry_run():
         info(f"would run: kiro-cli agent set-default {name}")
         return
-    kiro_bin = shutil.which(HARNESS_BIN) or _macos_app_kiro_path()
+    kiro_bin = _resolve_kiro_bin()
     if not kiro_bin:
         info(
             "Could not find kiro-cli on PATH; skipping set-default. " f"Run manually: kiro-cli agent set-default {name}"

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,10 +1,10 @@
 # Arize Agent Kit — VS Code Extension
 
-Wire up [Arize](https://arize.com) tracing for AI coding agents — Claude Code, Codex, Cursor, Copilot, and Gemini — without leaving the editor. The extension installs and configures the Arize harness in a managed venv, then surfaces status and controls in a sidebar view.
+Wire up [Arize](https://arize.com) tracing for AI coding agents — Claude Code, Codex, Cursor, Copilot, Gemini, and Kiro — without leaving the editor. The extension installs and configures the Arize harness in a managed venv, then surfaces status and controls in a sidebar view.
 
 ## What it does
 
-- **Guided setup wizard** for tracing with `claude-code`, `codex`, `cursor`, `copilot`, and `gemini` harnesses
+- **Guided setup wizard** for tracing with `claude-code`, `codex`, `cursor`, `copilot`, `gemini`, and `kiro` harnesses
 - **Sidebar view** listing configured harnesses with their project names and backends
 - **Reconfigure and uninstall** individual harnesses directly from the sidebar
 - **Status bar item** showing current tracing state at a glance

--- a/vscode-extension/media/wizard.js
+++ b/vscode-extension/media/wizard.js
@@ -59,14 +59,16 @@
 
   // ---- Constants ----
 
-  var HARNESS_KEYS = ["claude-code", "codex", "cursor", "copilot", "gemini"];
+  var HARNESS_KEYS = ["claude-code", "codex", "cursor", "copilot", "gemini", "kiro"];
   var HARNESS_LABELS = {
     "claude-code": "Claude Code",
     codex: "Codex",
     cursor: "Cursor",
     copilot: "Copilot",
     gemini: "Gemini",
+    kiro: "Kiro",
   };
+  var KIRO_DEFAULT_AGENT_NAME = "arize-traced";
   var TOTAL_STEPS = 4;
 
   var ARIZE_DEFAULT_ENDPOINT = "otlp.arize.com:443";
@@ -87,6 +89,8 @@
     logPrompts: true,
     logToolDetails: true,
     logToolContent: true,
+    kiroAgentName: KIRO_DEFAULT_AGENT_NAME,
+    kiroSetDefault: false,
     installing: false,
     resultPayload: null,
     prefillHarness: null,
@@ -285,6 +289,31 @@
       }, "(optional)")
     );
 
+    if (state.harness === "kiro") {
+      container.appendChild(
+        formGroup(
+          "Kiro Agent Name",
+          "text",
+          "kiro_agent_name",
+          state.kiroAgentName,
+          function (v) {
+            state.kiroAgentName = v;
+          },
+          "Default: " + KIRO_DEFAULT_AGENT_NAME + " — name of the ~/.kiro/agents/<name>.json file to install hooks into"
+        )
+      );
+      container.appendChild(
+        checkboxRow(
+          "kiro_set_default",
+          "Set as Kiro's default agent",
+          state.kiroSetDefault,
+          function (v) {
+            state.kiroSetDefault = v;
+          }
+        )
+      );
+    }
+
     container.appendChild(
       checkboxRow("with_skills", "Enable skills", state.withSkills, function (v) {
         state.withSkills = v;
@@ -336,6 +365,10 @@
       ["Log Tool Details", state.logToolDetails ? "Yes" : "No"],
       ["Log Tool Content", state.logToolContent ? "Yes" : "No"],
     ];
+    if (state.harness === "kiro") {
+      rows.push(["Kiro Agent Name", state.kiroAgentName || KIRO_DEFAULT_AGENT_NAME]);
+      rows.push(["Set as Default Agent", state.kiroSetDefault ? "Yes" : "No"]);
+    }
     rows.forEach(function (r) {
       table.appendChild(
         h("tr", null, [h("td", null, r[0]), h("td", null, r[1])])
@@ -419,7 +452,14 @@
         tool_details: state.logToolDetails,
         tool_content: state.logToolContent,
       },
+      kiro_options: null,
     };
+    if (state.harness === "kiro") {
+      request.kiro_options = {
+        agent_name: state.kiroAgentName || KIRO_DEFAULT_AGENT_NAME,
+        set_default: state.kiroSetDefault,
+      };
+    }
 
     vscode.postMessage({ type: "install", request: request });
   }
@@ -524,6 +564,10 @@
             if (r.logging.tool_details != null) state.logToolDetails = r.logging.tool_details;
             if (r.logging.tool_content != null) state.logToolContent = r.logging.tool_content;
           }
+          if (r.kiro_options && r.kiro_options.agent_name) {
+            state.kiroAgentName = r.kiro_options.agent_name;
+          }
+          // set_default always renders as unchecked on prefill — do NOT read it from r.kiro_options.set_default
         }
         render();
         break;

--- a/vscode-extension/src/__tests__/installer.test.ts
+++ b/vscode-extension/src/__tests__/installer.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for installer.ts → bridge.install argv forwarding.
+ *
+ * Specifically: verify that Kiro-specific options (--agent-name and
+ * --set-default) are forwarded to the bridge CLI when, and only when,
+ * the harness is "kiro" and kiro_options is populated.
+ */
+
+// ── Mocks must be declared before any require/import of the mocked modules ──
+
+jest.mock("../python", () => ({
+  findPython: jest.fn(),
+  findBridgeBinary: jest.fn(),
+}));
+
+const mockSpawn = jest.fn();
+jest.mock("child_process", () => ({
+  spawn: mockSpawn,
+  execFile: jest.fn(),
+}));
+
+import { EventEmitter } from "events";
+import { findBridgeBinary } from "../python";
+import { createBridgeInstaller } from "../installer";
+import type { InstallRequest } from "../types";
+
+const mockFindBridgeBinary = findBridgeBinary as jest.MockedFunction<
+  typeof findBridgeBinary
+>;
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const BRIDGE_PATH = "/home/user/.arize/harness/venv/bin/arize-vscode-bridge";
+
+/**
+ * Wire up a fake child process that returns a successful OperationResult
+ * via the bridge's NDJSON protocol.
+ */
+function fakeBridgeSpawn(): void {
+  const child = new EventEmitter() as any;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = jest.fn();
+  child.stdin = null;
+
+  mockSpawn.mockReturnValueOnce(child);
+
+  setImmediate(() => {
+    const result = {
+      event: "result",
+      payload: {
+        success: true,
+        error: null,
+        harness: "kiro",
+        logs: [],
+      },
+    };
+    child.stdout.emit("data", Buffer.from(JSON.stringify(result) + "\n"));
+    child.emit("close", 0);
+  });
+}
+
+function makeKiroRequest(
+  overrides: Partial<InstallRequest> = {},
+): InstallRequest {
+  return {
+    harness: "kiro",
+    backend: {
+      target: "arize",
+      endpoint: "https://otlp.arize.com/v1",
+      api_key: "ak-123",
+      space_id: "sp-1",
+    },
+    project_name: "demo",
+    user_id: null,
+    with_skills: false,
+    logging: null,
+    kiro_options: { agent_name: "arize-traced", set_default: false },
+    ...overrides,
+  };
+}
+
+function makeCodexRequest(
+  overrides: Partial<InstallRequest> = {},
+): InstallRequest {
+  return {
+    harness: "codex",
+    backend: {
+      target: "arize",
+      endpoint: "https://otlp.arize.com/v1",
+      api_key: "ak-123",
+      space_id: "sp-1",
+    },
+    project_name: "demo",
+    user_id: null,
+    with_skills: false,
+    logging: null,
+    kiro_options: null,
+    ...overrides,
+  };
+}
+
+/** Pull the argv array from the most recent spawn call. */
+function lastSpawnArgs(): string[] {
+  expect(mockSpawn).toHaveBeenCalled();
+  const call = mockSpawn.mock.calls[mockSpawn.mock.calls.length - 1];
+  return call[1] as string[];
+}
+
+// ── Reset ────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  mockFindBridgeBinary.mockResolvedValue(BRIDGE_PATH);
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("installer.install argv forwarding", () => {
+  it("forwards --agent-name when kiro_options present", async () => {
+    fakeBridgeSpawn();
+
+    const installer = createBridgeInstaller();
+    const req = makeKiroRequest({
+      kiro_options: { agent_name: "my-agent", set_default: false },
+    });
+    const result = await installer.install(req, () => {});
+
+    expect(result.success).toBe(true);
+    const args = lastSpawnArgs();
+    // --agent-name forwarded with the chosen value
+    const agentIdx = args.indexOf("--agent-name");
+    expect(agentIdx).toBeGreaterThan(-1);
+    expect(args[agentIdx + 1]).toBe("my-agent");
+    // set_default is false → flag must NOT be present
+    expect(args).not.toContain("--set-default");
+  });
+
+  it("forwards --set-default when set_default is true", async () => {
+    fakeBridgeSpawn();
+
+    const installer = createBridgeInstaller();
+    const req = makeKiroRequest({
+      kiro_options: { agent_name: "x", set_default: true },
+    });
+    const result = await installer.install(req, () => {});
+
+    expect(result.success).toBe(true);
+    const args = lastSpawnArgs();
+    const agentIdx = args.indexOf("--agent-name");
+    expect(agentIdx).toBeGreaterThan(-1);
+    expect(args[agentIdx + 1]).toBe("x");
+    expect(args).toContain("--set-default");
+  });
+
+  it("omits kiro flags when kiro_options is null", async () => {
+    fakeBridgeSpawn();
+
+    const installer = createBridgeInstaller();
+    const req = makeKiroRequest({ kiro_options: null });
+    const result = await installer.install(req, () => {});
+
+    expect(result.success).toBe(true);
+    const args = lastSpawnArgs();
+    expect(args).not.toContain("--agent-name");
+    expect(args).not.toContain("--set-default");
+  });
+
+  it("omits kiro flags for non-kiro harness even when kiro_options is set", async () => {
+    fakeBridgeSpawn();
+
+    const installer = createBridgeInstaller();
+    // Defensive: a codex request that somehow carries kiro_options.
+    const req = makeCodexRequest({
+      kiro_options: { agent_name: "my-agent", set_default: true },
+    });
+    const result = await installer.install(req, () => {});
+
+    expect(result.success).toBe(true);
+    const args = lastSpawnArgs();
+    expect(args).not.toContain("--agent-name");
+    expect(args).not.toContain("--set-default");
+  });
+});

--- a/vscode-extension/src/__tests__/status.test.ts
+++ b/vscode-extension/src/__tests__/status.test.ts
@@ -24,6 +24,7 @@ function makeHarness(
       ? { target: "arize", endpoint: "https://arize.com", api_key: "key", space_id: null }
       : null,
     scope: null,
+    kiro_options: null,
   };
 }
 

--- a/vscode-extension/src/__tests__/teardown.test.ts
+++ b/vscode-extension/src/__tests__/teardown.test.ts
@@ -39,11 +39,11 @@ function makeStatus(overrides: Partial<StatusPayload> = {}): StatusPayload {
     error: null,
     user_id: null,
     harnesses: [
-      { name: "claude-code", configured: false, project_name: null, backend: null, scope: null },
-      { name: "codex", configured: false, project_name: null, backend: null, scope: null },
-      { name: "cursor", configured: false, project_name: null, backend: null, scope: null },
-      { name: "copilot", configured: false, project_name: null, backend: null, scope: null },
-      { name: "gemini", configured: false, project_name: null, backend: null, scope: null },
+      { name: "claude-code", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+      { name: "codex", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+      { name: "cursor", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+      { name: "copilot", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+      { name: "gemini", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
     ],
     logging: null,
     codex_buffer: null,
@@ -113,11 +113,11 @@ describe("teardownAll", () => {
   it("when two harnesses are configured and the first uninstall fails, result records failure and continues", async () => {
     const status = makeStatus({
       harnesses: [
-        { name: "claude-code", configured: true, project_name: "test", backend: null, scope: null },
-        { name: "codex", configured: true, project_name: "test", backend: null, scope: null },
-        { name: "cursor", configured: false, project_name: null, backend: null, scope: null },
-        { name: "copilot", configured: false, project_name: null, backend: null, scope: null },
-        { name: "gemini", configured: false, project_name: null, backend: null, scope: null },
+        { name: "claude-code", configured: true, project_name: "test", backend: null, scope: null, kiro_options: null },
+        { name: "codex", configured: true, project_name: "test", backend: null, scope: null, kiro_options: null },
+        { name: "cursor", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+        { name: "copilot", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+        { name: "gemini", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
       ],
     });
     mockGetStatus.mockResolvedValueOnce(status);
@@ -187,11 +187,11 @@ describe("teardownAll", () => {
 
     const status = makeStatus({
       harnesses: [
-        { name: "claude-code", configured: true, project_name: "test", backend: null, scope: null },
-        { name: "codex", configured: true, project_name: "test", backend: null, scope: null },
-        { name: "cursor", configured: false, project_name: null, backend: null, scope: null },
-        { name: "copilot", configured: false, project_name: null, backend: null, scope: null },
-        { name: "gemini", configured: false, project_name: null, backend: null, scope: null },
+        { name: "claude-code", configured: true, project_name: "test", backend: null, scope: null, kiro_options: null },
+        { name: "codex", configured: true, project_name: "test", backend: null, scope: null, kiro_options: null },
+        { name: "cursor", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+        { name: "copilot", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+        { name: "gemini", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
       ],
     });
     mockGetStatus.mockResolvedValueOnce(status);
@@ -259,11 +259,11 @@ describe("teardownAll", () => {
         pid: 1234,
       },
       harnesses: [
-        { name: "claude-code", configured: false, project_name: null, backend: null, scope: null },
-        { name: "codex", configured: true, project_name: "test", backend: null, scope: null },
-        { name: "cursor", configured: false, project_name: null, backend: null, scope: null },
-        { name: "copilot", configured: false, project_name: null, backend: null, scope: null },
-        { name: "gemini", configured: false, project_name: null, backend: null, scope: null },
+        { name: "claude-code", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+        { name: "codex", configured: true, project_name: "test", backend: null, scope: null, kiro_options: null },
+        { name: "cursor", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+        { name: "copilot", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+        { name: "gemini", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
       ],
     });
     mockGetStatus.mockResolvedValueOnce(status);
@@ -312,11 +312,11 @@ describe("teardownAll", () => {
   it("when bridge.uninstall throws, records the harness as failed and continues", async () => {
     const status = makeStatus({
       harnesses: [
-        { name: "claude-code", configured: true, project_name: "test", backend: null, scope: null },
-        { name: "codex", configured: true, project_name: "test", backend: null, scope: null },
-        { name: "cursor", configured: false, project_name: null, backend: null, scope: null },
-        { name: "copilot", configured: false, project_name: null, backend: null, scope: null },
-        { name: "gemini", configured: false, project_name: null, backend: null, scope: null },
+        { name: "claude-code", configured: true, project_name: "test", backend: null, scope: null, kiro_options: null },
+        { name: "codex", configured: true, project_name: "test", backend: null, scope: null, kiro_options: null },
+        { name: "cursor", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+        { name: "copilot", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
+        { name: "gemini", configured: false, project_name: null, backend: null, scope: null, kiro_options: null },
       ],
     });
     mockGetStatus.mockResolvedValueOnce(status);

--- a/vscode-extension/src/__tests__/teardown.test.ts
+++ b/vscode-extension/src/__tests__/teardown.test.ts
@@ -79,7 +79,7 @@ describe("teardownAll", () => {
     const result = await teardownAll({});
 
     expect(result.ok).toBe(true);
-    expect(result.harnesses).toHaveLength(5);
+    expect(result.harnesses).toHaveLength(6);
     for (const h of result.harnesses) {
       expect(h.state).toBe("skipped");
     }
@@ -101,7 +101,7 @@ describe("teardownAll", () => {
     const result = await teardownAll({});
 
     expect(result.ok).toBe(true);
-    expect(result.harnesses).toHaveLength(5);
+    expect(result.harnesses).toHaveLength(6);
     for (const h of result.harnesses) {
       expect(h.state).toBe("skipped");
     }

--- a/vscode-extension/src/__tests__/types.test.ts
+++ b/vscode-extension/src/__tests__/types.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Tests for types.ts — sanity checks for the harness key list and the
+ * KiroOptions shape introduced for the Kiro harness.
+ */
+
+import { HARNESS_KEYS } from "../types";
+import type { KiroOptions } from "../types";
+
+describe("HARNESS_KEYS", () => {
+  it("contains kiro", () => {
+    expect(HARNESS_KEYS).toContain("kiro");
+  });
+
+  it("has 6 entries", () => {
+    expect(HARNESS_KEYS.length).toBe(6);
+  });
+});
+
+describe("KiroOptions", () => {
+  it("compiles with the expected shape", () => {
+    const opts: KiroOptions = { agent_name: "arize-traced", set_default: false };
+    expect(opts.agent_name).toBe("arize-traced");
+    expect(opts.set_default).toBe(false);
+  });
+});

--- a/vscode-extension/src/__tests__/wizard.test.ts
+++ b/vscode-extension/src/__tests__/wizard.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for wizard.ts → _sendPrefill mapping.
+ *
+ * Specifically: verify that kiro_options on a HarnessStatusItem is forwarded
+ * into the prefill message posted to the webview during reconfigure.
+ */
+
+import * as vscode from "vscode";
+import { WizardPanel } from "../wizard";
+import type { InstallerBridge } from "../installer";
+import type {
+  HarnessKey,
+  HarnessStatusItem,
+  StatusPayload,
+} from "../types";
+import { HARNESS_KEYS } from "../types";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function makeHarness(
+  name: HarnessKey,
+  overrides: Partial<HarnessStatusItem> = {},
+): HarnessStatusItem {
+  return {
+    name,
+    configured: false,
+    project_name: null,
+    backend: null,
+    scope: null,
+    kiro_options: null,
+    ...overrides,
+  };
+}
+
+function makeStatus(overrides: Partial<StatusPayload> = {}): StatusPayload {
+  return {
+    success: true,
+    error: null,
+    user_id: "u1",
+    harnesses: HARNESS_KEYS.map((k) => makeHarness(k)),
+    logging: null,
+    codex_buffer: null,
+    ...overrides,
+  };
+}
+
+function makeInstaller(status: StatusPayload): InstallerBridge {
+  return {
+    install: jest.fn(),
+    uninstall: jest.fn(),
+    loadStatus: jest.fn().mockResolvedValue(status),
+  };
+}
+
+function getCreatedPanel(): {
+  webview: {
+    postMessage: jest.Mock;
+    _simulateMessage: (msg: unknown) => void;
+  };
+  dispose: () => void;
+} {
+  const mockFn = vscode.window.createWebviewPanel as jest.Mock;
+  const result = mockFn.mock.results[mockFn.mock.results.length - 1];
+  return result.value;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("WizardPanel._sendPrefill", () => {
+  const extensionUri = vscode.Uri.file("/ext");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset the singleton between tests.
+    WizardPanel.currentPanel?.dispose();
+  });
+
+  afterEach(() => {
+    WizardPanel.currentPanel?.dispose();
+  });
+
+  it("prefill for kiro forwards kiro_options.agent_name", async () => {
+    const kiroItem = makeHarness("kiro", {
+      configured: true,
+      project_name: "my-kiro",
+      backend: {
+        target: "arize",
+        endpoint: "https://otlp.arize.com/v1",
+        api_key: "ak-1",
+        space_id: "sp-1",
+      },
+      kiro_options: { agent_name: "x", set_default: false },
+    });
+    const status = makeStatus({
+      harnesses: HARNESS_KEYS.map((k) =>
+        k === "kiro" ? kiroItem : makeHarness(k),
+      ),
+    });
+
+    const installer = makeInstaller(status);
+    WizardPanel.open(extensionUri, installer, { prefillHarness: "kiro" });
+
+    const panel = getCreatedPanel();
+    panel.webview._simulateMessage({ type: "ready" });
+
+    // Wait for _sendPrefill's async loadStatus() + postMessage to resolve.
+    await new Promise((r) => setImmediate(r));
+
+    expect(panel.webview.postMessage).toHaveBeenCalledTimes(1);
+    const msg = panel.webview.postMessage.mock.calls[0][0];
+    expect(msg.type).toBe("prefill");
+    expect(msg.harness).toBe("kiro");
+    expect(msg.request.kiro_options).toEqual({
+      agent_name: "x",
+      set_default: false,
+    });
+    expect(msg.request.kiro_options.agent_name).toBe("x");
+  });
+});

--- a/vscode-extension/src/bootstrap.ts
+++ b/vscode-extension/src/bootstrap.ts
@@ -336,7 +336,15 @@ async function doEnsureBridge(opts: EnsureBridgeOptions): Promise<BootstrapResul
 
   // Step 6: pip install the wheel
   try {
-    const result = await runProcess(venvPip, ["install", "--quiet", wheelPath], onLog, signal);
+    // --force-reinstall: the bundled wheel keeps the same version across rebuilds, so
+    // pip would otherwise treat an existing 0.1.0 install as "already satisfied" and
+    // skip refreshing entry-point scripts (e.g. a newly-added arize-vscode-bridge).
+    const result = await runProcess(
+      venvPip,
+      ["install", "--quiet", "--force-reinstall", "--no-deps", wheelPath],
+      onLog,
+      signal,
+    );
     if (result.code !== 0) {
       return { ok: false, error: "pip_install_failed", errorMessage: result.stderr || "pip install failed." };
     }

--- a/vscode-extension/src/bridge.ts
+++ b/vscode-extension/src/bridge.ts
@@ -179,6 +179,12 @@ export async function install(
     argv.push("--log-tool-details", String(req.logging.tool_details));
     argv.push("--log-tool-content", String(req.logging.tool_content));
   }
+  if (req.harness === "kiro" && req.kiro_options) {
+    argv.push("--agent-name", req.kiro_options.agent_name);
+    if (req.kiro_options.set_default) {
+      argv.push("--set-default");
+    }
+  }
 
   return runBridge<OperationResult>(argv, opts);
 }

--- a/vscode-extension/src/sidebar.ts
+++ b/vscode-extension/src/sidebar.ts
@@ -49,6 +49,7 @@ const HARNESS_LABELS: Record<HarnessKey, string> = {
   cursor: "Cursor",
   copilot: "Copilot",
   gemini: "Gemini",
+  kiro: "Kiro",
 };
 
 // ---------------------------------------------------------------------------

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -3,7 +3,7 @@
  */
 
 /** Supported harness identifiers. */
-export type HarnessKey = "claude-code" | "codex" | "cursor" | "copilot" | "gemini";
+export type HarnessKey = "claude-code" | "codex" | "cursor" | "copilot" | "gemini" | "kiro";
 
 /** All supported harness keys, in canonical order. */
 export const HARNESS_KEYS: readonly HarnessKey[] = [
@@ -12,7 +12,14 @@ export const HARNESS_KEYS: readonly HarnessKey[] = [
   "cursor",
   "copilot",
   "gemini",
+  "kiro",
 ] as const;
+
+/** Kiro-specific install/configuration options. */
+export interface KiroOptions {
+  agent_name: string;
+  set_default: boolean;
+}
 
 /** Tracing backend configuration. */
 export interface Backend {
@@ -36,6 +43,7 @@ export interface HarnessStatusItem {
   project_name: string | null;
   backend: Backend | null;
   scope: string | null;
+  kiro_options: KiroOptions | null;
 }
 
 /** Full status payload returned by the bridge. */
@@ -56,6 +64,7 @@ export interface InstallRequest {
   user_id: string | null;
   with_skills: boolean;
   logging: LoggingFlags | null;
+  kiro_options: KiroOptions | null;
 }
 
 /** Result of an install, reconfigure, or uninstall operation. */

--- a/vscode-extension/src/wizard.ts
+++ b/vscode-extension/src/wizard.ts
@@ -142,6 +142,7 @@ export class WizardPanel implements vscode.Disposable {
             project_name: item.project_name ?? "",
             user_id: status.user_id ?? null,
             with_skills: false,
+            kiro_options: item.kiro_options,
           },
         });
         return;

--- a/vscode-extension/src/wizard.ts
+++ b/vscode-extension/src/wizard.ts
@@ -142,7 +142,7 @@ export class WizardPanel implements vscode.Disposable {
             project_name: item.project_name ?? "",
             user_id: status.user_id ?? null,
             with_skills: false,
-            kiro_options: item.kiro_options,
+            kiro_options: item.kiro_options ?? null,
           },
         });
         return;

--- a/vscode-extension/test/sidebar-state.test.js
+++ b/vscode-extension/test/sidebar-state.test.js
@@ -101,7 +101,7 @@ describe("SidebarController", () => {
 
     expect(provider.render).toHaveBeenCalledTimes(1);
     const state = provider.render.mock.calls[0][0];
-    expect(state.harnesses).toHaveLength(5);
+    expect(state.harnesses).toHaveLength(6);
     expect(state.harnesses.every((h) => !h.configured)).toBe(true);
     expect(state.userId).toBeNull();
     expect(state.codexBuffer).toBeNull();
@@ -138,7 +138,7 @@ describe("SidebarController", () => {
 
     const state = provider.render.mock.calls[0][0];
     expect(state.bridgeError).toBe("network down");
-    expect(state.harnesses).toHaveLength(5);
+    expect(state.harnesses).toHaveLength(6);
     expect(state.harnesses.every((h) => !h.configured)).toBe(true);
   });
 

--- a/vscode-extension/test/sidebar-state.test.js
+++ b/vscode-extension/test/sidebar-state.test.js
@@ -94,7 +94,7 @@ describe("SidebarController", () => {
 
   // ---- refresh() ----------------------------------------------------------
 
-  test("refresh() with empty config produces five unconfigured rows", async () => {
+  test("refresh() with empty config produces six unconfigured rows", async () => {
     bridge.getStatus.mockResolvedValue(emptyStatus());
     ctrl = new SidebarController(provider);
     await ctrl.refresh();

--- a/vscode-extension/test/sidebar.test.js
+++ b/vscode-extension/test/sidebar.test.js
@@ -52,6 +52,7 @@ function fullState() {
       { name: "cursor", configured: false, projectName: null, backendLabel: null },
       { name: "copilot", configured: false, projectName: null, backendLabel: null },
       { name: "gemini", configured: false, projectName: null, backendLabel: null },
+      { name: "kiro", configured: false, projectName: null, backendLabel: null },
     ],
     userId: "user@example.com",
     codexBuffer: { state: "running", host: "localhost", port: 4318 },
@@ -107,7 +108,7 @@ describe("SidebarProvider", () => {
     provider.render(state);
     const call = viewParts.webview.postMessage.mock.calls[0][0];
     expect(call.type).toBe("render");
-    expect(call.state.harnesses).toHaveLength(5);
+    expect(call.state.harnesses).toHaveLength(6);
     expect(call.state.harnesses[0].name).toBe("claude-code");
     expect(call.state.harnesses[0].configured).toBe(true);
     expect(call.state.userId).toBe("user@example.com");


### PR DESCRIPTION
# Add Kiro CLI to the VS Code tracing extension

## Summary

Adds Kiro as the sixth supported harness across the VS Code extension surface — sidebar, wizard, and the Python bridge that drives both. Reaches feature parity with `claude-code` / `codex` / `cursor` / `copilot` / `gemini` in the VS Code UX; existing CLI install flow stays unchanged.

Two Kiro-specific options are exposed in the wizard:

- **Kiro Agent Name** — which `~/.kiro/agents/<name>.json` to install hooks into (default `arize-traced`)
- **Set as Kiro's default agent** — one-shot post-install flag that runs `kiro-cli agent set-default <name>`

## What changed

### Python — `core/vscode_bridge/`

- `models.py`: `HARNESS_KEYS` now includes `"kiro"`. `InstallRequest` and `HarnessStatusItem` carry a new `kiro_options: { agent_name: str, set_default: bool } | None` field; new `build_kiro_options()` helper enforces shape and requires a non-empty `agent_name`. `kiro_options` is validated to only appear when `harness == "kiro"`.
- `install.py`: `_HARNESS_MODULES` routes `"kiro"` to `tracing.kiro.install`. The dispatcher unpacks `kiro_options` into `install_noninteractive(agent_name=..., set_default=...)` kwargs only for the kiro harness; other harnesses' signatures stay unchanged.
- `cli.py`: `install` subcommand gets `--agent-name` and `--set-default` flags. They're forwarded into `kiro_options` only when `--harness kiro`; passing them for any other harness is silently ignored at the CLI layer (caught by the model validator).
- `status.py`: when reading `harnesses.kiro` from `config.yaml`, surfaces `agent_name` as `kiro_options.agent_name` on the status item so reconfigure can prefill the wizard.

### Python — `tracing/kiro/install.py`

- New `install_noninteractive(*, target, credentials, project_name, user_id, with_skills, logging_block, agent_name, set_default)` matches the cursor/copilot signature.
- New `uninstall_noninteractive()` mirrors the same pattern.
- The interactive `install()` and `uninstall()` paths now delegate to the noninteractive entry points; the interactive flow still owns its prompts (agent name, set-as-default).
- **Fail-fast** if `kiro-cli` is not on PATH (and not at the macOS bundled path) — raises `RuntimeError` with a clear message before writing anything.
- **Agent-name validation** rejects unsafe names (e.g. `../escape`) before touching the filesystem.
- **Single-agent-traced semantics**: `install_noninteractive` unregisters our hooks from every existing Kiro agent before installing into the chosen one. Reconfiguring with a different agent name therefore *moves* tracing instead of layering it. Multi-agent tracing remains future work and is intentionally not implemented here.
- `harnesses.kiro.agent_name` is persisted in `config.yaml`; `set_default` is install-time only and is not stored.

### TypeScript — `vscode-extension/`

- `src/types.ts`: `HarnessKey` and `HARNESS_KEYS` include `"kiro"`. New `KiroOptions` interface; `HarnessStatusItem` and `InstallRequest` each carry `kiro_options: KiroOptions | null`.
- `src/sidebar.ts`: `HARNESS_LABELS` includes `kiro: "Kiro"`. No other sidebar logic changed — rows are still rendered from `HARNESS_KEYS`.
- `src/bridge.ts` / `src/wizard.ts`: forward `kiro_options` end-to-end (status → wizard prefill → install request → bridge CLI flags).
- `media/wizard.js`: when the selected harness is `"kiro"`, the Options step renders an agent-name text field (prefilled from status when reconfiguring) and a "Set as Kiro's default agent" checkbox (always starts unchecked, even on reconfigure, since it's an action rather than persistent state). The review step adds two rows. The install payload includes `kiro_options` for kiro and `null` for every other harness.

### Documentation

- `tracing/kiro/README.md` and `vscode-extension/README.md` mention the new VS Code surface, the agent-name field, and the single-agent-traced behavior.

## Tests

### New

- `tests/test_kiro_install_noninteractive.py` (9 tests): default agent name, agent-file write, hook-event registration, `set_default` on/off, config persistence, unregister-on-reinstall, missing-`kiro-cli` failure, unsafe-name rejection, uninstall path.
- `tests/test_vscode_bridge_cli.py`: kiro-specific flag forwarding + non-kiro harnesses ignoring kiro flags.
- `vscode-extension/src/__tests__/types.test.ts`: HARNESS_KEYS length + kiro membership + `KiroOptions` shape compiles.
- `vscode-extension/src/__tests__/installer.test.ts`: kiro_options → CLI args forwarding (agent_name, set_default, omission rules).
- `vscode-extension/src/__tests__/wizard.test.ts`: prefill propagates `kiro_options.agent_name`; `set_default` is not prefilled.

### Updated (count-only)

- `tests/test_vscode_bridge_models.py`, `tests/test_vscode_bridge_install.py`, `tests/test_vscode_bridge_status.py`: bumped harness counts from 5 → 6 and added kiro to expected tuples.
- `vscode-extension/src/__tests__/teardown.test.ts`, `vscode-extension/src/__tests__/status.test.ts`, `vscode-extension/test/sidebar-state.test.js`, `vscode-extension/test/sidebar.test.js`: same count bumps.

### Status

- Python: `python -m pytest tests/test_kiro_install_noninteractive.py tests/test_vscode_bridge_*.py tests/test_kiro_install.py -q` → **153 passed** ✅
- TypeScript: extension suite was not run locally (no `node_modules`); please verify in CI with `cd vscode-extension && npm ci && npm test`.

## Test plan

- [x] CI: full Python suite passes
- [x] CI: `cd vscode-extension && npm ci && npm test` passes
- [x] Manual: open the VS Code sidebar — Kiro appears as the 6th row
- [x] Manual: click "Set Up" for Kiro — wizard shows Agent Name + Set-as-default fields on the Options step
- [x] Manual: install Kiro with default agent name; verify `~/.kiro/agents/arize-traced.json` exists with all 5 hook entries pointing at `arize-hook-kiro`
- [x] Manual: install Kiro on a system without `kiro-cli` on PATH — wizard reports a clear failure (no agent file written)
- [x] Manual: reconfigure Kiro with a different agent name — old agent file no longer contains our hook command; new one does; `config.yaml::harnesses.kiro.agent_name` updates
- [x] Manual: install with "Set as Kiro's default agent" checked — `kiro-cli agent set-default <name>` runs successfully
- [x] Manual: uninstall Kiro from the sidebar — `harnesses.kiro` removed from `config.yaml`; hooks gone from agent file

## Out of scope / future work

- Multi-agent tracing (`agent_names: list[str]`) — current schema is single-agent. Multi-agent would require an `agent_names` migration + multi-select UI; deferred until there's demand.
- Workspace-scoped agents (`<workspace>/.kiro/agents/`) — still global-only.
- Persisting `set_default` in config so reconfigure can warn on toggle changes.

## Notes for reviewers

- Plan executed via `wb run .workbench/kiro-vscode-integration/plan.md` — 11 tasks across 6 waves. Commit history includes merge commits per task.
- One follow-up cleanup commit (`d9e1c83`) removes a bogus `monkeypatch.setattr(inst, "CONFIG_FILE", ...)` line from the kiro_env fixture that was erroring all 9 new tests at setup; the surrounding `core.setup.CONFIG_FILE` / `core.config.CONFIG_FILE` patches already cover the path redirect. Squashing it into the kiro-noninteractive-installer commit before merging is optional.
