### PR TITLE
fix for phoenix traces

### DIFF
--- a/core/common.py
+++ b/core/common.py
@@ -14,7 +14,9 @@ import shutil
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO, Optional
 
@@ -422,6 +424,120 @@ def _inject_arize_project_name(span_dict: dict, project_name: str) -> dict:
     return payload
 
 
+def _otlp_attr_value_to_python(value: dict):
+    """Convert an OTLP AnyValue JSON object to a plain JSON value."""
+    if not isinstance(value, dict):
+        return value
+    if "stringValue" in value:
+        return value["stringValue"]
+    if "boolValue" in value:
+        return value["boolValue"]
+    if "intValue" in value:
+        try:
+            return int(value["intValue"])
+        except (TypeError, ValueError):
+            return value["intValue"]
+    if "doubleValue" in value:
+        return value["doubleValue"]
+    if "bytesValue" in value:
+        return value["bytesValue"]
+    if "arrayValue" in value:
+        values = value.get("arrayValue", {}).get("values", [])
+        return [_otlp_attr_value_to_python(item) for item in values]
+    if "kvlistValue" in value:
+        values = value.get("kvlistValue", {}).get("values", [])
+        return {item.get("key", ""): _otlp_attr_value_to_python(item.get("value", {})) for item in values}
+    return value
+
+
+def _otlp_attrs_to_dict(attrs: list) -> dict:
+    """Convert OTLP attribute arrays to the object shape Phoenix REST expects."""
+    result = {}
+    for attr in attrs or []:
+        key = attr.get("key")
+        if not key:
+            continue
+        result[key] = _otlp_attr_value_to_python(attr.get("value", {}))
+    return result
+
+
+def _unix_nano_to_iso(value) -> str:
+    """Convert OTLP Unix nanoseconds to an ISO-8601 UTC timestamp."""
+    try:
+        ns = int(value)
+    except (TypeError, ValueError):
+        ns = 0
+    seconds, nanos = divmod(ns, 1_000_000_000)
+    dt = datetime.fromtimestamp(seconds, tz=timezone.utc).replace(microsecond=nanos // 1000)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _phoenix_status_code(status: dict) -> str:
+    """Convert OTLP status code enum values to Phoenix status strings."""
+    if not isinstance(status, dict):
+        return "UNSET"
+    raw_code = status.get("code", 0)
+    if raw_code is None:
+        raw_code = 0
+    try:
+        code = int(raw_code)
+    except (TypeError, ValueError):
+        code = 0
+    return {1: "OK", 2: "ERROR"}.get(code, "UNSET")
+
+
+def _phoenix_span_kind(span: dict, attrs: dict) -> str:
+    """Prefer OpenInference span kind attributes, falling back to OTLP kind."""
+    oi_kind = attrs.get("openinference.span.kind")
+    if oi_kind:
+        return str(oi_kind).upper()
+    try:
+        otlp_kind = int(span.get("kind", 0))
+    except (TypeError, ValueError):
+        otlp_kind = 0
+    return {2: "SERVER", 3: "CLIENT", 4: "PRODUCER", 5: "CONSUMER"}.get(otlp_kind, "UNKNOWN")
+
+
+def _otlp_to_phoenix_payload(span_dict: dict) -> dict:
+    """Translate OTLP JSON into Phoenix's native REST create-spans schema."""
+    phoenix_spans = []
+    for rs in span_dict.get("resourceSpans", []):
+        resource_attrs = _otlp_attrs_to_dict(rs.get("resource", {}).get("attributes", []))
+        for ss in rs.get("scopeSpans", []):
+            for span in ss.get("spans", []):
+                attrs = {**resource_attrs, **_otlp_attrs_to_dict(span.get("attributes", []))}
+                item = {
+                    "name": span.get("name", "unknown"),
+                    "context": {
+                        "trace_id": span.get("traceId", ""),
+                        "span_id": span.get("spanId", ""),
+                    },
+                    "span_kind": _phoenix_span_kind(span, attrs),
+                    "start_time": _unix_nano_to_iso(span.get("startTimeUnixNano")),
+                    "end_time": _unix_nano_to_iso(span.get("endTimeUnixNano")),
+                    "status_code": _phoenix_status_code(span.get("status", {})),
+                    "status_message": (span.get("status", {}) or {}).get("message", ""),
+                    "attributes": attrs,
+                }
+                parent_id = span.get("parentSpanId")
+                if parent_id:
+                    item["parent_id"] = parent_id
+
+                events = []
+                for event in span.get("events", []) or []:
+                    events.append(
+                        {
+                            "name": event.get("name", "event"),
+                            "timestamp": _unix_nano_to_iso(event.get("timeUnixNano")),
+                            "attributes": _otlp_attrs_to_dict(event.get("attributes", [])),
+                        }
+                    )
+                if events:
+                    item["events"] = events
+                phoenix_spans.append(item)
+    return {"data": phoenix_spans}
+
+
 def _extract_span_name(span_dict: dict) -> str:
     """Extract the first span name from an OTLP payload."""
     try:
@@ -456,8 +572,9 @@ def send_span(span_dict: dict) -> bool:
             project = backend["project_name"]
             endpoint = backend["endpoint"]
             api_key = backend.get("api_key", "")
-            url = f"{endpoint}/v1/projects/{project}/spans"
-            body = _json.dumps(span_dict).encode("utf-8")
+            project_identifier = urllib.parse.quote(project, safe="")
+            url = f"{endpoint.rstrip('/')}/v1/projects/{project_identifier}/spans"
+            body = _json.dumps(_otlp_to_phoenix_payload(span_dict)).encode("utf-8")
             headers = {"Content-Type": "application/json"}
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"

--- a/core/common.py
+++ b/core/common.py
@@ -466,10 +466,10 @@ def _unix_nano_to_iso(value) -> str:
     try:
         ns = int(value)
     except (TypeError, ValueError):
-        ns = 0
+        raise ValueError(f"Invalid Unix nanosecond timestamp: {value!r}")
     seconds, nanos = divmod(ns, 1_000_000_000)
     dt = datetime.fromtimestamp(seconds, tz=timezone.utc).replace(microsecond=nanos // 1000)
-    return dt.isoformat().replace("+00:00", "Z")
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
 def _phoenix_status_code(status: dict) -> str:

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -13,6 +13,7 @@ from core.common import (
     FileLock,
     StateManager,
     _attrs_to_otlp,
+    _otlp_to_phoenix_payload,
     _resolve_kind,
     _to_otlp_attr_value,
     build_multi_span,
@@ -713,6 +714,77 @@ class TestBuildMultiSpan:
         assert scope["name"] == "override-scope"
 
 
+# ── Phoenix REST payload translation tests ────────────────────────────────
+
+
+class TestPhoenixPayloadTranslation:
+    def test_translates_otlp_payload_to_phoenix_create_spans_body(self):
+        payload = {
+            "resourceSpans": [
+                {
+                    "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": "svc"}}]},
+                    "scopeSpans": [
+                        {
+                            "scope": {"name": "scope"},
+                            "spans": [
+                                {
+                                    "traceId": "t" * 32,
+                                    "spanId": "s" * 16,
+                                    "parentSpanId": "p" * 16,
+                                    "name": "tool-call",
+                                    "kind": 1,
+                                    "startTimeUnixNano": "1000000000",
+                                    "endTimeUnixNano": "1500000000",
+                                    "attributes": [
+                                        {"key": "openinference.span.kind", "value": {"stringValue": "TOOL"}},
+                                        {"key": "count", "value": {"intValue": "3"}},
+                                    ],
+                                    "events": [
+                                        {
+                                            "name": "exception",
+                                            "timeUnixNano": "1250000000",
+                                            "attributes": [{"key": "message", "value": {"stringValue": "boom"}}],
+                                        }
+                                    ],
+                                    "status": {"code": 2, "message": "failed"},
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        result = _otlp_to_phoenix_payload(payload)
+
+        assert result == {
+            "data": [
+                {
+                    "name": "tool-call",
+                    "context": {"trace_id": "t" * 32, "span_id": "s" * 16},
+                    "span_kind": "TOOL",
+                    "start_time": "1970-01-01T00:00:01Z",
+                    "end_time": "1970-01-01T00:00:01.500000Z",
+                    "status_code": "ERROR",
+                    "status_message": "failed",
+                    "attributes": {
+                        "service.name": "svc",
+                        "openinference.span.kind": "TOOL",
+                        "count": 3,
+                    },
+                    "parent_id": "p" * 16,
+                    "events": [
+                        {
+                            "name": "exception",
+                            "timestamp": "1970-01-01T00:00:01.250000Z",
+                            "attributes": {"message": "boom"},
+                        }
+                    ],
+                }
+            ]
+        }
+
+
 # ── EnvConfig property tests ──────────────────────────────────────────────
 
 
@@ -801,8 +873,27 @@ class TestSendSpan:
     _SAMPLE_SPAN = {
         "resourceSpans": [
             {
-                "resource": {"attributes": []},
-                "scopeSpans": [{"scope": {"name": "test"}, "spans": [{"name": "test-span"}]}],
+                "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": "test-service"}}]},
+                "scopeSpans": [
+                    {
+                        "scope": {"name": "test"},
+                        "spans": [
+                            {
+                                "traceId": "0123456789abcdef0123456789abcdef",
+                                "spanId": "abcdef1234567890",
+                                "name": "test-span",
+                                "kind": 1,
+                                "startTimeUnixNano": "1000000000",
+                                "endTimeUnixNano": "2000000000",
+                                "attributes": [
+                                    {"key": "openinference.span.kind", "value": {"stringValue": "LLM"}},
+                                    {"key": "input.value", "value": {"stringValue": "hello"}},
+                                ],
+                                "status": {"code": 1},
+                            }
+                        ],
+                    }
+                ],
             }
         ]
     }
@@ -880,7 +971,27 @@ class TestSendSpan:
         assert req.get_header("Authorization") == "Bearer test-key"
         assert req.method == "POST"
         body = json.loads(req.data)
-        assert body == self._SAMPLE_SPAN
+        assert body == {
+            "data": [
+                {
+                    "name": "test-span",
+                    "context": {
+                        "trace_id": "0123456789abcdef0123456789abcdef",
+                        "span_id": "abcdef1234567890",
+                    },
+                    "span_kind": "LLM",
+                    "start_time": "1970-01-01T00:00:01Z",
+                    "end_time": "1970-01-01T00:00:02Z",
+                    "status_code": "OK",
+                    "status_message": "",
+                    "attributes": {
+                        "service.name": "test-service",
+                        "openinference.span.kind": "LLM",
+                        "input.value": "hello",
+                    },
+                }
+            ]
+        }
 
     @mock.patch("core.common.resolve_backend")
     @mock.patch("core.common.urllib.request.urlopen")

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -763,7 +763,7 @@ class TestPhoenixPayloadTranslation:
                     "name": "tool-call",
                     "context": {"trace_id": "t" * 32, "span_id": "s" * 16},
                     "span_kind": "TOOL",
-                    "start_time": "1970-01-01T00:00:01Z",
+                    "start_time": "1970-01-01T00:00:01.000000Z",
                     "end_time": "1970-01-01T00:00:01.500000Z",
                     "status_code": "ERROR",
                     "status_message": "failed",
@@ -783,6 +783,29 @@ class TestPhoenixPayloadTranslation:
                 }
             ]
         }
+
+    def test_rejects_missing_phoenix_span_timestamp(self):
+        payload = {
+            "resourceSpans": [
+                {
+                    "scopeSpans": [
+                        {
+                            "spans": [
+                                {
+                                    "traceId": "t" * 32,
+                                    "spanId": "s" * 16,
+                                    "name": "missing-time",
+                                    "endTimeUnixNano": "2000000000",
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+
+        with pytest.raises(ValueError, match="Invalid Unix nanosecond timestamp"):
+            _otlp_to_phoenix_payload(payload)
 
 
 # ── EnvConfig property tests ──────────────────────────────────────────────
@@ -980,8 +1003,8 @@ class TestSendSpan:
                         "span_id": "abcdef1234567890",
                     },
                     "span_kind": "LLM",
-                    "start_time": "1970-01-01T00:00:01Z",
-                    "end_time": "1970-01-01T00:00:02Z",
+                    "start_time": "1970-01-01T00:00:01.000000Z",
+                    "end_time": "1970-01-01T00:00:02.000000Z",
                     "status_code": "OK",
                     "status_message": "",
                     "attributes": {


### PR DESCRIPTION
## Summary

Fixes Phoenix trace export by translating the existing OTLP-style span payloads into Phoenix's native REST create-spans request shape before posting to `POST /v1/projects/{project}/spans`.

## Root Cause

The Phoenix branch of `send_span()` posted OTLP JSON with `resourceSpans` to Phoenix's REST spans endpoint. That endpoint expects a JSON body shaped as `{\"data\": [...]}`, so current Phoenix versions reject the request with a 422 response.

## Changes

- Convert OTLP span/resource attributes into Phoenix REST span objects.
- Map trace/span context IDs, parent IDs, timestamps, span kind, status, attributes, and events.
- Keep Arize export behavior unchanged.
- Add tests for the Phoenix REST payload shape and send path.

Fixes #44.

## Validation

- `UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest -q` -> `1597 passed`
- `UV_CACHE_DIR=/private/tmp/uv-cache PRE_COMMIT_HOME=/private/tmp/pre-commit-cache uv run pre-commit run --all-files` -> passed