### PR TITLE
fix: prefer per-harness config credentials over global env vars

### DIFF
--- a/core/common.py
+++ b/core/common.py
@@ -441,9 +441,14 @@ def resolve_backend(span_dict: dict) -> dict:
     # Resolve project_name: env > YAML > service_name
     project_name = env.project_name or harness_cfg.get("project_name", "") or service_name
 
-    # Resolve target: env-derived backend takes precedence over YAML target
+    # Resolve target: harness-specific config credentials take precedence over
+    # global env vars (ARIZE_API_KEY / ARIZE_SPACE_ID) so that a harness with
+    # its own api_key+space_id in config.yaml is not hijacked by a different
+    # harness's credentials exported in the shell environment.
     if env.phoenix_endpoint:
         target = "phoenix"
+    elif harness_cfg.get("api_key") and harness_cfg.get("space_id"):
+        target = "arize"
     elif env.api_key and env.space_id:
         target = "arize"
     else:
@@ -474,8 +479,8 @@ def resolve_backend(span_dict: dict) -> dict:
 
     if target == "arize":
         endpoint = harness_cfg.get("endpoint", "") or "otlp.arize.com:443"
-        api_key = env.api_key or harness_cfg.get("api_key", "")
-        space_id = env.space_id or harness_cfg.get("space_id", "")
+        api_key = harness_cfg.get("api_key", "") or env.api_key
+        space_id = harness_cfg.get("space_id", "") or env.space_id
 
         missing = []
         if not api_key:

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -1540,8 +1540,13 @@ class TestResolveBackend:
         assert result["target"] == "arize"
         assert result["api_key"] == "ak-env"
 
-    def test_env_api_key_overrides_yaml(self, monkeypatch):
-        """ARIZE_API_KEY env overrides YAML api_key while keeping YAML target/endpoint/space_id."""
+    def test_yaml_api_key_overrides_env(self, monkeypatch):
+        """Per-harness YAML api_key takes precedence over ARIZE_API_KEY env var.
+
+        When a harness has its own credentials in config.yaml, a globally-exported
+        ARIZE_API_KEY (e.g. from ~/.zshrc for a different harness) must not hijack
+        this harness's traces and send them to the wrong Arize space.
+        """
         monkeypatch.setenv("ARIZE_API_KEY", "ak-env")
         cfg = {
             "harnesses": {
@@ -1556,8 +1561,30 @@ class TestResolveBackend:
         monkeypatch.setattr("core.config.load_config", lambda: cfg)
 
         result = resolve_backend(self._make_span("claude-code"))
-        assert result["api_key"] == "ak-env"
+        assert result["api_key"] == "ak-yaml"
         assert result["space_id"] == "sp-yaml"
+
+    def test_env_api_key_used_when_yaml_has_no_credentials(self, monkeypatch):
+        """ARIZE_API_KEY + ARIZE_SPACE_ID env vars are used when YAML has no credentials.
+
+        Harnesses that rely solely on env vars (no api_key/space_id in config.yaml)
+        should still work via the global env var fallback.
+        """
+        monkeypatch.setenv("ARIZE_API_KEY", "ak-env")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "sp-env")
+        cfg = {
+            "harnesses": {
+                "claude-code": {
+                    "target": "arize",
+                    "endpoint": "otlp.arize.com:443",
+                },
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["api_key"] == "ak-env"
+        assert result["space_id"] == "sp-env"
 
     # ── error paths ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- When multiple harnesses are configured with **different Arize spaces** (e.g. one for cursor/claude-code and another for kiro), a global `ARIZE_API_KEY` + `ARIZE_SPACE_ID` exported in `~/.zshrc` is inherited by every harness hook process, silently routing all traces to whichever space those env vars point at — regardless of the per-harness credentials in `~/.arize/harness/config.yaml`.
- `resolve_backend()` now checks whether the harness has its own `api_key` + `space_id` in config **before** falling back to global env vars, and flips the credential resolution order so harness config wins.
- Harnesses without per-harness config entries continue to fall through to the global env vars as before, so the change is fully backwards-compatible.

## Root cause (discovered during kiro trace debugging)

User had `cursor`/`claude-code` credentials exported globally in `~/.zshrc`. The `kiro` harness had its own credentials pointing at a different Arize space in `config.yaml`. Because `resolve_backend` checked `env.api_key` + `env.space_id` first, every kiro hook invocation used the cursor credentials and sent traces to the wrong space. The kiro project in the intended space remained empty.

## Test plan

- [ ] Confirm that a harness with per-harness `api_key` + `space_id` in config.yaml uses those credentials even when `ARIZE_API_KEY` / `ARIZE_SPACE_ID` are set to different values in the environment
- [ ] Confirm that a harness **without** per-harness credentials in config.yaml still picks up the global env vars correctly
- [ ] Existing unit tests for `resolve_backend` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)