### PR TITLE
Share venv bootstrap across plugins; isolate Cursor venv; bootstrap robustness

### DIFF
--- a/core/scripts/bootstrap-venv
+++ b/core/scripts/bootstrap-venv
@@ -1,0 +1,150 @@
+#!/bin/sh
+# Shared venv bootstrap for Arize tracing plugins (Cursor, Claude Code, ...).
+#
+# Usage: bootstrap-venv <PLUGIN_ROOT> <VENV_DIR> <ENTRY_POINT>
+#   PLUGIN_ROOT  directory containing the plugin's pyproject.toml
+#   VENV_DIR     where the plugin's venv lives (created on first run)
+#   ENTRY_POINT  console-script name to exec (e.g. arize-hook-cursor)
+#
+# Creates a Python 3.9+ venv on first run, reinstalls when the plugin's
+# pyproject.toml changes, then execs the entry point. The host's hook payload
+# arrives on stdin and is inherited through exec, so the dispatcher reads it
+# directly. All diagnostics go to stderr; stdout is reserved for the host's
+# control protocol. Any failure exits 0 so tracing never blocks the host.
+#
+# Hot-path note: once the venv is built and current, the steady-state path
+# execs the entry point WITHOUT spawning a Python interpreter to probe the
+# version or hash pyproject.toml — both are skipped behind a cheap mtime gate.
+# This script runs on every host hook event, so that fast path matters.
+set -e
+
+PLUGIN_ROOT="${1:?usage: bootstrap-venv <plugin-root> <venv-dir> <entry-point>}"
+VENV_DIR="${2:?usage: bootstrap-venv <plugin-root> <venv-dir> <entry-point>}"
+ENTRY_POINT="${3:?usage: bootstrap-venv <plugin-root> <venv-dir> <entry-point>}"
+# The reinstall marker lives beside the venv (its parent dir) so it shares the
+# venv's isolation — callers give each plugin its own VENV_DIR.
+DATA_DIR="${VENV_DIR%/*}"
+MARKER="$DATA_DIR/.pyproject.sha256"
+PYPROJECT="$PLUGIN_ROOT/pyproject.toml"
+
+# --- Locate the installed entry-point binary (pure builtins) ---
+find_entry_point() {
+    if [ -x "$VENV_DIR/bin/$ENTRY_POINT" ]; then
+        echo "$VENV_DIR/bin/$ENTRY_POINT"
+    elif [ -x "$VENV_DIR/Scripts/$ENTRY_POINT" ]; then
+        echo "$VENV_DIR/Scripts/$ENTRY_POINT"
+    elif [ -x "$VENV_DIR/Scripts/${ENTRY_POINT}.exe" ]; then
+        echo "$VENV_DIR/Scripts/${ENTRY_POINT}.exe"
+    else
+        return 1
+    fi
+}
+
+# --- Find Python 3.9+ (only needed when (re)building the venv) ---
+find_python() {
+    for p in python3 python py; do
+        if "$p" -c "import sys; sys.exit(0 if sys.version_info>=(3,9) else 1)" 2>/dev/null; then
+            echo "$p"
+            return 0
+        fi
+    done
+    return 1
+}
+
+pyproject_hash() {
+    "$PYTHON_CMD" -c "import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$PYPROJECT" 2>/dev/null
+}
+
+# --- Is a (re)install needed? (slow path only; assumes PYTHON_CMD is set) ---
+needs_install() {
+    [ ! -d "$VENV_DIR" ] && return 0
+    [ ! -f "$MARKER" ] && return 0
+    current=$(pyproject_hash) || return 0
+    stored=$(cat "$MARKER" 2>/dev/null) || return 0
+    [ "$current" != "$stored" ]
+}
+
+# --- Bootstrap venv ---
+bootstrap() {
+    PYTHON_CMD=$(find_python) || {
+        echo "[arize] No Python 3.9+ found — tracing will not be available" >&2
+        return 1
+    }
+
+    # Recover from a half-created venv (e.g. Cursor Cloud where python3-venv
+    # may be only partially available): if VENV_DIR exists but has no usable
+    # pip, wipe it and rebuild from scratch.
+    if [ -d "$VENV_DIR" ] && [ ! -x "$VENV_DIR/bin/pip" ] && [ ! -x "$VENV_DIR/Scripts/pip" ] && [ ! -x "$VENV_DIR/Scripts/pip.exe" ]; then
+        echo "[arize] Removing incomplete venv at $VENV_DIR" >&2
+        rm -rf "$VENV_DIR"
+        rm -f "$MARKER"
+    fi
+
+    if ! needs_install; then
+        # pyproject mtime was newer (so we took the slow path) but the content
+        # is unchanged. Rewrite the marker to bump its mtime, so the cheap
+        # mtime gate keeps short-circuiting instead of re-hashing every event.
+        if [ -f "$MARKER" ]; then
+            _m=$(cat "$MARKER" 2>/dev/null) && printf '%s\n' "$_m" > "$MARKER" 2>/dev/null || true
+        fi
+        return 0
+    fi
+
+    echo "[arize] Setting up tracing venv at $VENV_DIR..." >&2
+    mkdir -p "$DATA_DIR"
+
+    # Capture combined output and check Python's real exit status: a
+    # `... | tail` pipeline would report tail's exit code and mask a venv
+    # failure (e.g. missing python3-venv).
+    venv_log=$("$PYTHON_CMD" -m venv "$VENV_DIR" 2>&1) || {
+        echo "[arize] Failed to create venv" >&2
+        printf '%s\n' "$venv_log" | tail -3 >&2
+        return 1
+    }
+
+    # Find pip in the new venv
+    PIP=""
+    if [ -x "$VENV_DIR/bin/pip" ]; then PIP="$VENV_DIR/bin/pip"
+    elif [ -x "$VENV_DIR/Scripts/pip" ]; then PIP="$VENV_DIR/Scripts/pip"
+    elif [ -x "$VENV_DIR/Scripts/pip.exe" ]; then PIP="$VENV_DIR/Scripts/pip.exe"
+    fi
+    if [ -z "$PIP" ]; then
+        echo "[arize] pip not found in venv" >&2
+        return 1
+    fi
+
+    echo "[arize] Installing tracing package from $PLUGIN_ROOT..." >&2
+    if ! "$PIP" install --quiet "$PLUGIN_ROOT" >&2; then
+        echo "[arize] pip install failed" >&2
+        rm -f "$MARKER"
+        return 1
+    fi
+
+    # Save hash marker (mtime now > pyproject's, so future events take the
+    # fast path). If hashing fails, drop the marker so we retry next event.
+    pyproject_hash > "$MARKER" || {
+        echo "[arize] Failed to record pyproject marker" >&2
+        rm -f "$MARKER"
+    }
+
+    echo "[arize] Tracing venv ready" >&2
+}
+
+# --- Main ---
+# Fast path: venv already built and pyproject unchanged since last install.
+# Skips find_python + hashing entirely (pure builtins, no subprocess) — this
+# is the steady state on every hook event.
+EP=$(find_entry_point) || EP=""
+if [ -n "$EP" ] && [ -f "$MARKER" ] && ! [ "$PYPROJECT" -nt "$MARKER" ]; then
+    exec "$EP"
+fi
+
+# Slow path: (re)build the venv if needed (first run or after an update).
+bootstrap || exit 0
+
+EP=$(find_entry_point) || {
+    echo "[arize] Entry point '$ENTRY_POINT' not found in venv" >&2
+    exit 0
+}
+
+exec "$EP"

--- a/tests/core/test_bootstrap_venv.py
+++ b/tests/core/test_bootstrap_venv.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Tests for the shared venv bootstrap at core/scripts/bootstrap-venv.
+
+Both the Cursor and Claude Code plugin run-hook wrappers delegate to this one
+script (reached via each plugin's core symlink). It must: keep a POSIX sh
+shebang, fail open (exit 0, silent stdout) when it cannot build a venv, and
+reserve stdout for the host's control protocol so a tracing hook never blocks
+the host.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+BOOTSTRAP = REPO_ROOT / "core" / "scripts" / "bootstrap-venv"
+
+
+def test_exists_and_executable():
+    assert BOOTSTRAP.is_file()
+    assert os.access(BOOTSTRAP, os.X_OK), "bootstrap-venv must be executable"
+
+
+def test_has_sh_shebang():
+    first_line = BOOTSTRAP.read_text().splitlines()[0]
+    assert first_line.startswith("#!/bin/sh"), f"expected POSIX sh shebang, got: {first_line!r}"
+
+
+def test_sh_syntax_check_passes():
+    if not shutil.which("sh"):
+        pytest.skip("sh not available")
+    result = subprocess.run(["sh", "-n", str(BOOTSTRAP)], capture_output=True)
+    assert result.returncode == 0, f"sh -n failed: {result.stderr.decode(errors='replace')}"
+
+
+def test_missing_args_is_a_usage_error():
+    """The arg guards (${1:?...}) surface a programming error loudly — this is
+    not the fail-open path (that's for runtime venv failures, not bad calls)."""
+    if not shutil.which("sh"):
+        pytest.skip("sh not available")
+    result = subprocess.run([str(BOOTSTRAP)], capture_output=True, stdin=subprocess.DEVNULL)
+    assert result.returncode != 0
+    assert b"usage" in result.stderr.lower()
+
+
+def test_fails_open_with_empty_stdout_when_no_python():
+    """With no Python on PATH, bootstrap-venv must exit 0 and write nothing to
+    stdout — stdout is reserved for the host's control protocol."""
+    if not shutil.which("sh"):
+        pytest.skip("sh not available")
+    with tempfile.TemporaryDirectory() as tmp:
+        venv_dir = os.path.join(tmp, "data", "venv")
+        # PATH = empty dir → no python/python3/py discoverable.
+        env = {"HOME": tmp, "PATH": tmp}
+        result = subprocess.run(
+            [str(BOOTSTRAP), str(REPO_ROOT / "tracing" / "cursor"), venv_dir, "arize-hook-cursor"],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            timeout=30,
+        )
+    assert result.returncode == 0, (
+        f"must fail open (exit 0); got {result.returncode}. " f"stderr: {result.stderr.decode(errors='replace')}"
+    )
+    assert result.stdout == b"", f"must write nothing to stdout; got {result.stdout!r}"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/tracing/cursor/test_cursor_plugin.py
+++ b/tests/tracing/cursor/test_cursor_plugin.py
@@ -181,6 +181,42 @@ class TestPyproject:
             "core.setup",
         }
 
+    def test_listed_packages_resolve_to_tracked_modules(self, parsed):
+        # The exact-set guard above only freezes a literal; it can't tell a
+        # correct list from a stale one. This asserts the real property the
+        # #41 trap is about: every declared package maps (via package-dir) to
+        # a real directory that ships at least one git-tracked .py file, so the
+        # wheel never declares a package whose only contents are gitignored.
+        packages = parsed["tool"]["setuptools"]["packages"]
+        package_dir = parsed["tool"]["setuptools"]["package-dir"]
+
+        def resolve(pkg: str) -> Path:
+            # Longest matching package-dir prefix wins, then append the rest.
+            best_key, best_root = "", "."
+            for key, root in package_dir.items():
+                if (pkg == key or pkg.startswith(key + ".")) and len(key) > len(best_key):
+                    best_key, best_root = key, root
+            rest = pkg[len(best_key) :].lstrip(".") if best_key else pkg
+            rel = rest.replace(".", "/")
+            return (PLUGIN_DIR / best_root / rel).resolve()
+
+        tracked = set(
+            subprocess.run(
+                ["git", "ls-files"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.splitlines()
+        )
+        for pkg in packages:
+            pkg_dir = resolve(pkg)
+            assert pkg_dir.is_dir(), f"package {pkg!r} resolves to missing dir {pkg_dir}"
+            has_tracked_py = any(
+                (REPO_ROOT / rel).resolve().parent == pkg_dir and rel.endswith(".py") for rel in tracked
+            )
+            assert has_tracked_py, f"package {pkg!r} ({pkg_dir}) ships no git-tracked .py file"
+
 
 # --- core symlink ---
 
@@ -221,14 +257,24 @@ class TestRunHook:
     def test_uses_dedicated_venv_path(self):
         # Must be plugin-dedicated, NOT the shared bare harness/venv used by
         # install.sh — otherwise a marketplace install would clobber an
-        # install.sh-managed venv (and vice versa).
+        # install.sh-managed venv (and vice versa). The venv lives in its own
+        # subdir so the reinstall marker (derived as <venv-parent>/.pyproject.sha256
+        # by the shared bootstrap) is isolated too.
         text = RUN_HOOK.read_text()
-        assert "cursor-plugin-venv" in text
+        assert "cursor-plugin/venv" in text
+        assert "harness/venv" not in text, "must not collide with the install.sh-managed venv"
 
     def test_resolves_plugin_root_from_script(self):
         # Cursor exposes no plugin-root env var; the script must derive its
         # own location.
         assert "dirname" in RUN_HOOK.read_text()
+
+    def test_delegates_to_shared_bootstrap(self):
+        # run-hook is a thin wrapper; the bootstrap logic lives in the shared
+        # core/scripts/bootstrap-venv reached via the plugin's core symlink.
+        text = RUN_HOOK.read_text()
+        assert "core/scripts/bootstrap-venv" in text
+        assert (REPO_ROOT / "core" / "scripts" / "bootstrap-venv").is_file()
 
     def test_does_not_reference_claude_plugin_vars(self):
         text = RUN_HOOK.read_text()

--- a/tracing/claude_code/scripts/run-hook
+++ b/tracing/claude_code/scripts/run-hook
@@ -1,107 +1,27 @@
 #!/bin/sh
-# Arize tracing hook dispatcher.
-# Called by every Claude Code hook. Bootstraps the venv on first run,
-# then dispatches to the named entry point.
+# Arize tracing hook dispatcher for the Claude Code plugin.
+#
+# Thin wrapper over the shared bootstrap-venv script (reached via the plugin's
+# core symlink). Claude Code sets CLAUDE_PLUGIN_ROOT and CLAUDE_PLUGIN_DATA for
+# plugin hooks; the entry-point name is passed as $1.
 #
 # Usage: run-hook <entry-point-name>
 #   e.g. run-hook arize-hook-session-start
 #
-# Requires CLAUDE_PLUGIN_ROOT and CLAUDE_PLUGIN_DATA env vars
-# (set automatically by Claude Code for plugin hooks).
+# Claude passes the hook payload on stdin (inherited through exec); stdout is
+# reserved for Claude's hook protocol. Any failure exits 0 so tracing never
+# blocks Claude Code.
 set -e
 
-HOOK_NAME="${1:?usage: run-hook <entry-point-name>}"
+ENTRY_POINT="${1:?usage: run-hook <entry-point-name>}"
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT not set}"
 DATA_DIR="${CLAUDE_PLUGIN_DATA:?CLAUDE_PLUGIN_DATA not set}"
 VENV_DIR="$DATA_DIR/venv"
-MARKER="$DATA_DIR/.pyproject.sha256"
+BOOTSTRAP="$PLUGIN_ROOT/core/scripts/bootstrap-venv"
 
-# --- Find the entry point binary ---
-find_entry_point() {
-    if [ -x "$VENV_DIR/bin/$HOOK_NAME" ]; then
-        echo "$VENV_DIR/bin/$HOOK_NAME"
-    elif [ -x "$VENV_DIR/Scripts/$HOOK_NAME" ]; then
-        echo "$VENV_DIR/Scripts/$HOOK_NAME"
-    elif [ -x "$VENV_DIR/Scripts/${HOOK_NAME}.exe" ]; then
-        echo "$VENV_DIR/Scripts/${HOOK_NAME}.exe"
-    else
-        return 1
-    fi
-}
-
-# --- Find Python 3.9+ ---
-find_python() {
-    for p in python3 python py; do
-        if "$p" -c "import sys; sys.exit(0 if sys.version_info>=(3,9) else 1)" 2>/dev/null; then
-            echo "$p"
-            return 0
-        fi
-    done
-    return 1
-}
-
-# --- Check if (re)install is needed ---
-needs_install() {
-    [ ! -d "$VENV_DIR" ] && return 0
-    [ ! -f "$MARKER" ] && return 0
-    # Compare pyproject.toml hash
-    current=$("$PYTHON_CMD" -c "import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$PLUGIN_ROOT/pyproject.toml" 2>/dev/null) || return 0
-    stored=$(cat "$MARKER" 2>/dev/null) || return 0
-    [ "$current" != "$stored" ]
-}
-
-# --- Bootstrap venv ---
-bootstrap() {
-    PYTHON_CMD=$(find_python) || {
-        echo "[arize] No Python 3.9+ found — tracing will not be available" >&2
-        return 1
-    }
-
-    if ! needs_install; then
-        return 0
-    fi
-
-    echo "[arize] Setting up tracing venv..." >&2
-    mkdir -p "$DATA_DIR"
-
-    "$PYTHON_CMD" -m venv "$VENV_DIR" 2>&1 | tail -3 >&2 || {
-        echo "[arize] Failed to create venv" >&2
-        return 1
-    }
-
-    # Find pip in the new venv
-    PIP=""
-    if [ -x "$VENV_DIR/bin/pip" ]; then PIP="$VENV_DIR/bin/pip"
-    elif [ -x "$VENV_DIR/Scripts/pip" ]; then PIP="$VENV_DIR/Scripts/pip"
-    elif [ -x "$VENV_DIR/Scripts/pip.exe" ]; then PIP="$VENV_DIR/Scripts/pip.exe"
-    fi
-    if [ -z "$PIP" ]; then
-        echo "[arize] pip not found in venv" >&2
-        return 1
-    fi
-
-    echo "[arize] Installing claude-code-tracing from $PLUGIN_ROOT..." >&2
-    if ! "$PIP" install --quiet "$PLUGIN_ROOT" >&2; then
-        echo "[arize] pip install failed" >&2
-        rm -f "$MARKER"
-        return 1
-    fi
-
-    # Save hash marker
-    "$PYTHON_CMD" -c "import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" \
-        "$PLUGIN_ROOT/pyproject.toml" > "$MARKER"
-
-    echo "[arize] Tracing venv ready" >&2
-}
-
-# --- Main ---
-# Bootstrap if needed (only does work on first run or after update)
-bootstrap || exit 0
-
-# Find and exec the entry point
-EP=$(find_entry_point) || {
-    echo "[arize] Entry point '$HOOK_NAME' not found in venv" >&2
+if [ ! -x "$BOOTSTRAP" ]; then
+    echo "[arize] shared bootstrap script not found at $BOOTSTRAP" >&2
     exit 0
-}
+fi
 
-exec "$EP"
+exec "$BOOTSTRAP" "$PLUGIN_ROOT" "$VENV_DIR" "$ENTRY_POINT"

--- a/tracing/cursor/README.md
+++ b/tracing/cursor/README.md
@@ -9,7 +9,7 @@ Pass `--with-skills` to also symlink the `manage-cursor-tracing` skill into the 
 
 ### Plugin install
 
-Cursor 2.5+ users can install via the Cursor marketplace instead of running `install.sh`. The plugin auto-registers every hook event and lazily bootstraps a dedicated Python venv on first hook fire into `~/.arize/harness/cursor-plugin-venv` (kept separate from the `install.sh`-managed `~/.arize/harness/venv` to avoid pip file-ownership conflicts).
+Cursor 2.5+ users can install via the Cursor marketplace instead of running `install.sh`. The plugin auto-registers every hook event and lazily bootstraps a dedicated Python venv on first hook fire into `~/.arize/harness/cursor-plugin/venv` (kept separate from the `install.sh`-managed `~/.arize/harness/venv` to avoid pip file-ownership conflicts).
 
 ```text
 /add-plugin Arize-ai/coding-harness-tracing

--- a/tracing/cursor/scripts/run-hook
+++ b/tracing/cursor/scripts/run-hook
@@ -1,125 +1,28 @@
 #!/bin/sh
 # Arize tracing hook dispatcher for the Cursor plugin.
-# Called by every Cursor hook event. Bootstraps a dedicated plugin venv on
-# first run, then execs the single dispatcher entry point. Cursor passes the
-# hook payload (including the event name) on stdin, which the entry point
-# reads to route internally.
 #
-# hooks.json invokes this script as "${CURSOR_PLUGIN_ROOT}/scripts/run-hook":
-# Cursor runs plugin hook commands from the opened project folder (not the
-# plugin dir), so a relative command would not resolve. Even so:
-#   - PLUGIN_ROOT is re-resolved here from the script's own location ($0), so
-#     dispatch is correct regardless of how the script was invoked
-#   - Cursor exposes no per-plugin *data* dir env var, so the venv lives in a
-#     fixed, plugin-dedicated path under ~/.arize/harness
+# Thin wrapper over the shared bootstrap-venv script (reached via the plugin's
+# core symlink). hooks.json invokes this as "${CURSOR_PLUGIN_ROOT}/scripts/run-hook"
+# because Cursor runs plugin hook commands from the opened project folder, not
+# the plugin dir. Even so, PLUGIN_ROOT is re-resolved here from the script's
+# own location ($0) so dispatch is correct however the script is launched.
 #
-# All diagnostic output goes to stderr; stdout is reserved for Cursor's
-# control JSON. Any failure exits 0 so tracing never blocks Cursor.
+# Cursor exposes no per-plugin *data* dir env var, so the venv lives at a
+# fixed, plugin-dedicated path under ~/.arize/harness (its own subdir, kept
+# isolated from the install.sh-managed venv). Cursor passes the hook payload
+# on stdin; stdout is reserved for Cursor's control JSON. Any failure exits 0
+# so tracing never blocks Cursor.
 set -e
 
-HOOK_NAME="arize-hook-cursor"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-DATA_DIR="$HOME/.arize/harness"
-VENV_DIR="$DATA_DIR/cursor-plugin-venv"
-MARKER="$DATA_DIR/.cursor-plugin.pyproject.sha256"
+VENV_DIR="$HOME/.arize/harness/cursor-plugin/venv"
+ENTRY_POINT="arize-hook-cursor"
+BOOTSTRAP="$PLUGIN_ROOT/core/scripts/bootstrap-venv"
 
-# --- Find the entry point binary ---
-find_entry_point() {
-    if [ -x "$VENV_DIR/bin/$HOOK_NAME" ]; then
-        echo "$VENV_DIR/bin/$HOOK_NAME"
-    elif [ -x "$VENV_DIR/Scripts/$HOOK_NAME" ]; then
-        echo "$VENV_DIR/Scripts/$HOOK_NAME"
-    elif [ -x "$VENV_DIR/Scripts/${HOOK_NAME}.exe" ]; then
-        echo "$VENV_DIR/Scripts/${HOOK_NAME}.exe"
-    else
-        return 1
-    fi
-}
-
-# --- Find Python 3.9+ ---
-find_python() {
-    for p in python3 python py; do
-        if "$p" -c "import sys; sys.exit(0 if sys.version_info>=(3,9) else 1)" 2>/dev/null; then
-            echo "$p"
-            return 0
-        fi
-    done
-    return 1
-}
-
-# --- Check if (re)install is needed ---
-needs_install() {
-    [ ! -d "$VENV_DIR" ] && return 0
-    [ ! -f "$MARKER" ] && return 0
-    # Compare pyproject.toml hash
-    current=$("$PYTHON_CMD" -c "import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$PLUGIN_ROOT/pyproject.toml" 2>/dev/null) || return 0
-    stored=$(cat "$MARKER" 2>/dev/null) || return 0
-    [ "$current" != "$stored" ]
-}
-
-# --- Bootstrap venv ---
-bootstrap() {
-    PYTHON_CMD=$(find_python) || {
-        echo "[arize] No Python 3.9+ found — tracing will not be available" >&2
-        return 1
-    }
-
-    # Recover from a half-created venv (seen in Cursor Cloud where
-    # python3-venv may be partially available). If $VENV_DIR exists but has
-    # no usable pip, wipe it and rebuild.
-    if [ -d "$VENV_DIR" ] && [ ! -x "$VENV_DIR/bin/pip" ] && [ ! -x "$VENV_DIR/Scripts/pip" ] && [ ! -x "$VENV_DIR/Scripts/pip.exe" ]; then
-        echo "[arize] Removing incomplete venv at $VENV_DIR" >&2
-        rm -rf "$VENV_DIR"
-        rm -f "$MARKER"
-    fi
-
-    if ! needs_install; then
-        return 0
-    fi
-
-    echo "[arize] Setting up Cursor tracing venv..." >&2
-    mkdir -p "$DATA_DIR"
-
-    "$PYTHON_CMD" -m venv "$VENV_DIR" 2>&1 | tail -3 >&2 || {
-        echo "[arize] Failed to create venv" >&2
-        return 1
-    }
-
-    # Find pip in the new venv
-    PIP=""
-    if [ -x "$VENV_DIR/bin/pip" ]; then PIP="$VENV_DIR/bin/pip"
-    elif [ -x "$VENV_DIR/Scripts/pip" ]; then PIP="$VENV_DIR/Scripts/pip"
-    elif [ -x "$VENV_DIR/Scripts/pip.exe" ]; then PIP="$VENV_DIR/Scripts/pip.exe"
-    fi
-    if [ -z "$PIP" ]; then
-        echo "[arize] pip not found in venv" >&2
-        return 1
-    fi
-
-    echo "[arize] Installing cursor-tracing from $PLUGIN_ROOT..." >&2
-    if ! "$PIP" install --quiet "$PLUGIN_ROOT" >&2; then
-        echo "[arize] pip install failed" >&2
-        rm -f "$MARKER"
-        return 1
-    fi
-
-    # Save hash marker
-    "$PYTHON_CMD" -c "import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" \
-        "$PLUGIN_ROOT/pyproject.toml" > "$MARKER"
-
-    echo "[arize] Cursor tracing venv ready" >&2
-}
-
-# --- Main ---
-# Bootstrap if needed (only does work on first run or after update)
-bootstrap || exit 0
-
-# Find and exec the entry point. Cursor's hook payload is on stdin and is
-# inherited by exec, so the dispatcher reads it directly.
-EP=$(find_entry_point) || {
-    echo "[arize] Entry point '$HOOK_NAME' not found in venv" >&2
+if [ ! -x "$BOOTSTRAP" ]; then
+    echo "[arize] shared bootstrap script not found at $BOOTSTRAP" >&2
     exit 0
-}
+fi
 
-exec "$EP"
+exec "$BOOTSTRAP" "$PLUGIN_ROOT" "$VENV_DIR" "$ENTRY_POINT"


### PR DESCRIPTION
Stacked on #55 (follow-up to the #56 hook-root fix). Addresses the remaining quality/robustness items from the #55 code review — **#3, #4, #5, #6, #7**. The #1 correctness fix landed in #56; #2 was refuted by Cursor's docs (fail-open is the default); #8 (runtime span-dedup guard) was intentionally left out as a separate design decision.

## Changes

**#5 — de-duplicate the bootstrap (cross-plugin).** The ~110-line venv bootstrap was copy-pasted between the Cursor and Claude Code `run-hook` scripts. Factored it into a single `core/scripts/bootstrap-venv`, reached via each plugin's **existing `core` symlink** (no new symlink added — same fragility profile as today's packaging). Both `run-hook`s are now thin wrappers that set `PLUGIN_ROOT`/`VENV_DIR`/`ENTRY_POINT` and `exec` the shared script. The half-venv self-heal that previously existed only in the Cursor copy now covers Claude Code too.

**#4 — hot path.** `run-hook` fires on every hook event. Once the venv is built and `pyproject.toml` is unchanged, the script now execs the entry point using pure shell builtins behind a cheap mtime gate — no `find_python` probes and no Python hashing subprocess per event. (Verified: second run produces empty stderr.)

**#3 — unmask venv-creation failure.** `python -m venv … | tail -3` reported `tail`'s exit code, so a venv failure (e.g. missing `python3-venv`) slipped past the error branch. Now captures output and checks Python's real exit status.

**#7 — isolate the Cursor venv.** Moved it to a dedicated `~/.arize/harness/cursor-plugin/` subdir so both the venv **and** the derived reinstall marker (`<venv-parent>/.pyproject.sha256`) are isolated from the `install.sh`-managed `~/.arize/harness/venv`. Claude's marker location is unchanged (`$CLAUDE_PLUGIN_DATA/.pyproject.sha256`).

**#6 — strengthen the packaging test.** Added a property assertion: every declared package resolves (via `package-dir`) to a real directory shipping at least one git-tracked `.py` — the actual invariant behind the #41 trap — alongside the existing exact-set guard.

## Verification

- `uv run pytest tests/tracing tests/core` → **1659 passed**
- New `tests/core/test_bootstrap_venv.py` (shebang, `sh -n`, usage-error, fail-open).
- `uv run pre-commit run --all-files` → clean.
- Manual end-to-end, both plugins: first-run venv build at the correct/dedicated path → second-run fast path (empty stderr) → fail-open (exit 0, silent stdout) with no Python on PATH.

> Note: a pre-existing local branch `wb/shared-bootstrap` also prototyped #5; this is a fresh, independent implementation (per review decision) that additionally folds in #3/#4/#7 and fixes a marker-namespacing regression that approach introduced for Cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)