### PR TITLE
Add custom span attributes from config and OTEL_RESOURCE_ATTRIBUTES + increase flexible user_id by project or ARIZE_USER_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,35 @@ All configuration lives in `~/.arize/harness/config.yaml`, written by the instal
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `user_id` | No | — | User identifier added to all spans as `user.id` |
+| `user_id` | No | — | User identifier added to all spans as `user.id` (global default; can be overridden per-harness) |
+| `harnesses.<name>.user_id` | No | — | Per-harness user identifier; overrides the global `user_id` for that harness's spans |
+
+**Custom span attributes** (optional)
+
+Attach arbitrary key/value attributes to every emitted span — useful for grouping or filtering by
+custom dimensions (`team`, `environment`, etc.) in Arize or Phoenix. Define a global `attributes:`
+block, a per-harness `harnesses.<name>.attributes:` block, or both:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `attributes` | No | — | Map of key/value attributes added to every span across all harnesses |
+| `harnesses.<name>.attributes` | No | — | Per-harness attributes; override the global block on key collision |
+
+Values keep their YAML type (`cost_center: 4021` lands as an integer). Custom attributes never
+overwrite attributes the harness sets itself (e.g. `project.name`, `user.id`).
+
+Example:
+
+```yaml
+attributes:                 # all harnesses
+  team: payments
+  environment: prod
+harnesses:
+  claude-code:
+    attributes:             # claude-code only; overrides global on shared keys
+      environment: prod-claude
+      surface: ide
+```
 
 Each harness owns its full backend configuration directly — there is no shared global backend block. This allows different harnesses to use different backends or credentials.
 
@@ -197,6 +225,7 @@ Most settings live in `config.yaml`, but a small set of env vars affect runtime 
 | `ARIZE_PROJECT_NAME` | per-harness | Overrides `harnesses.<name>.project_name` from `config.yaml` for a single session. |
 | `ARIZE_LOG_FILE` | per-harness | Path the harness writes its log to. Adapters default to `~/.arize/harness/logs/<harness>.log`. |
 | `ARIZE_TRACE_DEBUG` | `false` | Dump raw hook payloads as YAML under `~/.arize/harness/state/<harness>/debug/`. Codex hooks use this for span-tree inspection. |
+| `OTEL_RESOURCE_ATTRIBUTES` | — | Standard OTel attribute string (`team=payments,environment=prod`) added to every span. Overrides config-file `attributes`/`harnesses.<name>.attributes` on key collision; set per-harness by placing it in that harness's settings env block. |
 
 **Backend overrides** (set if you want env to take priority over `config.yaml` for a single run):
 

--- a/core/common.py
+++ b/core/common.py
@@ -42,27 +42,27 @@ class _Env:
         return os.environ.get("ARIZE_PROJECT_NAME", "")
 
     def get_user_id(self, service_name: str = "") -> str:
-        """Resolve user id. Layered, later wins:
+        """Resolve user id, checking highest precedence first and returning on
+        the first hit:
 
-        1. top-level ``user_id`` in config.yaml (global)
-        2. ``harnesses.<service_name>.user_id`` in config.yaml (per-harness)
-        3. ``ARIZE_USER_ID`` env var (env always wins; an explicit empty value
+        1. ``ARIZE_USER_ID`` env var (env always wins; an explicit empty value
            blanks it)
+        2. ``harnesses.<service_name>.user_id`` in config.yaml (per-harness)
+        3. top-level ``user_id`` in config.yaml (global)
+        → ``""`` if none set
         """
+        raw = os.environ.get("ARIZE_USER_ID")
+        if raw is not None:
+            return raw
         cfg = self._top_level_config
-        value = ""
-        if cfg.get("user_id"):
-            value = str(cfg["user_id"])
         if service_name:
             harnesses = cfg.get("harnesses")
             if isinstance(harnesses, dict):
                 entry = harnesses.get(service_name)
                 if isinstance(entry, dict) and entry.get("user_id"):
-                    value = str(entry["user_id"])
-        raw = os.environ.get("ARIZE_USER_ID")
-        if raw is not None:
-            value = raw
-        return value
+                    return str(entry["user_id"])
+        val = cfg.get("user_id")
+        return str(val) if val else ""
 
     @property
     def user_id(self) -> str:

--- a/core/common.py
+++ b/core/common.py
@@ -41,14 +41,32 @@ class _Env:
     def project_name(self) -> str:
         return os.environ.get("ARIZE_PROJECT_NAME", "")
 
-    @property
-    def user_id(self) -> str:
-        # env var > config.yaml top-level `user_id` > ""
+    def get_user_id(self, service_name: str = "") -> str:
+        """Resolve user id. Layered, later wins:
+
+        1. top-level ``user_id`` in config.yaml (global)
+        2. ``harnesses.<service_name>.user_id`` in config.yaml (per-harness)
+        3. ``ARIZE_USER_ID`` env var (env always wins; an explicit empty value
+           blanks it)
+        """
+        cfg = self._top_level_config
+        value = ""
+        if cfg.get("user_id"):
+            value = str(cfg["user_id"])
+        if service_name:
+            harnesses = cfg.get("harnesses")
+            if isinstance(harnesses, dict):
+                entry = harnesses.get(service_name)
+                if isinstance(entry, dict) and entry.get("user_id"):
+                    value = str(entry["user_id"])
         raw = os.environ.get("ARIZE_USER_ID")
         if raw is not None:
-            return raw
-        val = self._top_level_config.get("user_id")
-        return str(val) if val else ""
+            value = raw
+        return value
+
+    @property
+    def user_id(self) -> str:
+        return self.get_user_id()
 
     @property
     def verbose(self) -> bool:
@@ -114,6 +132,60 @@ class _Env:
         if isinstance(val, bool):
             return val
         return default
+
+    @staticmethod
+    def _parse_otel_resource_attributes() -> dict:
+        """Parse OTEL_RESOURCE_ATTRIBUTES ("k1=v1,k2=v2") into a dict of str->str.
+
+        Splits on ',', then on the first '=' per token. Trims whitespace from
+        key and value. Tokens with no '=' or an empty key are skipped silently
+        (fail-soft). Returns {} when the env var is unset or empty.
+        """
+        raw = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
+        result: dict = {}
+        if not raw:
+            return result
+        for token in raw.split(","):
+            if "=" not in token:
+                continue
+            key, value = token.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+            if not key:
+                continue
+            result[key] = value
+        return result
+
+    def custom_attributes(self, service_name: str = "") -> dict:
+        """Resolve custom span attributes for a harness.
+
+        Layered, later wins:
+          1. top-level ``attributes:`` in config.yaml (global — all harnesses)
+          2. ``harnesses.<service_name>.attributes:`` in config.yaml (per-harness)
+          3. ``OTEL_RESOURCE_ATTRIBUTES`` env var (env always wins)
+
+        Config values keep their YAML type (an int stays an int, bool stays
+        bool); env values are always strings. Returns a fresh dict every call.
+        """
+        cfg = self._top_level_config
+        merged: dict = {}
+
+        glob = cfg.get("attributes")
+        if isinstance(glob, dict):
+            merged.update(glob)
+
+        if service_name:
+            harnesses = cfg.get("harnesses")
+            if isinstance(harnesses, dict):
+                entry = harnesses.get(service_name)
+                if isinstance(entry, dict):
+                    per = entry.get("attributes")
+                    if isinstance(per, dict):
+                        merged.update(per)
+
+        merged.update(self._parse_otel_resource_attributes())
+
+        return merged
 
     @property
     def log_prompts(self) -> bool:
@@ -1012,8 +1084,9 @@ def build_span(
 
     If end_ms is empty/None/0, defaults to start_ms (matches bash: end="${7:-$start}").
     """
-    if attrs is None:
-        attrs = {}
+    attrs = {} if attrs is None else dict(attrs)
+    for k, v in env.custom_attributes(service_name).items():
+        attrs.setdefault(k, v)
 
     start = int(start_ms) if start_ms else 0
     end = int(end_ms) if end_ms else start

--- a/core/common.py
+++ b/core/common.py
@@ -131,6 +131,21 @@ class _Env:
         except Exception:
             return {}
 
+    # cached_property attributes that read config.yaml once per process. Kept in
+    # one place so invalidate_caches() stays correct if a new cached read is added.
+    _CACHED_CONFIG_PROPERTIES = ("_top_level_config", "_logging_config")
+
+    def invalidate_caches(self) -> None:
+        """Drop cached config reads so the next access reloads from disk.
+
+        ``functools.cached_property`` stores its result in the instance
+        ``__dict__``; popping the key forces recomputation. Used by tests (and
+        any code that mutates config.yaml at runtime) to avoid serving stale
+        config. Safe to call when nothing is cached.
+        """
+        for name in self._CACHED_CONFIG_PROPERTIES:
+            self.__dict__.pop(name, None)
+
     def _resolve_log_flag(self, env_key: str, config_key: str, default: bool) -> bool:
         """env var > config.yaml `logging.<key>` > default."""
         raw = os.environ.get(env_key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,31 @@ REPO_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 
+@pytest.fixture(autouse=True)
+def isolate_config(tmp_path, monkeypatch):
+    """Isolate every test from the developer's real ~/.arize/harness/config.yaml.
+
+    Two independent leaks are closed here:
+
+    1. ``core.config.load_config`` binds its path via ``from core.constants
+       import CONFIG_FILE``, so patching ``core.constants.CONFIG_FILE`` (as
+       ``tmp_harness_dir`` does) does NOT redirect it — the name ``load_config``
+       actually reads is ``core.config.CONFIG_FILE``. Point that at a
+       nonexistent path so config defaults to ``{}`` unless a test opts in
+       (tests that need real config, like ``test_config.py``, re-patch it).
+    2. ``core.common.env`` is a module-level singleton whose ``cached_property``
+       config reads survive across tests. Clear them before and after each test
+       so the next access re-reads the isolated config rather than a stale value
+       cached from a sibling test.
+    """
+    from core.common import env
+
+    monkeypatch.setattr("core.config.CONFIG_FILE", tmp_path / "no-such-config.yaml")
+    env.invalidate_caches()
+    yield
+    env.invalidate_caches()
+
+
 @pytest.fixture
 def tmp_harness_dir(tmp_path, monkeypatch):
     """Create the full ~/.arize/harness directory tree in a temp location.

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -850,14 +850,13 @@ class TestLoggingFlagPrecedence:
 
     def _patch_config(self, monkeypatch, block):
         """Patch core.config.load_config so _Env._logging_config returns *block*."""
-        import core.common
 
         monkeypatch.setattr(
             "core.config.load_config",
             lambda config_path=None: {"logging": block} if block is not None else {},
         )
         # Drop the cached value so the next access re-reads.
-        core.common.env.__dict__.pop("_logging_config", None)
+        env.__dict__.pop("_logging_config", None)
 
     def test_default_true_when_nothing_set(self, monkeypatch):
         self._patch_config(monkeypatch, None)
@@ -1729,10 +1728,9 @@ class TestBuildSpanCustomAttributes:
         assert attrs["cost_center"] == {"intValue": 4021}
 
     def test_handler_set_attr_not_overwritten(self, monkeypatch):
-        import core.common
 
         monkeypatch.setattr(
-            core.common.env,
+            env,
             "custom_attributes",
             lambda service_name="": {"project.name": "from-custom"},
         )
@@ -1763,10 +1761,9 @@ class TestBuildSpanCustomAttributes:
         assert set(attrs.keys()) == {"project.name", "user.id"}
 
     def test_caller_attrs_dict_not_mutated(self, monkeypatch):
-        import core.common
 
         monkeypatch.setattr(
-            core.common.env,
+            env,
             "custom_attributes",
             lambda service_name="": {"team": "payments"},
         )
@@ -1783,7 +1780,6 @@ class TestBuildSpanCustomAttributes:
         assert caller_attrs == {"project.name": "p"}
 
     def test_resolver_receives_service_name(self, monkeypatch):
-        import core.common
 
         seen = {}
 
@@ -1791,7 +1787,7 @@ class TestBuildSpanCustomAttributes:
             seen["service_name"] = service_name
             return {}
 
-        monkeypatch.setattr(core.common.env, "custom_attributes", fake)
+        monkeypatch.setattr(env, "custom_attributes", fake)
         build_span(
             name="t",
             kind="LLM",

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -1543,3 +1543,287 @@ class TestFileLockMkdir:
             assert lock_path.is_dir()
 
         assert not lock_path.exists()
+
+
+# ── Custom attributes tests ──────────────────────────────────────────────
+
+
+class TestCustomAttributes:
+    """env.custom_attributes(service_name) layering: global < per-harness < env."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        monkeypatch.delenv("OTEL_RESOURCE_ATTRIBUTES", raising=False)
+        from core.common import env as _env
+
+        _env.__dict__.pop("_top_level_config", None)
+        yield
+        _env.__dict__.pop("_top_level_config", None)
+
+    def _patch_config(self, monkeypatch, cfg):
+        import core.common
+
+        monkeypatch.setattr("core.config.load_config", lambda config_path=None: cfg or {})
+        core.common.env.__dict__.pop("_top_level_config", None)
+
+    def test_nothing_set_returns_empty(self, monkeypatch):
+        self._patch_config(monkeypatch, {})
+        assert env.custom_attributes() == {}
+        assert env.custom_attributes("claude-code") == {}
+
+    def test_global_only_returned_for_any_service(self, monkeypatch):
+        self._patch_config(monkeypatch, {"attributes": {"team": "payments", "env": "prod"}})
+        assert env.custom_attributes("claude-code") == {"team": "payments", "env": "prod"}
+        assert env.custom_attributes("codex") == {"team": "payments", "env": "prod"}
+        assert env.custom_attributes("") == {"team": "payments", "env": "prod"}
+
+    def test_per_harness_only_isolated_to_that_harness(self, monkeypatch):
+        self._patch_config(
+            monkeypatch,
+            {"harnesses": {"claude-code": {"attributes": {"environment": "prod-claude"}}}},
+        )
+        assert env.custom_attributes("claude-code") == {"environment": "prod-claude"}
+        # Different harness must NOT see the claude-code per-harness block.
+        assert env.custom_attributes("codex") == {}
+
+    def test_per_harness_overrides_global_shared_key(self, monkeypatch):
+        self._patch_config(
+            monkeypatch,
+            {
+                "attributes": {"team": "payments", "environment": "prod"},
+                "harnesses": {"claude-code": {"attributes": {"environment": "prod-claude"}}},
+            },
+        )
+        # Shared key (environment) overridden; non-shared keys from both layers survive.
+        result = env.custom_attributes("claude-code")
+        assert result == {"team": "payments", "environment": "prod-claude"}
+
+    def test_env_only_no_config(self, monkeypatch):
+        self._patch_config(monkeypatch, {})
+        monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "team=payments,region=us-east-1")
+        assert env.custom_attributes() == {"team": "payments", "region": "us-east-1"}
+
+    def test_env_wins_over_per_harness_and_global(self, monkeypatch):
+        self._patch_config(
+            monkeypatch,
+            {
+                "attributes": {"environment": "prod-global"},
+                "harnesses": {"claude-code": {"attributes": {"environment": "prod-claude"}}},
+            },
+        )
+        monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "environment=staging")
+        assert env.custom_attributes("claude-code") == {"environment": "staging"}
+
+    def test_malformed_env_skipped(self, monkeypatch):
+        self._patch_config(monkeypatch, {})
+        monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "team=a,garbage,=b,env=c")
+        assert env.custom_attributes() == {"team": "a", "env": "c"}
+
+    def test_typed_config_values_preserved(self, monkeypatch):
+        self._patch_config(
+            monkeypatch,
+            {"attributes": {"cost_center": 4021, "enabled": True, "ratio": 0.5}},
+        )
+        result = env.custom_attributes()
+        assert result["cost_center"] == 4021
+        assert isinstance(result["cost_center"], int) and not isinstance(result["cost_center"], bool)
+        assert result["enabled"] is True
+        assert result["ratio"] == 0.5
+        assert isinstance(result["ratio"], float)
+
+    def test_malformed_global_attributes_block_ignored(self, monkeypatch):
+        # attributes: set to a string (not a dict) — must not crash.
+        self._patch_config(monkeypatch, {"attributes": "not-a-dict"})
+        assert env.custom_attributes("claude-code") == {}
+
+    def test_malformed_per_harness_attributes_block_ignored(self, monkeypatch):
+        self._patch_config(
+            monkeypatch,
+            {"harnesses": {"claude-code": {"attributes": ["bad", "list"]}}},
+        )
+        assert env.custom_attributes("claude-code") == {}
+
+    def test_returns_fresh_dict_each_call(self, monkeypatch):
+        self._patch_config(monkeypatch, {"attributes": {"team": "payments"}})
+        a = env.custom_attributes()
+        b = env.custom_attributes()
+        a["mutated"] = "x"
+        assert "mutated" not in b
+
+
+# ── build_span × custom_attributes injection tests ───────────────────────
+
+
+class TestBuildSpanCustomAttributes:
+    """build_span() merges env.custom_attributes() into per-span attrs via setdefault."""
+
+    def _attrs_dict(self, span_payload):
+        attrs = span_payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
+        return {a["key"]: a["value"] for a in attrs}
+
+    def test_custom_attrs_appear_in_built_span(self, monkeypatch):
+        import core.common
+
+        monkeypatch.setattr(
+            core.common.env,
+            "custom_attributes",
+            lambda service_name="": {"team": "payments", "cost_center": 4021},
+        )
+        result = build_span(
+            name="t",
+            kind="LLM",
+            span_id="aa",
+            trace_id="bb",
+            start_ms=1000,
+            end_ms=2000,
+        )
+        attrs = self._attrs_dict(result)
+        assert attrs["team"] == {"stringValue": "payments"}
+        assert attrs["cost_center"] == {"intValue": 4021}
+
+    def test_handler_set_attr_not_overwritten(self, monkeypatch):
+        import core.common
+
+        monkeypatch.setattr(
+            core.common.env,
+            "custom_attributes",
+            lambda service_name="": {"project.name": "from-custom"},
+        )
+        result = build_span(
+            name="t",
+            kind="LLM",
+            span_id="aa",
+            trace_id="bb",
+            start_ms=1000,
+            end_ms=2000,
+            attrs={"project.name": "from-handler"},
+        )
+        attrs = self._attrs_dict(result)
+        assert attrs["project.name"] == {"stringValue": "from-handler"}
+
+    def test_empty_resolver_is_noop(self, monkeypatch):
+        import core.common
+
+        monkeypatch.setattr(core.common.env, "custom_attributes", lambda service_name="": {})
+        result = build_span(
+            name="t",
+            kind="LLM",
+            span_id="aa",
+            trace_id="bb",
+            start_ms=1000,
+            end_ms=2000,
+            attrs={"project.name": "p", "user.id": "u"},
+        )
+        attrs = self._attrs_dict(result)
+        assert set(attrs.keys()) == {"project.name", "user.id"}
+
+    def test_caller_attrs_dict_not_mutated(self, monkeypatch):
+        import core.common
+
+        monkeypatch.setattr(
+            core.common.env,
+            "custom_attributes",
+            lambda service_name="": {"team": "payments"},
+        )
+        caller_attrs = {"project.name": "p"}
+        build_span(
+            name="t",
+            kind="LLM",
+            span_id="aa",
+            trace_id="bb",
+            start_ms=1000,
+            end_ms=2000,
+            attrs=caller_attrs,
+        )
+        assert caller_attrs == {"project.name": "p"}
+
+    def test_resolver_receives_service_name(self, monkeypatch):
+        import core.common
+
+        seen = {}
+
+        def fake(service_name=""):
+            seen["service_name"] = service_name
+            return {}
+
+        monkeypatch.setattr(core.common.env, "custom_attributes", fake)
+        build_span(
+            name="t",
+            kind="LLM",
+            span_id="aa",
+            trace_id="bb",
+            start_ms=1000,
+            end_ms=2000,
+            service_name="claude-code",
+        )
+        assert seen["service_name"] == "claude-code"
+
+
+# ── env.get_user_id ladder tests ────────────────────────────────────────
+
+
+class TestGetUserId:
+    """env.get_user_id(service_name) layering: global < per-harness < env."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        monkeypatch.delenv("ARIZE_USER_ID", raising=False)
+        from core.common import env as _env
+
+        _env.__dict__.pop("_top_level_config", None)
+        yield
+        _env.__dict__.pop("_top_level_config", None)
+
+    def _patch_config(self, monkeypatch, cfg):
+        import core.common
+
+        monkeypatch.setattr("core.config.load_config", lambda config_path=None: cfg or {})
+        core.common.env.__dict__.pop("_top_level_config", None)
+
+    def test_nothing_set_returns_empty(self, monkeypatch):
+        self._patch_config(monkeypatch, {})
+        assert env.get_user_id() == ""
+        assert env.get_user_id("claude-code") == ""
+
+    def test_global_config_returned_for_any_service(self, monkeypatch):
+        self._patch_config(monkeypatch, {"user_id": "alice"})
+        assert env.get_user_id() == "alice"
+        assert env.get_user_id("claude-code") == "alice"
+        assert env.get_user_id("codex") == "alice"
+
+    def test_per_harness_overrides_global(self, monkeypatch):
+        self._patch_config(
+            monkeypatch,
+            {"user_id": "alice", "harnesses": {"claude-code": {"user_id": "bob"}}},
+        )
+        # Per-harness wins for claude-code; other harness still gets global.
+        assert env.get_user_id("claude-code") == "bob"
+        assert env.get_user_id("codex") == "alice"
+
+    def test_env_beats_both_config_layers(self, monkeypatch):
+        self._patch_config(
+            monkeypatch,
+            {"user_id": "alice", "harnesses": {"claude-code": {"user_id": "bob"}}},
+        )
+        monkeypatch.setenv("ARIZE_USER_ID", "carol")
+        assert env.get_user_id("claude-code") == "carol"
+        assert env.get_user_id("codex") == "carol"
+
+    def test_explicit_empty_env_blanks_result(self, monkeypatch):
+        self._patch_config(
+            monkeypatch,
+            {"user_id": "alice", "harnesses": {"claude-code": {"user_id": "bob"}}},
+        )
+        monkeypatch.setenv("ARIZE_USER_ID", "")
+        assert env.get_user_id("claude-code") == ""
+
+    def test_user_id_property_regression(self, monkeypatch):
+        """env.user_id (property) still returns the global+env result, unchanged."""
+        self._patch_config(
+            monkeypatch,
+            {"user_id": "alice", "harnesses": {"claude-code": {"user_id": "bob"}}},
+        )
+        # Property doesn't take a service_name → only global + env apply.
+        assert env.user_id == "alice"
+        monkeypatch.setenv("ARIZE_USER_ID", "carol")
+        assert env.user_id == "carol"

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -1612,10 +1612,8 @@ class TestCustomAttributes:
         _env.__dict__.pop("_top_level_config", None)
 
     def _patch_config(self, monkeypatch, cfg):
-        import core.common
-
         monkeypatch.setattr("core.config.load_config", lambda config_path=None: cfg or {})
-        core.common.env.__dict__.pop("_top_level_config", None)
+        env.__dict__.pop("_top_level_config", None)
 
     def test_nothing_set_returns_empty(self, monkeypatch):
         self._patch_config(monkeypatch, {})
@@ -1713,10 +1711,8 @@ class TestBuildSpanCustomAttributes:
         return {a["key"]: a["value"] for a in attrs}
 
     def test_custom_attrs_appear_in_built_span(self, monkeypatch):
-        import core.common
-
         monkeypatch.setattr(
-            core.common.env,
+            env,
             "custom_attributes",
             lambda service_name="": {"team": "payments", "cost_center": 4021},
         )
@@ -1753,9 +1749,7 @@ class TestBuildSpanCustomAttributes:
         assert attrs["project.name"] == {"stringValue": "from-handler"}
 
     def test_empty_resolver_is_noop(self, monkeypatch):
-        import core.common
-
-        monkeypatch.setattr(core.common.env, "custom_attributes", lambda service_name="": {})
+        monkeypatch.setattr(env, "custom_attributes", lambda service_name="": {})
         result = build_span(
             name="t",
             kind="LLM",
@@ -1826,10 +1820,8 @@ class TestGetUserId:
         _env.__dict__.pop("_top_level_config", None)
 
     def _patch_config(self, monkeypatch, cfg):
-        import core.common
-
         monkeypatch.setattr("core.config.load_config", lambda config_path=None: cfg or {})
-        core.common.env.__dict__.pop("_top_level_config", None)
+        env.__dict__.pop("_top_level_config", None)
 
     def test_nothing_set_returns_empty(self, monkeypatch):
         self._patch_config(monkeypatch, {})

--- a/tests/tracing/gemini/test_gemini_adapter.py
+++ b/tests/tracing/gemini/test_gemini_adapter.py
@@ -13,7 +13,7 @@ import time
 import pytest
 import yaml
 
-from core.common import StateManager
+from core.common import StateManager, env
 
 # ---------------------------------------------------------------------------
 # We import the adapter module itself so we can monkeypatch its module-level
@@ -224,8 +224,6 @@ class TestEnsureSessionInitialized:
         monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
         monkeypatch.delenv("GEMINI_SESSION_ID", raising=False)
 
-        import core.common
-
         monkeypatch.setattr(
             "core.config.load_config",
             lambda config_path=None: {
@@ -233,13 +231,13 @@ class TestEnsureSessionInitialized:
                 "harnesses": {adapter.SERVICE_NAME: {"user_id": "scoped@x"}},
             },
         )
-        core.common.env.__dict__.pop("_top_level_config", None)
+        env.__dict__.pop("_top_level_config", None)
         try:
             sm = self._make_state(gemini_state_dir, "user-scoped")
             adapter.ensure_session_initialized(sm, {})
             assert sm.get("user_id") == "scoped@x"
         finally:
-            core.common.env.__dict__.pop("_top_level_config", None)
+            env.__dict__.pop("_top_level_config", None)
 
 
 # ── gc_stale_state_files tests ───────────────────────────────────────────────

--- a/tests/tracing/gemini/test_gemini_adapter.py
+++ b/tests/tracing/gemini/test_gemini_adapter.py
@@ -217,6 +217,30 @@ class TestEnsureSessionInitialized:
         adapter.ensure_session_initialized(sm, {})
         assert sm.get("user_id") == "test-user-123"
 
+    def test_user_id_per_harness_override(self, gemini_state_dir, monkeypatch):
+        """harnesses.gemini.user_id in config overrides the global user_id."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.delenv("ARIZE_USER_ID", raising=False)
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        monkeypatch.delenv("GEMINI_SESSION_ID", raising=False)
+
+        import core.common
+
+        monkeypatch.setattr(
+            "core.config.load_config",
+            lambda config_path=None: {
+                "user_id": "global@x",
+                "harnesses": {adapter.SERVICE_NAME: {"user_id": "scoped@x"}},
+            },
+        )
+        core.common.env.__dict__.pop("_top_level_config", None)
+        try:
+            sm = self._make_state(gemini_state_dir, "user-scoped")
+            adapter.ensure_session_initialized(sm, {})
+            assert sm.get("user_id") == "scoped@x"
+        finally:
+            core.common.env.__dict__.pop("_top_level_config", None)
+
 
 # ── gc_stale_state_files tests ───────────────────────────────────────────────
 

--- a/tests/tracing/opencode/test_opencode_adapter.py
+++ b/tests/tracing/opencode/test_opencode_adapter.py
@@ -36,7 +36,12 @@ def opencode_state_dir(tmp_harness_dir, monkeypatch):
 
 @pytest.fixture
 def disable_env_vars(monkeypatch):
-    """Clear env vars that could influence session resolution."""
+    """Clear env vars that could influence session resolution.
+
+    On-disk config.yaml is isolated globally by the autouse ``reset_env_caches``
+    fixture combined with ``tmp_harness_dir``'s ``CONFIG_FILE`` redirect, so this
+    only needs to clear the env-var inputs.
+    """
     monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
     monkeypatch.delenv("ARIZE_USER_ID", raising=False)
     monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
@@ -155,8 +160,11 @@ class TestEnsureSessionInitialized:
         sm.init_state()
         return sm
 
-    def test_sets_all_keys(self, opencode_state_dir, disable_env_vars):
+    def test_sets_all_keys(self, opencode_state_dir, disable_env_vars, monkeypatch):
         """First call sets all expected keys."""
+        # Source user_id from env so the assertion is hermetic, not leaked from
+        # the developer's on-disk config.yaml.
+        monkeypatch.setenv("ARIZE_USER_ID", "test-user-all-keys")
         sm = self._make_state(opencode_state_dir, "all-keys")
         adapter.ensure_session_initialized(sm, {"sessionID": "ses_all"})
         assert sm.get("session_id") is not None
@@ -164,7 +172,7 @@ class TestEnsureSessionInitialized:
         assert sm.get("project_name") is not None
         assert sm.get("trace_count") == "0"
         assert sm.get("tool_count") == "0"
-        assert sm.get("user_id") is not None
+        assert sm.get("user_id") == "test-user-all-keys"
 
     def test_session_id_matches_session_id_field(self, opencode_state_dir, disable_env_vars):
         """session_id stored in state == the opencode sessionID from payload."""

--- a/tracing/claude_code/hooks/adapter.py
+++ b/tracing/claude_code/hooks/adapter.py
@@ -122,7 +122,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     - project_name: from ARIZE_PROJECT_NAME env, or basename of input_json["cwd"], or cwd
     - trace_count: "0"
     - tool_count: "0"
-    - user_id: from env.user_id, then input_json["user_id"], then ""
+    - user_id: from env.get_user_id(SERVICE_NAME), then input_json["user_id"], then ""
     """
     # Skip if already initialized
     existing = state.get("session_id")
@@ -147,7 +147,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     state.set("tool_count", "0")
 
     # user_id priority: env var, then hook input
-    user_id = env.user_id
+    user_id = env.get_user_id(SERVICE_NAME)
     if not user_id:
         user_id = input_json.get("user_id", "")
     state.set("user_id", user_id)

--- a/tracing/codex/hooks/handlers.py
+++ b/tracing/codex/hooks/handlers.py
@@ -336,7 +336,7 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
 def _build_and_send_spans(thread_id: str, turn_id: str, turn: dict) -> None:
     """Assemble the LLM + TOOL spans from an extracted turn and ship them."""
     project_name = env.project_name or "codex"
-    user_id = env.user_id or ""
+    user_id = env.get_user_id(SERVICE_NAME) or ""
 
     trace_id = generate_trace_id()
     parent_span_id = generate_span_id()
@@ -491,8 +491,9 @@ def _send_legacy_single_span(thread_id: str, turn_id: str, input_json: dict) -> 
         "codex.turn_id": turn_id,
         "codex.notify_fallback": "true",
     }
-    if env.user_id:
-        attrs["user.id"] = env.user_id
+    user_id = env.get_user_id(SERVICE_NAME)
+    if user_id:
+        attrs["user.id"] = user_id
     if assistant_output:
         attrs["llm.output_messages"] = json.dumps([{"message.role": "assistant", "message.content": assistant_output}])
 

--- a/tracing/copilot/hooks/adapter.py
+++ b/tracing/copilot/hooks/adapter.py
@@ -128,7 +128,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
                              else basename(getcwd())
       trace_count         -- "0"
       tool_count          -- "0"
-      user_id             -- env.user_id (Copilot does not pass user_id in payload)
+      user_id             -- env.get_user_id(SERVICE_NAME) (Copilot does not pass user_id in payload)
     """
     if state.get("session_id") is not None:
         return
@@ -145,7 +145,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     state.set("project_name", project_name)
     state.set("trace_count", "0")
     state.set("tool_count", "0")
-    state.set("user_id", env.user_id)
+    state.set("user_id", env.get_user_id(SERVICE_NAME))
 
     log(f"Session initialized: {session_id}")
 

--- a/tracing/cursor/hooks/handlers.py
+++ b/tracing/cursor/hooks/handlers.py
@@ -60,13 +60,14 @@ def _jq_str(input_json: dict, *keys, default: str = "") -> str:
 
 
 def _resolve_user_id(input_json: dict) -> str:
-    """env.user_id (env var > config.yaml `user_id`) > payload `user_email` > "".
+    """env.get_user_id(SERVICE_NAME) (global config < harnesses.cursor.user_id < ARIZE_USER_ID env)
+    > payload `user_email` > "".
 
     Cursor has no per-session state for user_id, so each handler resolves it
     inline. Configured user_id wins over the implicit `user_email` payload field
     so an explicitly set user takes precedence on shared workstations.
     """
-    return env.user_id or _jq_str(input_json, "user_email")
+    return env.get_user_id(SERVICE_NAME) or _jq_str(input_json, "user_email")
 
 
 def _to_int(v):

--- a/tracing/gemini/hooks/adapter.py
+++ b/tracing/gemini/hooks/adapter.py
@@ -154,7 +154,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     state.set("trace_count", "0")
     state.set("tool_count", "0")
 
-    user_id = env.user_id
+    user_id = env.get_user_id(SERVICE_NAME)
     state.set("user_id", user_id)
 
     log(f"Session initialized: {session_id}")

--- a/tracing/kiro/hooks/adapter.py
+++ b/tracing/kiro/hooks/adapter.py
@@ -86,7 +86,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     state.set("project_name", project_name)
     state.set("trace_count", "0")
     state.set("tool_count", "0")
-    state.set("user_id", env.user_id or "")
+    state.set("user_id", env.get_user_id(SERVICE_NAME) or "")
 
     log(f"Session initialized: {session_id} (project={project_name})")
 

--- a/tracing/opencode/hooks/adapter.py
+++ b/tracing/opencode/hooks/adapter.py
@@ -92,10 +92,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     state.set("project_name", project_name)
     state.set("trace_count", "0")
     state.set("tool_count", "0")
-
-    user_id = env.get_user_id(SERVICE_NAME)
-    if user_id:
-        state.set("user_id", user_id)
+    state.set("user_id", env.get_user_id(SERVICE_NAME))
 
     log(f"Session initialized: {session_id}")
 

--- a/tracing/opencode/hooks/adapter.py
+++ b/tracing/opencode/hooks/adapter.py
@@ -93,8 +93,9 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     state.set("trace_count", "0")
     state.set("tool_count", "0")
 
-    user_id = env.user_id
-    state.set("user_id", user_id)
+    user_id = env.get_user_id(SERVICE_NAME)
+    if user_id:
+        state.set("user_id", user_id)
 
     log(f"Session initialized: {session_id}")
 


### PR DESCRIPTION
## Summary

Lets users declare arbitrary key/value attributes — globally and per-harness — in `~/.arize/harness/config.yaml` or via `OTEL_RESOURCE_ATTRIBUTES`, and attaches them to every emitted span without per-harness code changes by resolving them inside the shared `build_span()`. Also moves `user_id` onto the same global → per-harness → env precedence ladder so callers that pass `SERVICE_NAME` pick up per-harness overrides.

## Changes

- `core/common.py`: add custom-attribute resolution layered as global config `attributes:` → `harnesses.<service>.attributes:` → `OTEL_RESOURCE_ATTRIBUTES`, applied via `setdefault` in `build_span()` so handler-set attributes are never overwritten; add `_Env.get_user_id(service_name)` resolver and keep the existing `user_id` property as a thin delegate.
- `tracing/{claude_code,codex,copilot,cursor,gemini,kiro}/hooks/`: route `user_id` reads through `env.get_user_id(SERVICE_NAME)` so per-harness `user_id` config takes effect.
- `tests/core/test_common.py`: cover attribute precedence (global, per-harness override, env wins, handler-set values preserved), malformed input fail-soft behavior, and the new `get_user_id` ladder.
- `tests/tracing/gemini/test_gemini_adapter.py`: verify the gemini adapter resolves `user_id` via the service-scoped path.
- `README.md`: document the `attributes:` config block, per-harness override semantics, and `OTEL_RESOURCE_ATTRIBUTES` precedence.

## Test plan

- [x] `uv run pytest tests/core/test_common.py` passes, including the new attribute-precedence and `get_user_id` classes.
- [x] `uv run pytest` passes across the full suite.
- [x] `uv run pre-commit run --all-files` is clean.
- [x] With a global `attributes: {team: platform}` in `~/.arize/harness/config.yaml`, emitted spans from each harness include `team=platform`.
- [x] A `harnesses.<service>.attributes` entry overrides the global value for that harness only.
- [x] `OTEL_RESOURCE_ATTRIBUTES="team=infra,env=prod"` overrides both config layers on emitted spans.
- [x] Handler-set attributes (`project.name`, `user.id`) are not overwritten when a custom attribute uses the same key.
- [x] Setting `harnesses.<service>.user_id` in config takes effect for that harness; `ARIZE_USER_ID` still wins when set.
- [x] Malformed `OTEL_RESOURCE_ATTRIBUTES` values (missing `=`, empty keys) are skipped silently rather than raising.

🤖 Generated by workbench pr_writer