### PR TITLE
Fix Cursor orphan span parenting

### DIFF
--- a/tests/tracing/cursor/test_cursor_hook.py
+++ b/tests/tracing/cursor/test_cursor_hook.py
@@ -49,6 +49,22 @@ def captured_spans():
         yield sent
 
 
+def _span(payload: dict) -> dict:
+    return payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+
+
+def _attrs(span: dict) -> dict:
+    return {a["key"]: a["value"] for a in span["attributes"]}
+
+
+def _span_named(sent: list, name: str) -> dict:
+    for payload in sent:
+        span = _span(payload)
+        if span["name"] == name:
+            return span
+    raise AssertionError(f"span {name!r} not found")
+
+
 # ---------------------------------------------------------------------------
 # _print_permissive tests
 # ---------------------------------------------------------------------------
@@ -257,7 +273,6 @@ class TestHandleBeforeSubmitPrompt:
         with (
             mock.patch("tracing.cursor.hooks.handlers.get_timestamp_ms", return_value=5000),
             mock.patch("tracing.cursor.hooks.handlers.span_id_16", return_value="aabb" * 4),
-            mock.patch("tracing.cursor.hooks.handlers.gen_root_span_save") as save_mock,
         ):
             _dispatch(
                 "beforeSubmitPrompt",
@@ -270,9 +285,9 @@ class TestHandleBeforeSubmitPrompt:
                 },
             )
 
-        save_mock.assert_called_once_with("gen-1", "aabb" * 4)
+        assert adapter.gen_root_span_get("gen-1") == "aabb" * 4
         assert len(captured_spans) == 1
-        root0 = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        root0 = _span(captured_spans[0])
         assert root0["name"] == "User Prompt"
         root_attrs0 = {a["key"]: a["value"] for a in root0["attributes"]}
         assert root_attrs0["input.value"]["stringValue"] == "fix the bug"
@@ -516,10 +531,12 @@ class TestHandleAfterAgentResponse:
                 },
             )
 
-        assert len(captured_spans) == 1
-        span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        assert len(captured_spans) == 2
+        assert _span(captured_spans[0])["name"] == "Cursor Session"
+        span = _span_named(captured_spans, "Agent Response")
         assert span["name"] == "Agent Response"
-        attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert span["parentSpanId"] == _span(captured_spans[0])["spanId"]
+        attrs = _attrs(span)
         assert attrs["openinference.span.kind"]["stringValue"] == "LLM"
         assert attrs["output.value"]["stringValue"] == "I found the issue"
 
@@ -579,10 +596,7 @@ class TestHandleAfterShellExecution:
                 },
             )
 
-        attrs = {
-            a["key"]: a["value"]
-            for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
-        }
+        attrs = _attrs(_span_named(captured_spans, "Shell"))
         assert attrs["input.value"]["stringValue"] == "new_cmd"
 
     def test_no_popped_state_uses_now(self, captured_spans, monkeypatch):
@@ -602,7 +616,7 @@ class TestHandleAfterShellExecution:
                 },
             )
 
-        span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        span = _span_named(captured_spans, "Shell")
         # start_ms = "3000" -> ns = "3000000000"
         assert span["startTimeUnixNano"] == "3000000000"
 
@@ -617,10 +631,7 @@ class TestHandleAfterShellExecution:
         ):
             _dispatch(fixture["hook_event_name"], fixture)
 
-        attrs = {
-            a["key"]: a["value"]
-            for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
-        }
+        attrs = _attrs(_span_named(captured_spans, "Shell"))
         assert attrs["input.value"]["stringValue"] == "ls -la"
         assert attrs["output.value"]["stringValue"] == "total 0"
         assert attrs["shell.exit_code"]["stringValue"] == "0"
@@ -671,7 +682,7 @@ class TestHandleStop:
             _dispatch("stop", {"conversation_id": "c1"})
 
         cleanup.assert_not_called()
-        assert len(captured_spans) == 1
+        assert [_span(s)["name"] for s in captured_spans] == ["Cursor Session", "Agent Stop"]
 
     def test_optional_attrs_omitted(self, captured_spans, monkeypatch):
         """Status and loop_count omitted when empty."""
@@ -683,7 +694,7 @@ class TestHandleStop:
         ):
             _dispatch("stop", {"conversation_id": "c1", "generation_id": "g1"})
 
-        attr_keys = {a["key"] for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]}
+        attr_keys = {a["key"] for a in _span_named(captured_spans, "Agent Stop")["attributes"]}
         assert "cursor.stop.status" not in attr_keys
         assert "cursor.stop.loop_count" not in attr_keys
 
@@ -885,11 +896,12 @@ class TestHandleAfterMcpExecution:
                 },
             )
 
-        assert len(captured_spans) == 1
-        span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
-        attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert len(captured_spans) == 2
+        span = _span_named(captured_spans, "MCP: list_repos")
+        attrs = _attrs(span)
         assert attrs["tool.name"]["stringValue"] == "list_repos"
         assert span["name"] == "MCP: list_repos"
+        assert span["parentSpanId"] == _span(captured_spans[0])["spanId"]
 
 
 # ---------------------------------------------------------------------------
@@ -977,11 +989,41 @@ class TestHandleAfterFileEdit:
                 },
             )
 
-        attrs = {
-            a["key"]: a["value"]
-            for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
-        }
+        attrs = _attrs(_span_named(captured_spans, "File Edit"))
         assert attrs["input.value"]["stringValue"] == "/foo/bar.py"
+
+    def test_orphan_tool_events_share_session_fallback_root(self, captured_spans, monkeypatch):
+        """Cloud tool events without a prompt root are grouped under one session root."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("tracing.cursor.hooks.handlers.get_timestamp_ms", return_value=2000),
+            mock.patch("tracing.cursor.hooks.handlers.span_id_16", side_effect=["1111" * 4, "2222" * 4]),
+            mock.patch("tracing.cursor.hooks.handlers.gen_root_span_get", return_value=""),
+        ):
+            _dispatch(
+                "afterFileEdit",
+                {
+                    "conversation_id": "conv-1",
+                    "generation_id": "gen-1",
+                    "file_path": "/foo/bar.py",
+                },
+            )
+            _dispatch(
+                "afterFileEdit",
+                {
+                    "conversationId": "conv-1",
+                    "generationId": "gen-2",
+                    "filePath": "/foo/baz.py",
+                },
+            )
+
+        names = [_span(s)["name"] for s in captured_spans]
+        assert names == ["Cursor Session", "File Edit", "File Edit"]
+        root = _span(captured_spans[0])
+        for payload in captured_spans[1:]:
+            child = _span(payload)
+            assert child["traceId"] == root["traceId"]
+            assert child["parentSpanId"] == root["spanId"]
 
 
 # ---------------------------------------------------------------------------
@@ -1069,10 +1111,7 @@ class TestHandleAfterTabFileEdit:
                 },
             )
 
-        attrs = {
-            a["key"]: a["value"]
-            for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
-        }
+        attrs = _attrs(_span_named(captured_spans, "Tab File Edit"))
         assert attrs["input.value"]["stringValue"] == "/src/main.ts"
 
 
@@ -1408,7 +1447,7 @@ class TestHandleSessionStart:
                 },
             )
 
-        attr_keys = {a["key"] for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]}
+        attr_keys = {a["key"] for a in _span_named(captured_spans, "Session Start")["attributes"]}
         assert "cursor.session.cwd" not in attr_keys
 
 
@@ -1467,10 +1506,7 @@ class TestHandlePostToolUse:
                 },
             )
 
-        attrs = {
-            a["key"]: a["value"]
-            for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
-        }
+        attrs = _attrs(_span_named(captured_spans, "Tool: custom_runner"))
         # custom_runner is not in _SHELL_TOOL_NAMES so command field is NOT used as input
         # tool_input comes from the standard extraction keys
         assert attrs["output.value"]["stringValue"] == "total 40\ndrwxr-xr-x ..."
@@ -1490,7 +1526,7 @@ class TestHandlePostToolUse:
                 },
             )
 
-        attr_keys = {a["key"] for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]}
+        attr_keys = {a["key"] for a in _span_named(captured_spans, "Tool Use")["attributes"]}
         assert "tool.name" not in attr_keys
         assert "input.value" not in attr_keys
         assert "output.value" not in attr_keys
@@ -1553,10 +1589,11 @@ class TestHandlePostToolUse:
                 },
             )
 
-        assert len(captured_spans) == 1
-        span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
-        attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert len(captured_spans) == 2
+        span = _span_named(captured_spans, "Tool: glob")
+        attrs = _attrs(span)
         assert span["name"] == "Tool: glob"
+        assert span["parentSpanId"] == _span(captured_spans[0])["spanId"]
         assert attrs["tool.name"]["stringValue"] == "glob"
         assert attrs["input.value"]["stringValue"] == '{"pattern": "*.py"}'
 
@@ -1644,10 +1681,7 @@ class TestHandleStopTokenCounts:
                 },
             )
 
-        attrs = {
-            a["key"]: a["value"]
-            for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
-        }
+        attrs = _attrs(_span_named(captured_spans, "Agent Stop"))
         assert attrs["llm.token_count.prompt"]["intValue"] == 100
         assert "llm.token_count.completion" not in attrs
         assert "llm.token_count.cache_read" not in attrs
@@ -1724,8 +1758,8 @@ class TestHandleSessionEnd:
                 },
             )
 
-        assert len(captured_spans) == 1
-        attr_keys = {a["key"] for a in captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]}
+        assert len(captured_spans) == 2
+        attr_keys = {a["key"] for a in _span_named(captured_spans, "Session End")["attributes"]}
         assert "session.id" in attr_keys
         assert "cursor.conversation.id" in attr_keys
         assert "cursor.session.duration_ms" not in attr_keys
@@ -2018,7 +2052,7 @@ class TestDeferredLlmSpan:
                 },
             )
 
-        assert len(captured_spans) == 0
+        assert [_span(s)["name"] for s in captured_spans] == ["Cursor Session"]
 
         with mock.patch("tracing.cursor.hooks.handlers.get_timestamp_ms", return_value=4000):
             _dispatch(
@@ -2057,10 +2091,10 @@ class TestDeferredLlmSpan:
                 },
             )
 
-        # Only the Agent Stop span is sent (no deferred LLM existed).
+        # Fallback root plus Agent Stop are sent (no deferred LLM existed).
         names = [s["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["name"] for s in captured_spans]
-        assert names == ["Agent Stop"]
-        stop_attrs = _attrs(captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
+        assert names == ["Cursor Session", "Agent Stop"]
+        stop_attrs = _attrs(_span_named(captured_spans, "Agent Stop"))
         assert stop_attrs["openinference.span.kind"]["stringValue"] == "CHAIN"
         assert stop_attrs["llm.token_count.prompt"]["intValue"] == 100
         assert stop_attrs["llm.token_count.completion"]["intValue"] == 50
@@ -2181,8 +2215,8 @@ class TestDeferredLlmSpan:
             )
 
         names = [s["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["name"] for s in captured_spans]
-        assert names == ["Session End"]
-        attrs = _attrs(captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
+        assert names == ["Cursor Session", "Session End"]
+        attrs = _attrs(_span_named(captured_spans, "Session End"))
         assert attrs["llm.token_count.prompt"]["intValue"] == 200
         assert attrs["llm.token_count.completion"]["intValue"] == 75
         assert attrs["llm.token_count.total"]["intValue"] == 275

--- a/tracing/cursor/hooks/adapter.py
+++ b/tracing/cursor/hooks/adapter.py
@@ -8,6 +8,7 @@ pairs.
 
 Replaces cursor-tracing/hooks/common.sh (195 lines).
 """
+
 import hashlib
 import os
 import re
@@ -39,6 +40,37 @@ def trace_id_from_generation(gen_id: str) -> str:
     so all spans in the same generation share a trace_id.
     """
     return hashlib.md5(gen_id.encode()).hexdigest()[:32]
+
+
+def span_id_from_seed(seed: str) -> str:
+    """Deterministic 16-hex span ID from a stable seed."""
+    return hashlib.sha256(seed.encode()).hexdigest()[:16]
+
+
+def fallback_root_span_id(trace_id: str) -> str:
+    """Stable root span ID used when Cursor omits a prompt/root event."""
+    return span_id_from_seed(f"cursor-fallback-root:{trace_id}")
+
+
+def fallback_root_mark_sent(trace_id: str) -> bool:
+    """Mark a fallback root as sent.
+
+    Returns True only for the first process that marks the root. Cursor invokes
+    each hook in a fresh process, so this file marker prevents duplicate root
+    spans while keeping all orphan tool spans parented to the same deterministic
+    root ID.
+    """
+    if not trace_id:
+        return False
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    key = sanitize(trace_id)
+    marker = STATE_DIR / f"fallback_root_{key}.sent"
+    lock_path = STATE_DIR / f".lock_fallback_root_{key}"
+    with FileLock(lock_path):
+        if marker.exists():
+            return False
+        marker.write_text(fallback_root_span_id(trace_id))
+        return True
 
 
 def span_id_16() -> str:

--- a/tracing/cursor/hooks/handlers.py
+++ b/tracing/cursor/hooks/handlers.py
@@ -7,6 +7,7 @@ Input contract: JSON on stdin, all 15 events (IDE + CLI) routed here.
 stdout: MUST print permissive JSON response, even on error.
 stderr: redirected to ARIZE_LOG_FILE before dispatch.
 """
+
 import json
 import sys
 
@@ -15,6 +16,8 @@ from tracing.cursor.hooks.adapter import (
     SCOPE_NAME,
     SERVICE_NAME,
     check_requirements,
+    fallback_root_mark_sent,
+    fallback_root_span_id,
     gen_root_span_get,
     gen_root_span_save,
     sanitize,
@@ -85,6 +88,16 @@ def _event_name(input_json: dict) -> str:
     return _jq_str(input_json, "hook_event_name", "hookEventName", "event_name", "eventName", "event")
 
 
+def _conversation_id(input_json: dict) -> str:
+    """Extract the stable Cursor conversation/session ID across payload variants."""
+    return _jq_str(input_json, "conversation_id", "conversationId", "session_id", "sessionId")
+
+
+def _generation_id(input_json: dict) -> str:
+    """Extract the Cursor generation/turn ID across payload variants."""
+    return _jq_str(input_json, "generation_id", "generationId", "turn_id", "turnId")
+
+
 def _is_cursor_ide_hook_payload(input_json: dict) -> bool:
     """Return True when the stdin JSON looks like Cursor IDE (vs CLI) hook payloads.
 
@@ -116,6 +129,57 @@ def _trace_id_from_event(gen_id: str, conversation_id: str) -> str:
     return ""
 
 
+def _fallback_trace_id(gen_id: str, conversation_id: str, default_trace_id: str) -> str:
+    """Use the session ID as the trace key when no prompt/root span exists."""
+    if conversation_id:
+        return trace_id_from_generation(conversation_id)
+    if gen_id:
+        return trace_id_from_generation(gen_id)
+    return default_trace_id
+
+
+def _ensure_fallback_root(trace_id: str, conversation_id: str, now_ms: int) -> str:
+    """Emit one deterministic CHAIN root for orphan Cursor events."""
+    if not trace_id:
+        return ""
+
+    root_span_id = fallback_root_span_id(trace_id)
+    if fallback_root_mark_sent(trace_id):
+        attrs = {
+            "openinference.span.kind": "CHAIN",
+        }
+        if conversation_id:
+            attrs["session.id"] = conversation_id
+            attrs["cursor.conversation.id"] = conversation_id
+
+        span = build_span(
+            "Cursor Session",
+            "CHAIN",
+            root_span_id,
+            trace_id,
+            "",
+            now_ms,
+            now_ms,
+            attrs,
+            SERVICE_NAME,
+            SCOPE_NAME,
+        )
+        send_span(span)
+        log(f"fallback root: span {root_span_id} (trace={trace_id})")
+
+    return root_span_id
+
+
+def _root_parent_context(gen_id: str, conversation_id: str, trace_id: str, now_ms: int) -> "tuple[str, str]":
+    """Return trace ID and parent span ID, creating a fallback root when needed."""
+    parent = gen_root_span_get(gen_id)
+    if parent:
+        return trace_id, parent
+
+    fallback_trace = _fallback_trace_id(gen_id, conversation_id, trace_id)
+    return fallback_trace, _ensure_fallback_root(fallback_trace, conversation_id, now_ms)
+
+
 # ---------------------------------------------------------------------------
 # Dispatch
 # ---------------------------------------------------------------------------
@@ -123,8 +187,8 @@ def _trace_id_from_event(gen_id: str, conversation_id: str) -> str:
 
 def _dispatch(event: str, input_json: dict) -> None:
     """Route event to the appropriate handler."""
-    conversation_id = input_json.get("conversation_id", "")
-    gen_id = input_json.get("generation_id", "")
+    conversation_id = _conversation_id(input_json)
+    gen_id = _generation_id(input_json)
 
     # Early exit: tracing disabled
     if not env.trace_enabled:
@@ -228,7 +292,7 @@ def _handle_before_submit_prompt(input_json, conversation_id, gen_id, trace_id, 
 def _handle_after_agent_response(input_json, conversation_id, gen_id, trace_id, now_ms):
     """Defers LLM span until stop (so per-turn tokens land on it). IDE also sends deferred User Prompt CHAIN."""
     sid = span_id_16()
-    parent = gen_root_span_get(gen_id)
+    trace_id, parent = _root_parent_context(gen_id, conversation_id, trace_id, now_ms)
 
     # "text" is the documented field; fall back to "response"/"output" for compat
     response = _jq_str(input_json, "text", "response", "output")
@@ -329,7 +393,7 @@ def _handle_after_agent_response(input_json, conversation_id, gen_id, trace_id, 
 def _handle_after_agent_thought(input_json, conversation_id, gen_id, trace_id, now_ms):
     """CHAIN span for thinking. Replaces bash lines 138-158."""
     sid = span_id_16()
-    parent = gen_root_span_get(gen_id)
+    trace_id, parent = _root_parent_context(gen_id, conversation_id, trace_id, now_ms)
 
     thought = _jq_str(input_json, "thought", "thinking", "text")
 
@@ -385,7 +449,7 @@ def _handle_before_shell_execution(input_json, conversation_id, gen_id, trace_id
 def _handle_after_shell_execution(input_json, conversation_id, gen_id, trace_id, now_ms):
     """Merge with before state, create TOOL span. Replaces bash lines 184-232."""
     sid = span_id_16()
-    parent = gen_root_span_get(gen_id)
+    trace_id, parent = _root_parent_context(gen_id, conversation_id, trace_id, now_ms)
     popped = state_pop(f"shell_{sanitize(gen_id)}") if gen_id else None
 
     if popped:
@@ -467,7 +531,7 @@ def _handle_before_mcp_execution(input_json, conversation_id, gen_id, trace_id, 
 def _handle_after_mcp_execution(input_json, conversation_id, gen_id, trace_id, now_ms):
     """Merge with before state, create TOOL span. Replaces bash lines 262-312."""
     sid = span_id_16()
-    parent = gen_root_span_get(gen_id)
+    trace_id, parent = _root_parent_context(gen_id, conversation_id, trace_id, now_ms)
     popped = state_pop(f"mcp_{sanitize(gen_id)}") if gen_id else None
 
     if popped:
@@ -521,7 +585,7 @@ def _handle_after_mcp_execution(input_json, conversation_id, gen_id, trace_id, n
 def _handle_before_read_file(input_json, conversation_id, gen_id, trace_id, now_ms):
     """TOOL span for file read. Replaces bash lines 317-339."""
     sid = span_id_16()
-    parent = gen_root_span_get(gen_id)
+    trace_id, parent = _root_parent_context(gen_id, conversation_id, trace_id, now_ms)
 
     file_path = redact_content(env.log_tool_details, _jq_str(input_json, "file_path", "filePath", "path"))
 
@@ -557,7 +621,7 @@ def _handle_before_read_file(input_json, conversation_id, gen_id, trace_id, now_
 def _handle_after_file_edit(input_json, conversation_id, gen_id, trace_id, now_ms):
     """TOOL span for file edit. Replaces bash lines 344-371."""
     sid = span_id_16()
-    parent = gen_root_span_get(gen_id)
+    trace_id, parent = _root_parent_context(gen_id, conversation_id, trace_id, now_ms)
 
     file_path = redact_content(env.log_tool_details, _jq_str(input_json, "file_path", "filePath", "path"))
     edits = redact_content(env.log_tool_content, _jq_str(input_json, "edits", "changes", "diff"))
@@ -595,7 +659,7 @@ def _handle_after_file_edit(input_json, conversation_id, gen_id, trace_id, now_m
 def _handle_before_tab_file_read(input_json, conversation_id, gen_id, trace_id, now_ms):
     """TOOL span for tab file read. Replaces bash lines 376-398."""
     sid = span_id_16()
-    parent = gen_root_span_get(gen_id)
+    trace_id, parent = _root_parent_context(gen_id, conversation_id, trace_id, now_ms)
 
     file_path = redact_content(env.log_tool_details, _jq_str(input_json, "file_path", "filePath", "path"))
 
@@ -631,7 +695,7 @@ def _handle_before_tab_file_read(input_json, conversation_id, gen_id, trace_id, 
 def _handle_after_tab_file_edit(input_json, conversation_id, gen_id, trace_id, now_ms):
     """TOOL span for tab file edit. Replaces bash lines 403-430."""
     sid = span_id_16()
-    parent = gen_root_span_get(gen_id)
+    trace_id, parent = _root_parent_context(gen_id, conversation_id, trace_id, now_ms)
 
     file_path = redact_content(env.log_tool_details, _jq_str(input_json, "file_path", "filePath", "path"))
     edits = redact_content(env.log_tool_content, _jq_str(input_json, "edits", "changes", "diff"))
@@ -669,7 +733,7 @@ def _handle_after_tab_file_edit(input_json, conversation_id, gen_id, trace_id, n
 def _handle_stop(input_json, conversation_id, gen_id, trace_id, now_ms):
     """Flush deferred LLM span(s) with per-turn tokens, then send Agent Stop CHAIN + cleanup."""
     sid = span_id_16()
-    parent = gen_root_span_get(gen_id)
+    trace_id, parent = _root_parent_context(gen_id, conversation_id, trace_id, now_ms)
 
     status = _jq_str(input_json, "status", "reason")
     loop_count = _jq_str(input_json, "loop_count", "loopCount", "iterations")
@@ -836,7 +900,7 @@ def _handle_session_end(input_json, conversation_id, gen_id, trace_id, now_ms):
     the gen_id keyed root span if one was saved by sessionStart.
     """
     sid = span_id_16()
-    parent = gen_root_span_get(gen_id)
+    trace_id, parent = _root_parent_context(gen_id, conversation_id, trace_id, now_ms)
 
     _dur = input_json.get("duration_ms")
     duration_ms = _to_int(_dur if _dur is not None else input_json.get("durationMs"))
@@ -926,7 +990,7 @@ def _handle_post_tool_use(input_json, conversation_id, gen_id, trace_id, now_ms)
         return
 
     sid = span_id_16()
-    parent = gen_root_span_get(gen_id) if gen_id else ""
+    trace_id, parent = _root_parent_context(gen_id, conversation_id, trace_id, now_ms)
 
     tool_input = _jq_str(input_json, "tool_input", "toolInput", "input", "arguments", "args")
     output = _jq_str(input_json, "result", "output", "response", "stdout")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a deterministic session fallback root for Cursor events that arrive without a saved prompt/generation root.
- Parent orphan tool/LLM/stop/session-end spans to that fallback root and normalize camelCase/snake_case Cursor IDs.
- Add regression coverage for multiple orphan tool events sharing one session root.

## Validation
- `.venv/bin/python -m pytest tests/core/test_common.py tests/tracing/cursor/test_cursor_hook.py tests/tracing/cursor/test_cursor_adapter.py tests/tracing/cursor/test_install_cursor.py`
- `.venv/bin/python -m pytest tests/ -m 'not slow'`
- `.venv/bin/python -m pre_commit run --all-files`
- Dry-run hook smoke test for two orphan file-edit events sharing one fallback root
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-691cf33e-b74d-4a5e-bd76-ace756f93721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-691cf33e-b74d-4a5e-bd76-ace756f93721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

