### PR TITLE
Fix Kiro metering usage capture by retrying sidecar load

### DIFF
--- a/tests/tracing/kiro/test_kiro_adapter.py
+++ b/tests/tracing/kiro/test_kiro_adapter.py
@@ -250,12 +250,14 @@ class TestLoadSessionSidecar:
         """Empty session_id returns None."""
         assert adapter.load_session_sidecar("") is None
 
-    def test_returns_none_when_file_missing(self, sidecar_dir):
+    def test_returns_none_when_file_missing(self, sidecar_dir, monkeypatch):
         """Missing sidecar file returns None."""
+        monkeypatch.setattr(adapter, "_SIDECAR_RETRY_SECS", 0.0)
         assert adapter.load_session_sidecar("nonexistent-session") is None
 
-    def test_returns_none_for_malformed_json(self, sidecar_dir):
+    def test_returns_none_for_malformed_json(self, sidecar_dir, monkeypatch):
         """Malformed JSON in sidecar file returns None."""
+        monkeypatch.setattr(adapter, "_SIDECAR_RETRY_SECS", 0.0)
         sid = "malformed-session"
         (sidecar_dir / f"{sid}.json").write_text("not json")
         assert adapter.load_session_sidecar(sid) is None
@@ -270,6 +272,79 @@ class TestLoadSessionSidecar:
         """Successfully loads a complete sidecar file."""
         sid = "complete-session"
         (sidecar_dir / f"{sid}.json").write_text(json.dumps(sidecar_complete))
+        result = adapter.load_session_sidecar(sid)
+        assert isinstance(result, dict)
+        assert "session_state" in result
+
+    def test_returns_early_once_metering_present(self, sidecar_dir, sidecar_complete, monkeypatch):
+        """Returns on the first read when metering_usage is already present; sleep never called."""
+        sleep_calls = []
+        monkeypatch.setattr(adapter.time, "sleep", lambda s: sleep_calls.append(s))
+        monkeypatch.setattr(adapter.time, "monotonic", lambda: 0.0)
+
+        sid = "early-exit"
+        (sidecar_dir / f"{sid}.json").write_text(json.dumps(sidecar_complete))
+        result = adapter.load_session_sidecar(sid)
+
+        assert result is not None
+        assert sleep_calls == []  # returned immediately, no polling
+
+    def test_retries_until_metering_arrives(self, sidecar_dir, sidecar_complete, monkeypatch):
+        """Polls until metering_usage appears; sleep is called between retries, not after success."""
+        import copy
+
+        # Fake clock: each call advances by _SIDECAR_POLL_INTERVAL so deadline is never hit
+        tick = [0.0]
+
+        def _monotonic():
+            v = tick[0]
+            tick[0] += adapter._SIDECAR_POLL_INTERVAL
+            return v
+
+        monkeypatch.setattr(adapter, "_SIDECAR_RETRY_SECS", 10.0)
+        monkeypatch.setattr(adapter.time, "monotonic", _monotonic)
+        sleep_calls = []
+        monkeypatch.setattr(adapter.time, "sleep", lambda s: sleep_calls.append(s))
+
+        sid = "late-metering"
+        no_metering = copy.deepcopy(sidecar_complete)
+        del no_metering["session_state"]["conversation_metadata"]["user_turn_metadatas"][0]["metering_usage"]
+        path = sidecar_dir / f"{sid}.json"
+
+        # First two reads return no-metering; third returns complete sidecar
+        read_count = [0]
+
+        def _read_text(self, *a, **kw):
+            read_count[0] += 1
+            if read_count[0] < 3:
+                return json.dumps(no_metering)
+            return json.dumps(sidecar_complete)
+
+        monkeypatch.setattr(path.__class__, "read_text", _read_text)
+        path.write_text(json.dumps(no_metering))  # file must exist for path resolution
+
+        result = adapter.load_session_sidecar(sid)
+        assert result is not None
+        turns = result["session_state"]["conversation_metadata"]["user_turn_metadatas"]
+        assert turns[0].get("metering_usage")
+        assert len(sleep_calls) == 2  # slept twice before metering arrived
+
+    def test_fallback_returns_partial_data_when_metering_never_arrives(
+        self, sidecar_dir, sidecar_complete, monkeypatch
+    ):
+        """When deadline expires without metering, returns last valid JSON without sleeping again."""
+        import copy
+
+        # Clock starts at 0; second call returns past the deadline
+        times = iter([0.0, 999.0])
+        monkeypatch.setattr(adapter.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(adapter.time, "sleep", lambda s: None)
+
+        sid = "no-metering-timeout"
+        no_metering = copy.deepcopy(sidecar_complete)
+        del no_metering["session_state"]["conversation_metadata"]["user_turn_metadatas"][0]["metering_usage"]
+        (sidecar_dir / f"{sid}.json").write_text(json.dumps(no_metering))
+
         result = adapter.load_session_sidecar(sid)
         assert isinstance(result, dict)
         assert "session_state" in result

--- a/tests/tracing/kiro/test_kiro_hook.py
+++ b/tests/tracing/kiro/test_kiro_hook.py
@@ -74,6 +74,10 @@ def _patch_kiro_state(tmp_path, monkeypatch):
     sessions_dir = tmp_path / "sessions" / "cli"
     sessions_dir.mkdir(parents=True)
     monkeypatch.setattr(adapter, "KIRO_SESSIONS_DIR", sessions_dir)
+
+    # Don't burn real time waiting for sidecars that won't appear in tests
+    monkeypatch.setattr(adapter, "_SIDECAR_RETRY_SECS", 0.0)
+
     return state_dir
 
 
@@ -541,14 +545,17 @@ class TestStopSidecarEnrichment:
         assert attrs["kiro.cost.credits"] == pytest.approx(0.103, abs=1e-9)
 
     def test_uses_correct_turn_index(self, captured_spans, tmp_path):
-        """With multiple turns, stop uses trace_count-1 as the turn index."""
+        """stop always uses turn_index=-1 (most recent sidecar turn).
+
+        trace_count can drift from the sidecar turn count, so we rely on the
+        sidecar's own ordering rather than computing an index from trace_count.
+        """
         sidecar = self._load_sidecar_fixture("session_complete.json")
-        # Build 3 turns with distinct token counts
         import copy
 
         base_turn = sidecar["session_state"]["conversation_metadata"]["user_turn_metadatas"][0]
         turns = []
-        for i, (inp, out) in enumerate([(100, 200), (300, 400), (500, 600)]):
+        for inp, out in [(100, 200), (300, 400), (500, 600)]:
             t = copy.deepcopy(base_turn)
             t["input_token_count"] = inp
             t["output_token_count"] = out
@@ -556,22 +563,21 @@ class TestStopSidecarEnrichment:
         sidecar["session_state"]["conversation_metadata"]["user_turn_metadatas"] = turns
         self._place_sidecar(tmp_path, sidecar)
 
-        # Submit twice to get trace_count=2, then stop
         prompt = _load_fixture("user_prompt_submit.json")
-        _invoke_main(prompt)  # trace_count becomes 1
-        # We need a stop to clear pending keys, then a second prompt
+        _invoke_main(prompt)
         stop1 = _load_fixture("stop.json")
-        _invoke_main(stop1)  # emits span for turn 1
+        _invoke_main(stop1)
 
-        _invoke_main(prompt)  # trace_count becomes 2
+        _invoke_main(prompt)
         stop2 = _load_fixture("stop.json")
-        _invoke_main(stop2)  # emits span for turn 2
+        _invoke_main(stop2)
 
-        # The second stop should use turn_index=1 (trace_count=2, 0-indexed=1)
         assert len(captured_spans) == 2
-        attrs = _span_attrs(captured_spans[1])
-        assert attrs["llm.token_count.prompt"] == 300
-        assert attrs["llm.token_count.completion"] == 400
+        # Both stops use turn_index=-1, so both pick up the last sidecar turn (500/600)
+        for span in captured_spans:
+            attrs = _span_attrs(span)
+            assert attrs["llm.token_count.prompt"] == 500
+            assert attrs["llm.token_count.completion"] == 600
 
     def test_malformed_sidecar_logs_and_skips(self, captured_spans, tmp_path):
         """Malformed sidecar JSON does not crash; basic LLM span still emitted."""

--- a/tracing/kiro/hooks/adapter.py
+++ b/tracing/kiro/hooks/adapter.py
@@ -26,6 +26,8 @@ from tracing.kiro.constants import HARNESS_NAME, KIRO_SESSIONS_DIR
 STATE_DIR: Path = STATE_BASE_DIR / HARNESS_NAME
 SCOPE_NAME = "arize-kiro-plugin"
 SERVICE_NAME = HARNESS_NAME
+_SIDECAR_RETRY_SECS = 1.0
+_SIDECAR_POLL_INTERVAL = 0.1
 
 # Route hook stderr to a per-harness log file unless ARIZE_LOG_FILE is set.
 os.environ.setdefault(
@@ -114,21 +116,42 @@ def gc_stale_state_files() -> None:
 def load_session_sidecar(session_id: str) -> dict | None:
     """Load `~/.kiro/sessions/cli/<session_id>.json`.
 
-    Returns the parsed dict, or None if the file is missing, malformed, or
-    not a JSON object. NEVER raises — callers rely on fail-soft semantics.
+    Retries for up to _SIDECAR_RETRY_SECS to handle the race where Kiro
+    flushes the sidecar after the stop hook fires. Stops early once metering
+    data is present. Returns None on any unrecoverable error.
     """
     if not session_id:
         return None
     path = KIRO_SESSIONS_DIR / f"{session_id}.json"
+    deadline = time.monotonic() + _SIDECAR_RETRY_SECS
+    last_exc: Exception | None = None
+    while True:
+        try:
+            data = json.loads(path.read_text())
+            if not isinstance(data, dict):
+                log(f"sidecar for {session_id} is not a JSON object")
+                return None
+            # Stop retrying once metering data has been flushed
+            turns = data.get("session_state", {}).get("conversation_metadata", {}).get("user_turn_metadatas", [])
+            if turns and turns[-1].get("metering_usage"):
+                return data
+        except (OSError, json.JSONDecodeError) as exc:
+            last_exc = exc
+
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(_SIDECAR_POLL_INTERVAL)
+
+    if last_exc:
+        log(f"sidecar load failed for {session_id}: {last_exc!r}")
+    else:
+        log(f"sidecar for {session_id}: metering_usage not present after {_SIDECAR_RETRY_SECS}s")
+    # Return whatever we last successfully parsed (may lack metering), or None
     try:
         data = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError) as exc:
-        log(f"sidecar load failed for {session_id}: {exc!r}")
+        return data if isinstance(data, dict) else None
+    except Exception:
         return None
-    if not isinstance(data, dict):
-        log(f"sidecar for {session_id} is not a JSON object")
-        return None
-    return data
 
 
 def extract_sidecar_attrs(sidecar: dict | None, turn_index: int = -1) -> dict[str, Any]:

--- a/tracing/kiro/hooks/handlers.py
+++ b/tracing/kiro/hooks/handlers.py
@@ -181,13 +181,11 @@ def _handle_stop(input_json: dict, state: StateManager) -> None:
     if user_id:
         attrs["user.id"] = user_id
 
-    # Enrich with sidecar data
-    try:
-        turn_index = max(int(trace_count) - 1, -1)
-    except (TypeError, ValueError):
-        turn_index = -1
+    # Enrich with sidecar data — always use -1 (most recent turn).
+    # trace_count can drift from the sidecar turn count, so a fixed index
+    # would pick the wrong turn or go out of bounds.
     sidecar = load_session_sidecar(session_id)
-    attrs.update(extract_sidecar_attrs(sidecar, turn_index=turn_index))
+    attrs.update(extract_sidecar_attrs(sidecar, turn_index=-1))
 
     span = build_span(
         f"Turn {trace_count}",


### PR DESCRIPTION
## Summary

Fixes Kiro token/metering attributes being dropped from stop-hook spans due to a timing race and a turn-index mismatch with the session sidecar.

- **Retry sidecar load** (`adapter.py`): Kiro flushes `~/.kiro/sessions/cli/<session_id>.json` *after* the stop hook fires, so `metering_usage` was frequently missing when we read it. `load_session_sidecar` now polls for up to 1s (100ms intervals) and returns early once the latest turn has `metering_usage`. Still fail-soft — returns the last successfully parsed dict (or `None`) on any unrecoverable error.
- **Always read the most recent turn** (`handlers.py`): `trace_count` can drift from the sidecar's turn count, so deriving `turn_index` from it picked the wrong turn or went out of bounds. The stop handler now always passes `turn_index=-1`.

## Test plan

- [x] `uv run pytest tests/tracing/kiro`
- [x] `uv run pre-commit run --all-files`

Updated `test_kiro_adapter.py` and `test_kiro_hook.py` to cover the retry/early-stop behavior and the fixed turn index.