### PR TITLE
Harden Cursor Cloud tracing bootstrap

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,3 +1,3 @@
 {
-  "install": "ARIZE_API_KEY=\"${ARIZE_API_KEY:-}\" ARIZE_SPACE_ID=\"${ARIZE_SPACE_ID:-}\" PHOENIX_ENDPOINT=\"${PHOENIX_ENDPOINT:-}\" ARIZE_PROJECT_NAME=\"${ARIZE_PROJECT_NAME:-cursor}\" bash .cursor/hooks/arize-cursor-cloud-setup.sh"
+  "install": "ARIZE_API_KEY=\"${ARIZE_API_KEY:-}\" ARIZE_SPACE_ID=\"${ARIZE_SPACE_ID:-}\" PHOENIX_ENDPOINT=\"${PHOENIX_ENDPOINT:-}\" ARIZE_PROJECT_NAME=\"${ARIZE_PROJECT_NAME:-cursor}\" ARIZE_INSTALL_BRANCH=\"${ARIZE_INSTALL_BRANCH:-main}\" ARIZE_INSTALL_URL=\"${ARIZE_INSTALL_URL:-}\" bash .cursor/hooks/arize-cursor-cloud-setup.sh"
 }

--- a/.cursor/hooks/arize-cloud-env.example
+++ b/.cursor/hooks/arize-cloud-env.example
@@ -6,6 +6,11 @@ ARIZE_API_KEY=
 ARIZE_SPACE_ID=
 ARIZE_PROJECT_NAME=cursor
 
+# Optional: pin Cloud Agents to a branch or raw installer URL while testing
+# unmerged bootstrap changes. Omit these when main has the desired installer.
+# ARIZE_INSTALL_BRANCH=main
+# ARIZE_INSTALL_URL=
+
 # Phoenix alternative:
 # PHOENIX_ENDPOINT=http://localhost:6006
 # ARIZE_API_KEY=

--- a/.cursor/hooks/arize-cursor-cloud-setup.sh
+++ b/.cursor/hooks/arize-cursor-cloud-setup.sh
@@ -5,6 +5,56 @@ if [[ -z "${PHOENIX_ENDPOINT:-}" && ( -z "${ARIZE_API_KEY:-}" || -z "${ARIZE_SPA
     echo "[arize] Warning: set ARIZE_API_KEY+ARIZE_SPACE_ID or PHOENIX_ENDPOINT as Cursor Cloud secrets." >&2
 fi
 
+run_as_root() {
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        "$@"
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo "$@"
+    else
+        return 1
+    fi
+}
+
+ensure_python_venv_support() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        return 0
+    fi
+
+    probe_dir="$(mktemp -d)"
+    if python3 -m venv "$probe_dir/venv" >/dev/null 2>&1; then
+        rm -rf "$probe_dir"
+        return 0
+    fi
+    rm -rf "$probe_dir"
+
+    if ! command -v apt-get >/dev/null 2>&1; then
+        echo "[arize] Warning: python3 venv support is missing and apt-get is unavailable." >&2
+        return 0
+    fi
+
+    echo "[arize] Installing python3-venv for Cursor Cloud bootstrap..." >&2
+    run_as_root apt-get update
+    if ! run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y python3-venv; then
+        versioned_pkg="$(python3 - <<'PY'
+import sys
+print(f"python{sys.version_info.major}.{sys.version_info.minor}-venv")
+PY
+)"
+        run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y "$versioned_pkg"
+    fi
+}
+
+remove_incomplete_harness_venv() {
+    venv_dir="$HOME/.arize/harness/venv"
+    if [[ -d "$venv_dir" && ! -x "$venv_dir/bin/pip" && ! -x "$venv_dir/Scripts/pip.exe" ]]; then
+        echo "[arize] Removing incomplete harness venv at $venv_dir" >&2
+        rm -rf "$venv_dir"
+    fi
+}
+
+ensure_python_venv_support
+remove_incomplete_harness_venv
+
 branch="${ARIZE_INSTALL_BRANCH:-main}"
 url="${ARIZE_INSTALL_URL:-https://raw.githubusercontent.com/Arize-ai/coding-harness-tracing/${branch}/install.sh}"
 tmp="$(mktemp)"

--- a/install.sh
+++ b/install.sh
@@ -177,6 +177,10 @@ PYEOF
 
 setup_venv() {
     local python_cmd="$1"
+    if venv_python &>/dev/null && ! venv_pip &>/dev/null; then
+        warn "Existing venv is missing pip — recreating ${VENV_DIR}"
+        rm -rf "$VENV_DIR"
+    fi
     if ! venv_python &>/dev/null; then
         info "Creating venv..."
         "$python_cmd" -m venv "$VENV_DIR" 2>/dev/null || {

--- a/tests/core/test_shell_router.py
+++ b/tests/core/test_shell_router.py
@@ -301,6 +301,10 @@ class TestDispatchLogic:
     def test_update_calls_pip_install(self):
         assert "pip" in self.text and "install" in self.text
 
+    def test_setup_venv_recreates_incomplete_venv(self):
+        assert "Existing venv is missing pip" in self.text
+        assert 'rm -rf "$VENV_DIR"' in self.text
+
     def test_update_lists_installed_harnesses(self):
         assert "list_installed_harnesses" in self.text
 

--- a/tests/tracing/cursor/test_install_cursor.py
+++ b/tests/tracing/cursor/test_install_cursor.py
@@ -26,9 +26,12 @@ def fake_home(tmp_path, monkeypatch):
     """Redirect Path.home() to tmp_path so all file writes land in a temp dir.
 
     Also patches the module-level constants in install.py and core.setup that
-    derive from Path.home() so they point at the temp tree.
+    derive from Path.home() so they point at the temp tree. Cursor project-hook
+    paths are intentionally relative, so run each test from tmp_path to keep
+    install/uninstall helpers from touching the repository's real .cursor files.
     """
     monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.chdir(tmp_path)
 
     # Patch INSTALL_DIR / VENV_DIR / CONFIG_FILE in core.setup
     import core.setup as setup_mod

--- a/tests/tracing/cursor/test_install_cursor.py
+++ b/tests/tracing/cursor/test_install_cursor.py
@@ -393,15 +393,24 @@ class TestCloudAgentInstall:
         setup_script = repo / ".cursor" / "hooks" / "arize-cursor-cloud-setup.sh"
         assert setup_script.is_file()
         assert setup_script.stat().st_mode & 0o111
-        assert "ARIZE_API_KEY" in setup_script.read_text()
+        setup_text = setup_script.read_text()
+        assert "ARIZE_API_KEY" in setup_text
+        assert "ensure_python_venv_support" in setup_text
+        assert "python3-venv" in setup_text
+        assert "remove_incomplete_harness_venv" in setup_text
         env_example = repo / ".cursor" / "hooks" / "arize-cloud-env.example"
         assert env_example.is_file()
-        assert "ARIZE_API_KEY=" in env_example.read_text()
+        env_example_text = env_example.read_text()
+        assert "ARIZE_API_KEY=" in env_example_text
+        assert "ARIZE_INSTALL_BRANCH=main" in env_example_text
+        assert "ARIZE_INSTALL_URL=" in env_example_text
 
         environment = json.loads((repo / ".cursor" / "environment.json").read_text())
         assert environment["install"] == cursor_install.CLOUD_SETUP_COMMAND
         assert "ARIZE_SPACE_ID" in environment["install"]
         assert "PHOENIX_ENDPOINT" in environment["install"]
+        assert "ARIZE_INSTALL_BRANCH" in environment["install"]
+        assert "ARIZE_INSTALL_URL" in environment["install"]
         assert not (fake_home / ".arize" / "harness" / "config.yaml").exists()
 
     def test_existing_environment_install_is_prefixed(self, fake_home, monkeypatch):

--- a/tracing/cursor/README.md
+++ b/tracing/cursor/README.md
@@ -87,6 +87,10 @@ ARIZE_PROJECT_NAME=cursor
 ```
 
 Phoenix can be used instead with `PHOENIX_ENDPOINT` and optional `ARIZE_API_KEY`.
+`ARIZE_INSTALL_BRANCH` is optional; use it only when Cloud Agents must install from a branch other than `main`
+(for example, while validating unmerged bootstrap changes). `ARIZE_INSTALL_URL` can also pin the raw installer URL.
+The generated bootstrap checks for Python venv support and installs `python3-venv` on apt-based Cloud images when
+needed before running the harness installer.
 
 After running the installer, commit the generated `.cursor/hooks.json`, `.cursor/hooks/arize-hook-cursor.sh`,
 `.cursor/hooks/arize-cursor-cloud-setup.sh`, `.cursor/hooks/arize-cloud-env.example`, and `.cursor/environment.json`

--- a/tracing/cursor/install.py
+++ b/tracing/cursor/install.py
@@ -45,6 +45,8 @@ CLOUD_SETUP_COMMAND = (
     'ARIZE_SPACE_ID="${ARIZE_SPACE_ID:-}" '
     'PHOENIX_ENDPOINT="${PHOENIX_ENDPOINT:-}" '
     'ARIZE_PROJECT_NAME="${ARIZE_PROJECT_NAME:-cursor}" '
+    'ARIZE_INSTALL_BRANCH="${ARIZE_INSTALL_BRANCH:-main}" '
+    'ARIZE_INSTALL_URL="${ARIZE_INSTALL_URL:-}" '
     f"bash {PROJECT_CLOUD_SETUP_SCRIPT.as_posix()}"
 )
 
@@ -228,6 +230,56 @@ if [[ -z "${PHOENIX_ENDPOINT:-}" && ( -z "${ARIZE_API_KEY:-}" || -z "${ARIZE_SPA
     echo "[arize] Warning: set ARIZE_API_KEY+ARIZE_SPACE_ID or PHOENIX_ENDPOINT as Cursor Cloud secrets." >&2
 fi
 
+run_as_root() {
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        "$@"
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo "$@"
+    else
+        return 1
+    fi
+}
+
+ensure_python_venv_support() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        return 0
+    fi
+
+    probe_dir="$(mktemp -d)"
+    if python3 -m venv "$probe_dir/venv" >/dev/null 2>&1; then
+        rm -rf "$probe_dir"
+        return 0
+    fi
+    rm -rf "$probe_dir"
+
+    if ! command -v apt-get >/dev/null 2>&1; then
+        echo "[arize] Warning: python3 venv support is missing and apt-get is unavailable." >&2
+        return 0
+    fi
+
+    echo "[arize] Installing python3-venv for Cursor Cloud bootstrap..." >&2
+    run_as_root apt-get update
+    if ! run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y python3-venv; then
+        versioned_pkg="$(python3 - <<'PY'
+import sys
+print(f"python{sys.version_info.major}.{sys.version_info.minor}-venv")
+PY
+)"
+        run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y "$versioned_pkg"
+    fi
+}
+
+remove_incomplete_harness_venv() {
+    venv_dir="$HOME/.arize/harness/venv"
+    if [[ -d "$venv_dir" && ! -x "$venv_dir/bin/pip" && ! -x "$venv_dir/Scripts/pip.exe" ]]; then
+        echo "[arize] Removing incomplete harness venv at $venv_dir" >&2
+        rm -rf "$venv_dir"
+    fi
+}
+
+ensure_python_venv_support
+remove_incomplete_harness_venv
+
 branch="${ARIZE_INSTALL_BRANCH:-main}"
 url="${ARIZE_INSTALL_URL:-https://raw.githubusercontent.com/Arize-ai/coding-harness-tracing/${branch}/install.sh}"
 tmp="$(mktemp)"
@@ -265,6 +317,11 @@ def _write_cloud_env_example() -> None:
 ARIZE_API_KEY=
 ARIZE_SPACE_ID=
 ARIZE_PROJECT_NAME=cursor
+
+# Optional: pin Cloud Agents to a branch or raw installer URL while testing
+# unmerged bootstrap changes. Omit these when main has the desired installer.
+# ARIZE_INSTALL_BRANCH=main
+# ARIZE_INSTALL_URL=
 
 # Phoenix alternative:
 # PHOENIX_ENDPOINT=http://localhost:6006

--- a/tracing/cursor/skills/manage-cursor-tracing/SKILL.md
+++ b/tracing/cursor/skills/manage-cursor-tracing/SKILL.md
@@ -160,7 +160,7 @@ Cloud Agents run in a separate remote VM. Local `~/.cursor/hooks.json`, `~/.ariz
 ./install.sh cursor --cloud-agent
 ```
 
-This writes repo-local `.cursor/hooks.json`, `.cursor/hooks/arize-hook-cursor.sh`, `.cursor/hooks/arize-cursor-cloud-setup.sh`, `.cursor/hooks/arize-cloud-env.example`, and `.cursor/environment.json`. The generated environment install command surfaces `ARIZE_API_KEY`, `ARIZE_SPACE_ID`, `PHOENIX_ENDPOINT`, and `ARIZE_PROJECT_NAME` without committing secret values.
+This writes repo-local `.cursor/hooks.json`, `.cursor/hooks/arize-hook-cursor.sh`, `.cursor/hooks/arize-cursor-cloud-setup.sh`, `.cursor/hooks/arize-cloud-env.example`, and `.cursor/environment.json`. The generated environment install command surfaces `ARIZE_API_KEY`, `ARIZE_SPACE_ID`, `PHOENIX_ENDPOINT`, `ARIZE_PROJECT_NAME`, `ARIZE_INSTALL_BRANCH`, and `ARIZE_INSTALL_URL` without committing secret values.
 
 Do not copy local credentials from `~/.arize/harness/config.yaml` into `.cursor/environment.json`; that file is normally committed. Tell users to commit the generated `.cursor/` bootstrap files and configure real values as Cursor Cloud environment secrets.
 
@@ -173,6 +173,7 @@ ARIZE_PROJECT_NAME=cursor
 ```
 
 For Phoenix, configure `PHOENIX_ENDPOINT` instead.
+`ARIZE_INSTALL_BRANCH` is optional; set it only to pin Cloud Agents to an unmerged branch or non-main installer. The generated bootstrap installs missing `python3-venv` support on apt-based Cloud images before running the harness installer.
 
 ### Validate
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Install missing Python venv support during Cursor Cloud bootstrap on apt-based images
- Remove incomplete harness venvs so retries recover after failed ensurepip setup
- Surface optional `ARIZE_INSTALL_BRANCH` / `ARIZE_INSTALL_URL` pinning in generated Cloud env config
- Update docs and tests for Cursor Cloud bootstrap behavior
- Isolate Cursor install tests from repo-local `.cursor` files so tests do not mutate tracked hook configuration

## Testing
- `.venv/bin/python -m pytest tests/tracing/cursor/test_install_cursor.py tests/core/test_shell_router.py`
- Confirmed `git status --short` after the focused test run only showed the intentional test fixture edit, with no `.cursor/hooks.json` mutation
- `bash -n install.sh && bash -n .cursor/hooks/arize-cursor-cloud-setup.sh && bash -n .cursor/hooks/arize-hook-cursor.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-620019a6-ea60-4d1d-937f-db28cc45c215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-620019a6-ea60-4d1d-937f-db28cc45c215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

