### PR TITLE
fix(claude_code): emit prompt-cache token breakdown so cost isn't over-reported ~3-4x

### DIFF
--- a/tests/tracing/claude/test_claude_hook.py
+++ b/tests/tracing/claude/test_claude_hook.py
@@ -388,12 +388,40 @@ class TestStop:
             _handle_stop({})
         span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
         attrs = {a["key"]: a["value"] for a in span["attributes"]}
-        # input_tokens=100, cache_read=10, cache_creation=5 → 115 prompt
+        # input_tokens=100, cache_read=10, cache_creation=5 → 115 prompt (total, incl. cache)
         assert attrs["llm.token_count.prompt"]["intValue"] == 115
         # output_tokens=50
         assert attrs["llm.token_count.completion"]["intValue"] == 50
         # total
         assert attrs["llm.token_count.total"]["intValue"] == 165
+        # Cache breakdown surfaced as prompt_details so cost is priced at cache rates
+        assert attrs["llm.token_count.prompt_details.cache_read"]["intValue"] == 10
+        assert attrs["llm.token_count.prompt_details.cache_write"]["intValue"] == 5
+
+    def test_omits_cache_details_when_uncached(self, mock_resolve, state, captured_spans, tmp_path):
+        """No prompt_details.cache_* attributes when there are no cache tokens."""
+        tf = tmp_path / "uncached.jsonl"
+        entry = {
+            "message": {
+                "role": "assistant",
+                "content": "no caching here",
+                "model": "claude-test",
+                "usage": {"input_tokens": 42, "output_tokens": 7},
+            }
+        }
+        tf.write_text(json.dumps(entry) + "\n")
+        state.set("current_trace_id", "t" * 32)
+        state.set("current_trace_span_id", "s" * 16)
+        state.set("current_trace_start_time", "1000")
+        state.set("current_trace_prompt", "test")
+        state.set("trace_start_line", "0")
+        with mock.patch("tracing.claude_code.hooks.handlers.resolve_transcript_path", return_value=tf):
+            _handle_stop({})
+        span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert attrs["llm.token_count.prompt"]["intValue"] == 42
+        assert "llm.token_count.prompt_details.cache_read" not in attrs
+        assert "llm.token_count.prompt_details.cache_write" not in attrs
 
     def test_skips_lines_before_trace_start_line(self, mock_resolve, state, captured_spans, transcript_file):
         """Skips lines before trace_start_line."""
@@ -490,6 +518,8 @@ class TestStop:
         assert attrs["llm.token_count.prompt"]["intValue"] == 115
         assert attrs["llm.token_count.completion"]["intValue"] == 50
         assert attrs["llm.token_count.total"]["intValue"] == 165
+        assert attrs["llm.token_count.prompt_details.cache_read"]["intValue"] == 10
+        assert attrs["llm.token_count.prompt_details.cache_write"]["intValue"] == 5
         # Output text
         assert attrs["output.value"]["stringValue"] == "I found the issue."
         # Model
@@ -568,18 +598,22 @@ class TestScanTranscriptForUsage:
 
     def test_basic_extraction(self, transcript_file):
         """Extracts text, tokens, and model from standard transcript."""
-        output, in_tok, out_tok, model = _scan_transcript_for_usage(Path(transcript_file), 0)
+        output, usage, model = _scan_transcript_for_usage(Path(transcript_file), 0)
         assert output == "I found the issue."
-        assert in_tok == 115  # 100 + 10 + 5
-        assert out_tok == 50
+        assert usage.prompt == 115  # 100 + 10 + 5
+        assert usage.completion == 50
+        assert usage.cache_read == 10
+        assert usage.cache_write == 5
         assert model == "claude-sonnet-4-20250514"
 
     def test_skips_lines_before_start(self, transcript_file):
         """Lines before start_line are skipped entirely."""
-        output, in_tok, out_tok, model = _scan_transcript_for_usage(Path(transcript_file), 3)
+        output, usage, model = _scan_transcript_for_usage(Path(transcript_file), 3)
         assert output == ""
-        assert in_tok == 0
-        assert out_tok == 0
+        assert usage.prompt == 0
+        assert usage.completion == 0
+        assert usage.cache_read == 0
+        assert usage.cache_write == 0
         assert model == ""
 
     def test_handles_string_content(self, tmp_path):
@@ -594,10 +628,10 @@ class TestScanTranscriptForUsage:
             }
         }
         tf.write_text(json.dumps(entry) + "\n")
-        output, in_tok, out_tok, model = _scan_transcript_for_usage(tf, 0)
+        output, usage, model = _scan_transcript_for_usage(tf, 0)
         assert output == "plain text"
-        assert in_tok == 1
-        assert out_tok == 2
+        assert usage.prompt == 1
+        assert usage.completion == 2
         assert model == "m1"
 
     def test_handles_malformed_lines(self, tmp_path):
@@ -612,9 +646,9 @@ class TestScanTranscriptForUsage:
             "{invalid json",
         ]
         tf.write_text("\n".join(lines) + "\n")
-        output, in_tok, out_tok, model = _scan_transcript_for_usage(tf, 0)
+        output, usage, model = _scan_transcript_for_usage(tf, 0)
         assert output == "good"
-        assert out_tok == 5
+        assert usage.completion == 5
 
     def test_skips_non_assistant_messages(self, tmp_path):
         """Only processes assistant messages, skips user/system."""
@@ -634,9 +668,9 @@ class TestScanTranscriptForUsage:
             json.dumps({"message": {"role": "system", "content": "system msg"}}),
         ]
         tf.write_text("\n".join(lines) + "\n")
-        output, in_tok, out_tok, model = _scan_transcript_for_usage(tf, 0)
+        output, usage, model = _scan_transcript_for_usage(tf, 0)
         assert output == "assistant msg"
-        assert out_tok == 3
+        assert usage.completion == 3
 
     def test_concatenates_multiple_assistant_messages(self, tmp_path):
         """Multiple assistant messages are concatenated with newlines."""
@@ -650,9 +684,9 @@ class TestScanTranscriptForUsage:
             ),
         ]
         tf.write_text("\n".join(lines) + "\n")
-        output, in_tok, out_tok, model = _scan_transcript_for_usage(tf, 0)
+        output, usage, model = _scan_transcript_for_usage(tf, 0)
         assert output == "first\nsecond"
-        assert out_tok == 3
+        assert usage.completion == 3
         # Model should be the last non-empty one
         assert model == "m2"
 
@@ -672,12 +706,12 @@ class TestScanTranscriptForUsage:
             ),
         ]
         tf.write_text("\n".join(lines) + "\n")
-        output, in_tok, out_tok, model = _scan_transcript_for_usage(tf, 0)
+        output, usage, model = _scan_transcript_for_usage(tf, 0)
         assert output == ""
-        assert out_tok == 1
+        assert usage.completion == 1
 
     def test_accumulates_all_token_types(self, tmp_path):
-        """Sums input_tokens, cache_read, and cache_creation for in_tokens."""
+        """Prompt total sums input + cache_read + cache_creation; cache buckets tracked separately."""
         tf = tmp_path / "tokens.jsonl"
         entry = {
             "message": {
@@ -693,9 +727,11 @@ class TestScanTranscriptForUsage:
             }
         }
         tf.write_text(json.dumps(entry) + "\n")
-        output, in_tok, out_tok, model = _scan_transcript_for_usage(tf, 0)
-        assert in_tok == 60  # 10 + 20 + 30
-        assert out_tok == 40
+        output, usage, model = _scan_transcript_for_usage(tf, 0)
+        assert usage.prompt == 60  # 10 + 20 + 30
+        assert usage.completion == 40
+        assert usage.cache_read == 20
+        assert usage.cache_write == 30
 
 
 # ---------------------------------------------------------------------------

--- a/tracing/claude_code/hooks/handlers.py
+++ b/tracing/claude_code/hooks/handlers.py
@@ -6,6 +6,7 @@ entry point registered in pyproject.toml [project.scripts].
 """
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from core.common import (
@@ -346,16 +347,58 @@ def _handle_user_prompt_submit(input_json: dict) -> None:
         state.set("trace_start_line", "0")
 
 
+def _usage_int(usage: dict, key: str) -> int:
+    """Read an int token count from a usage dict, treating non-ints as 0."""
+    val = usage.get(key, 0)
+    return val if isinstance(val, int) else 0
+
+
+@dataclass
+class _TokenUsage:
+    """Token counts parsed from a transcript.
+
+    ``prompt`` is the OpenInference prompt total: it includes *all* input
+    subtypes (uncached input + cache reads + cache writes), per the Arize/
+    Phoenix cost model where the base "input" portion is derived as
+    ``prompt - cache_read - cache_write``. ``cache_read`` and ``cache_write``
+    are therefore subsets of ``prompt``, surfaced separately so the cost
+    engine can price them at their own (much cheaper) rates instead of the
+    full input rate. Without the breakdown, prompt-cache tokens are billed as
+    full-price input, over-reporting cost ~3-4x for heavily-cached agent runs.
+    """
+
+    prompt: int = 0
+    completion: int = 0
+    cache_read: int = 0
+    cache_write: int = 0
+
+    def token_count_attrs(self) -> dict:
+        """Return OpenInference token-count attributes for span emission.
+
+        Cache detail attributes are only included when non-zero to avoid
+        cluttering spans for uncached calls.
+        """
+        attrs: dict = {
+            "llm.token_count.prompt": self.prompt,
+            "llm.token_count.completion": self.completion,
+            "llm.token_count.total": self.prompt + self.completion,
+        }
+        if self.cache_read:
+            attrs["llm.token_count.prompt_details.cache_read"] = self.cache_read
+        if self.cache_write:
+            attrs["llm.token_count.prompt_details.cache_write"] = self.cache_write
+        return attrs
+
+
 def _scan_transcript_for_usage(
     transcript: Path,
     start_line: int,
-) -> "tuple[str, int, int, str]":
+) -> "tuple[str, _TokenUsage, str]":
     """Walk the transcript JSONL from *start_line* forward and return:
-    (combined_text, in_tokens, out_tokens, model_name)
+    (combined_text, usage, model_name)
     """
     output = ""
-    in_tokens = 0
-    out_tokens = 0
+    usage_totals = _TokenUsage()
     model = ""
 
     with open(transcript) as f:
@@ -387,16 +430,22 @@ def _scan_transcript_for_usage(
 
             model = msg.get("model", "") or model
 
+            # Anthropic reports input_tokens (uncached), cache_read_input_tokens,
+            # and cache_creation_input_tokens as disjoint buckets. The prompt
+            # total is their sum (the OpenInference total), while the two cache
+            # buckets are tracked separately and surfaced as prompt_details so
+            # downstream cost pricing can apply the cheaper cache-read /
+            # cache-write rates instead of the full input rate.
             usage = msg.get("usage", {})
-            for key in ("input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"):
-                val = usage.get(key, 0)
-                if isinstance(val, int):
-                    in_tokens += val
-            val = usage.get("output_tokens", 0)
-            if isinstance(val, int):
-                out_tokens += val
+            uncached = _usage_int(usage, "input_tokens")
+            cache_read = _usage_int(usage, "cache_read_input_tokens")
+            cache_write = _usage_int(usage, "cache_creation_input_tokens")
+            usage_totals.prompt += uncached + cache_read + cache_write
+            usage_totals.cache_read += cache_read
+            usage_totals.cache_write += cache_write
+            usage_totals.completion += _usage_int(usage, "output_tokens")
 
-    return output, in_tokens, out_tokens, model
+    return output, usage_totals, model
 
 
 def _handle_stop(input_json: dict) -> None:
@@ -419,22 +468,19 @@ def _handle_stop(input_json: dict) -> None:
     last_msg = input_json.get("last_assistant_message", "") or ""
     output = last_msg
 
-    in_tokens = 0
-    out_tokens = 0
+    usage = _TokenUsage()
     model = ""
 
     transcript = resolve_transcript_path(input_json, session_id)
     if transcript is not None:
         start_line = int(state.get("trace_start_line") or "0")
-        scanned_output, in_tokens, out_tokens, scanned_model = _scan_transcript_for_usage(transcript, start_line)
+        scanned_output, usage, scanned_model = _scan_transcript_for_usage(transcript, start_line)
         if not output:
             output = scanned_output
         model = scanned_model
 
     if not output:
         output = "(No response)"
-
-    total_tokens = in_tokens + out_tokens
 
     # Build and send LLM span. Redact at emit time, not at state-write time.
     redacted_prompt = redact_content(env.log_prompts, user_prompt)
@@ -446,9 +492,7 @@ def _handle_stop(input_json: dict) -> None:
         "project.name": project_name,
         "openinference.span.kind": "LLM",
         "llm.model_name": model,
-        "llm.token_count.prompt": in_tokens,
-        "llm.token_count.completion": out_tokens,
-        "llm.token_count.total": total_tokens,
+        **usage.token_count_attrs(),
         "input.value": redacted_prompt,
         "output.value": redacted_output,
         "llm.output_messages": json.dumps(output_messages),
@@ -539,8 +583,7 @@ def _handle_subagent_stop(input_json: dict) -> None:
     output = last_msg
 
     model = ""
-    in_tokens = 0
-    out_tokens = 0
+    usage = _TokenUsage()
 
     # Prefer state-stored start time set by SubagentStart; fall back to transcript birth time.
     stored_start = state.get(f"subagent_{agent_id}_start_time")
@@ -557,7 +600,7 @@ def _handle_subagent_stop(input_json: dict) -> None:
             birth = getattr(st, "st_birthtime", st.st_ctime)
             start_time = str(int(birth * 1000))
 
-        scanned_output, in_tokens, out_tokens, scanned_model = _scan_transcript_for_usage(transcript, 0)
+        scanned_output, usage, scanned_model = _scan_transcript_for_usage(transcript, 0)
         if not output:
             output = scanned_output
         model = scanned_model
@@ -568,8 +611,6 @@ def _handle_subagent_stop(input_json: dict) -> None:
     # Subagent output is a tool-like result — redact unless opted in.
     output = redact_content(env.log_tool_content, output)
 
-    total_tokens = in_tokens + out_tokens
-
     # Build attributes
     attrs = {
         "session.id": session_id,
@@ -577,9 +618,7 @@ def _handle_subagent_stop(input_json: dict) -> None:
         "subagent.id": agent_id,
         "subagent.type": agent_type,
         "llm.model_name": model,
-        "llm.token_count.prompt": in_tokens,
-        "llm.token_count.completion": out_tokens,
-        "llm.token_count.total": total_tokens,
+        **usage.token_count_attrs(),
         "output.value": output,
     }
     stored_prompt = state.get(f"subagent_{agent_id}_prompt") or ""


### PR DESCRIPTION
## Summary

Closes #66. The Claude Code tracer was summing `input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` into a single `llm.token_count.prompt` with **no cache breakdown**. Downstream (Arize/Phoenix) then priced that entire sum at the **full input rate**, so cache-read tokens (~10x cheaper) and cache-creation tokens (~1.25x input) were billed as full-price input — over-reporting traced cost **~3-4x** for heavily-cached agent runs (Signal generation, Signal "Open PR" fix jobs, dev sandboxes).

This is a **purely additive** fix: the `prompt` total is unchanged (it remains the OpenInference total *including* cache, from which the cost engine derives the base input as `prompt - cache_read - cache_write`). We now also emit the cache subsets as `prompt_details` so the cost engine can apply the cheaper cache rates.

## Changes

- `tracing/claude_code/hooks/handlers.py`
  - `_scan_transcript_for_usage()` now tracks the three input buckets separately via a small `_TokenUsage` dataclass instead of collapsing them.
  - Both span emitters (`_handle_stop` Turn/LLM span and `_handle_subagent_stop` CHAIN span) now emit, in addition to the existing counts:
    - `llm.token_count.prompt_details.cache_read` = `cache_read_input_tokens`
    - `llm.token_count.prompt_details.cache_write` = `cache_creation_input_tokens`
  - Detail attributes are only emitted when non-zero (no clutter for uncached calls).
- Tests updated for the new `(output, usage, model)` return shape; added coverage asserting the new `prompt_details.*` attributes are present when cached and absent when uncached.

## Effect on cost (from #66's live Signal PR run)

| | tokens |
|---|---|
| uncached input | 3,340 |
| cache_read | 785,824 |
| cache_creation | 126,531 |
| output | 585 |

- Before (full-rate on the 915,695 sum): **~\$2.76**
- After (cache rates applied via `prompt_details`): **~\$0.73**
- Over-report eliminated: **~3.8x**

## Note / follow-up (out of scope here)

The `cursor` adapter (`tracing/cursor/hooks/handlers.py`) emits cache counts under `llm.token_count.cache_read` / `llm.token_count.cache_write` — these are **not** the OpenInference attribute paths (`llm.token_count.prompt_details.cache_read` / `...cache_write`) the cost engine recognizes, so it likely has a similar (separate) pricing gap. Left out of this PR to keep it scoped to #66; happy to file a follow-up.

## Test plan

- [x] `pytest tests/tracing/claude/` (111 passed)
- [x] full suite `pytest` (1603 passed, 10 skipped)
- [x] `ruff check` clean + `black` formatted on changed files

Made with [Cursor](https://cursor.com)