### PR TITLE
chore: codeowner update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default code owners for all files
-* @dirkbrnd @duncankmckinnon @fjcasti1 @gabe0912 @tofuadmiral
+* @dirkbrnd @duncankmckinnon @fjcasti1 @gabe0912 @tofuadmiral @luke-moehlenbrock

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default code owners for all files
-* @dirkbrnd @duncankmckinnon @fjcasti1 @gabe0912 @tofuadmiral @luke-moehlenbrock
+* @dirkbrnd @duncankmckinnon @fjcasti1 @gabe0912 @tofuadmiral @luke-moehlenbrock @nate-mar @jyadav2008

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default code owners for all files
-* @dirkbrnd @duncankmckinnon @fjcasti1 @gabe0912 @tofuadmiral @luke-moehlenbrock @nate-mar @jyadav2008
+* @dirkbrnd @duncankmckinnon @fjcasti1 @gabe0912 @tofuadmiral @nate-mar @jyadav2008 @musicionary @caroger @sanchitram1 @21ShisodeParth @kafedewa @chrisgong52


### PR DESCRIPTION
add nate, jitendra, parth, chip, roger hu, kayla, sanchit arvind, and chris gong as codeowner