### PR TITLE
Improve Codex trace attribution and error logs

### DIFF
--- a/core/common.py
+++ b/core/common.py
@@ -6,6 +6,7 @@ key-value state backed by YAML files), and OTLP span building functions.
 Replaces the jq-based state functions in common.sh lines 46-109 and
 build_span/build_multi_span from common.sh lines 277-317 / codex common.sh lines 110-145.
 """
+
 import atexit
 import functools
 import json as _json
@@ -582,6 +583,13 @@ def send_span(span_dict: dict) -> bool:
             try:
                 with urllib.request.urlopen(req, timeout=10) as resp:
                     return 200 <= resp.status < 300
+            except urllib.error.HTTPError as e:
+                try:
+                    detail = e.read().decode("utf-8", errors="replace")
+                except Exception:
+                    detail = ""
+                error(f"Phoenix send failed: HTTP {e.code}: {detail or e.reason}")
+                return False
             except Exception as e:
                 error(f"Phoenix send failed: {e}")
                 return False
@@ -610,6 +618,13 @@ def send_span(span_dict: dict) -> bool:
             try:
                 with urllib.request.urlopen(req, timeout=10) as resp:
                     return 200 <= resp.status < 300
+            except urllib.error.HTTPError as e:
+                try:
+                    detail = e.read().decode("utf-8", errors="replace")
+                except Exception:
+                    detail = ""
+                error(f"Arize send failed: HTTP {e.code}: {detail or e.reason}")
+                return False
             except Exception as e:
                 error(f"Arize send failed: {e}")
                 return False

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Tests for core.common — FileLock, StateManager, and span building."""
+
+import io
 import json
 import threading
 import time
@@ -1058,6 +1060,30 @@ class TestSendSpan:
 
     @mock.patch("core.common.resolve_backend")
     @mock.patch("core.common.urllib.request.urlopen")
+    def test_phoenix_http_error_logs_response_body(self, mock_urlopen, mock_resolve, capsys, monkeypatch):
+        """Phoenix HTTP errors include the response body in logs."""
+        monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
+        monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
+
+        mock_resolve.return_value = {
+            "target": "phoenix",
+            "endpoint": "http://phoenix:6006",
+            "api_key": "",
+            "project_name": "default",
+        }
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            "http://phoenix:6006/v1/projects/default/spans",
+            400,
+            "Bad Request",
+            {},
+            io.BytesIO(b'{"error":"bad span"}'),
+        )
+
+        assert send_span(self._SAMPLE_SPAN) is False
+        assert '{"error":"bad span"}' in capsys.readouterr().err
+
+    @mock.patch("core.common.resolve_backend")
+    @mock.patch("core.common.urllib.request.urlopen")
     def test_arize_direct_send(self, mock_urlopen, mock_resolve, monkeypatch):
         """send_span sends directly to Arize HTTP/JSON endpoint."""
         monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
@@ -1106,6 +1132,31 @@ class TestSendSpan:
         mock_urlopen.side_effect = urllib.error.URLError("connection refused")
 
         assert send_span(self._SAMPLE_SPAN) is False
+
+    @mock.patch("core.common.resolve_backend")
+    @mock.patch("core.common.urllib.request.urlopen")
+    def test_arize_http_error_logs_response_body(self, mock_urlopen, mock_resolve, capsys, monkeypatch):
+        """Arize HTTP errors include the response body in logs."""
+        monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
+        monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
+
+        mock_resolve.return_value = {
+            "target": "arize",
+            "api_key": "key",
+            "space_id": "space",
+            "endpoint": "otlp.arize.com:443",
+            "project_name": "proj",
+        }
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            "https://otlp.arize.com:443/v1/traces",
+            500,
+            "Internal Server Error",
+            {},
+            io.BytesIO(b'{"code":13,"message":"unable to validate authorization from span"}'),
+        )
+
+        assert send_span(self._SAMPLE_SPAN) is False
+        assert "unable to validate authorization from span" in capsys.readouterr().err
 
     @mock.patch("core.common.resolve_backend")
     def test_no_backend_returns_false(self, mock_resolve, monkeypatch):

--- a/tests/tracing/codex/test_codex_hook.py
+++ b/tests/tracing/codex/test_codex_hook.py
@@ -358,7 +358,7 @@ class TestBuildAndSendSpans:
             "user_prompt": "hi",
             "assistant_output": "hello",
             "model": "gpt-5.5",
-            "cwd": "/Users/test/workspaces/loom_eval",
+            "cwd": "/x/workspace",
             "permission_mode": "on-request",
             "sandbox_mode": "workspace-write",
             "token_usage": {
@@ -394,15 +394,15 @@ class TestBuildAndSendSpans:
         assert parent_attrs["llm.model_name"]["stringValue"] == "gpt-5.5"
         assert parent_attrs["codex.approval_mode"]["stringValue"] == "on-request"
         assert parent_attrs["codex.sandbox_mode"]["stringValue"] == "workspace-write"
-        assert parent_attrs["codex.cwd"]["stringValue"] == "/Users/test/workspaces/loom_eval"
-        assert parent_attrs["codex.workspace"]["stringValue"] == "loom_eval"
+        assert parent_attrs["codex.cwd"]["stringValue"] == "/x/workspace"
+        assert parent_attrs["codex.workspace"]["stringValue"] == "workspace"
         assert parent_attrs["llm.token_count.total"]["intValue"] == 15
 
         child_attrs = _attrs_of_span(spans[1])
         assert child_attrs["tool.name"]["stringValue"] == "exec_command"
         assert child_attrs["codex.tool.call_id"]["stringValue"] == "c1"
-        assert child_attrs["codex.cwd"]["stringValue"] == "/Users/test/workspaces/loom_eval"
-        assert child_attrs["codex.workspace"]["stringValue"] == "loom_eval"
+        assert child_attrs["codex.cwd"]["stringValue"] == "/x/workspace"
+        assert child_attrs["codex.workspace"]["stringValue"] == "workspace"
         assert child_attrs["input.value"]["stringValue"] == '{"cmd":"ls"}'
         assert child_attrs["output.value"]["stringValue"] == "ok"
 

--- a/tests/tracing/codex/test_codex_hook.py
+++ b/tests/tracing/codex/test_codex_hook.py
@@ -358,7 +358,7 @@ class TestBuildAndSendSpans:
             "user_prompt": "hi",
             "assistant_output": "hello",
             "model": "gpt-5.5",
-            "cwd": "/x",
+            "cwd": "/Users/test/workspaces/loom_eval",
             "permission_mode": "on-request",
             "sandbox_mode": "workspace-write",
             "token_usage": {
@@ -394,11 +394,15 @@ class TestBuildAndSendSpans:
         assert parent_attrs["llm.model_name"]["stringValue"] == "gpt-5.5"
         assert parent_attrs["codex.approval_mode"]["stringValue"] == "on-request"
         assert parent_attrs["codex.sandbox_mode"]["stringValue"] == "workspace-write"
+        assert parent_attrs["codex.cwd"]["stringValue"] == "/Users/test/workspaces/loom_eval"
+        assert parent_attrs["codex.workspace"]["stringValue"] == "loom_eval"
         assert parent_attrs["llm.token_count.total"]["intValue"] == 15
 
         child_attrs = _attrs_of_span(spans[1])
         assert child_attrs["tool.name"]["stringValue"] == "exec_command"
         assert child_attrs["codex.tool.call_id"]["stringValue"] == "c1"
+        assert child_attrs["codex.cwd"]["stringValue"] == "/Users/test/workspaces/loom_eval"
+        assert child_attrs["codex.workspace"]["stringValue"] == "loom_eval"
         assert child_attrs["input.value"]["stringValue"] == '{"cmd":"ls"}'
         assert child_attrs["output.value"]["stringValue"] == "ok"
 

--- a/tracing/codex/hooks/handlers.py
+++ b/tracing/codex/hooks/handlers.py
@@ -19,6 +19,7 @@ single source of truth for the session.
 Input contract: JSON as ``sys.argv[1]`` (NOT stdin -- Codex passes notify
 JSON as a CLI argument). No stdout response expected.
 """
+
 from __future__ import annotations
 
 import json
@@ -344,6 +345,8 @@ def _build_and_send_spans(thread_id: str, turn_id: str, turn: dict) -> None:
     user_prompt = redact_content(env.log_prompts, turn.get("user_prompt") or "")
     assistant_output = redact_content(env.log_prompts, turn.get("assistant_output") or "")
     final_output = assistant_output or "(No response)"
+    cwd = turn.get("cwd") or ""
+    workspace = Path(cwd).name if cwd else ""
 
     attrs: dict = {
         "session.id": thread_id,
@@ -354,6 +357,10 @@ def _build_and_send_spans(thread_id: str, turn_id: str, turn: dict) -> None:
         "output.value": final_output,
         "codex.thread_id": thread_id,
     }
+    if cwd:
+        attrs["codex.cwd"] = cwd
+    if workspace:
+        attrs["codex.workspace"] = workspace
     if turn_id:
         attrs["codex.turn_id"] = turn_id
     if user_id:
@@ -393,6 +400,10 @@ def _build_and_send_spans(thread_id: str, turn_id: str, turn: dict) -> None:
             "output.value": redact_content(env.log_tool_content, output_raw),
             "session.id": thread_id,
         }
+        if cwd:
+            tool_attrs["codex.cwd"] = cwd
+        if workspace:
+            tool_attrs["codex.workspace"] = workspace
         if entry.get("call_id"):
             tool_attrs["codex.tool.call_id"] = entry["call_id"]
         child_start = entry.get("start_ts") or turn["turn_start_ms"]


### PR DESCRIPTION
Replaces #60 (original branch was on a fork without push access, so review feedback could not be applied there).

## Summary
- Capture Codex session `cwd` and derived `workspace` name on parent and tool spans for better trace attribution.
- Log the HTTP response body on Phoenix/Arize send failures so authorization and validation errors are diagnosable.
- Add tests covering the HTTP error logging and the new span attributes.

## Changes from #60
- Addressed @duncankmckinnon's review: replaced loom-specific test paths (`/Users/test/workspaces/loom_eval`) with neutral `/x/workspace`.

## Test plan
- [x] `pytest tests/tracing/codex/test_codex_hook.py -k test_multi_span_with_one_tool`
- [ ] `pytest tests/core/test_common.py` (HTTP error logging tests)

Made with [Cursor](https://cursor.com)