### PR TITLE
Adding support for oh-my-pi(omp) harness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,6 @@ repos:
       - id: mypy
         name: mypy (tracing/opencode)
         files: ^tracing/opencode/
+      - id: mypy
+        name: mypy (tracing/omp)
+        files: ^tracing/omp/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,7 @@ repos:
         name: mypy (tracing/opencode)
         files: ^tracing/opencode/
         additional_dependencies: [types-PyYAML]
+      - id: mypy
+        name: mypy (tracing/omp)
+        files: ^tracing/omp/
+        additional_dependencies: [types-PyYAML]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Trace AI coding sessions to [Arize AX](https://arize.com) or [Phoenix](https://g
 | [Gemini CLI](tracing/gemini/README.md) | [macOS / Linux](tracing/gemini/README.md#macos--linux) · [Windows](tracing/gemini/README.md#windows-powershell) | `gemini` |
 | [Kiro CLI](tracing/kiro/README.md) | [macOS / Linux](tracing/kiro/README.md#macos--linux) · [Windows](tracing/kiro/README.md#windows-powershell) | `kiro` |
 | [Opencode CLI](tracing/opencode/README.md) | [macOS / Linux](tracing/opencode/README.md#macos--linux) · [Windows](tracing/opencode/README.md#windows-powershell) | `opencode` |
+| [Oh My Pi (omp)](tracing/omp/README.md) | [macOS / Linux](tracing/omp/README.md#macos--linux) · [Windows](tracing/omp/README.md#windows-powershell) | `omp` |
 
 > **Each install link opens the ready-to-paste command for your OS — copy it and run it in a terminal**
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Trace AI coding sessions to [Arize AX](https://arize.com) or [Phoenix](https://g
 | [Gemini CLI](tracing/gemini/README.md) | `install.sh` / `install.bat` | `gemini` |
 | [Kiro CLI](tracing/kiro/README.md) | `install.sh` / `install.bat` | `kiro` |
 | [Opencode CLI](tracing/opencode/README.md) | `install.sh` / `install.bat` | `opencode` |
+| [Oh My Pi (omp) CLI](tracing/omp/README.md) | `install.sh` / `install.bat` | `omp` |
 
 Claude Code CLI and the Claude Agent SDK share the same plugin, hooks, and configuration — one install covers both.
 
@@ -30,7 +31,7 @@ Access and run the install script remotely to setup coding harness tracing in yo
 ```bash
 INSTALL_URL="https://raw.githubusercontent.com/Arize-ai/coding-harness-tracing/main/install.sh"
 
-# claude | codex | gemini | cursor | copilot | kiro | opencode
+# claude | codex | gemini | cursor | copilot | kiro | opencode | omp
 HARNESS="claude"
 
 # setup tracing for a harness
@@ -48,7 +49,7 @@ curl -sSL "$INSTALL_URL" | bash -s -- uninstall
 ```powershell
 $INSTALL_URL = "https://raw.githubusercontent.com/Arize-ai/coding-harness-tracing/main/install.bat"
 
-# claude | codex | gemini | cursor | copilot | kiro | opencode
+# claude | codex | gemini | cursor | copilot | kiro | opencode | omp
 $HARNESS = "claude"
 
 iwr -useb $INSTALL_URL -OutFile $env:TEMP\install.bat
@@ -74,7 +75,7 @@ cd coding-harness-tracing
 
 **macOS / Linux**
 ```bash
-# claude | codex | gemini | cursor | copilot | kiro | opencode
+# claude | codex | gemini | cursor | copilot | kiro | opencode | omp
 HARNESS="claude"
 
 # setup tracing for a harness
@@ -89,7 +90,7 @@ HARNESS="claude"
 
 **Windows**
 ```powershell
-# claude | codex | gemini | cursor | copilot | kiro | opencode
+# claude | codex | gemini | cursor | copilot | kiro | opencode | omp
 $HARNESS = "claude"
 
 # setup tracing for a harness

--- a/core/constants.py
+++ b/core/constants.py
@@ -75,4 +75,11 @@ HARNESSES: dict[str, HarnessMetadata] = {
         "state_subdir": "opencode",
         "default_log_file": LOG_DIR / "opencode.log",
     },
+    "omp": {
+        "service_name": "omp",
+        "scope_name": "arize-omp-plugin",
+        "default_project_name": "omp",
+        "state_subdir": "omp",
+        "default_log_file": LOG_DIR / "omp.log",
+    },
 }

--- a/core/setup/omp.py
+++ b/core/setup/omp.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Arize setup wizard shim for omp (Oh My Pi) tracing.
+
+Delegates to tracing.omp.install for the actual install/uninstall logic.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from tracing.omp import install as _install_mod
+
+
+def install() -> None:
+    """Delegate to tracing.omp.install.install()."""
+    _install_mod.install()
+
+
+def uninstall() -> None:
+    """Delegate to tracing.omp.install.uninstall()."""
+    _install_mod.uninstall()
+
+
+def main() -> None:
+    """Entry point for arize-setup-omp."""
+    try:
+        _run()
+    except (KeyboardInterrupt, EOFError):
+        print("\nSetup cancelled.")
+        sys.exit(1)
+
+
+def _run() -> None:
+    """Run the installer."""
+    _install_mod.install()
+
+
+if __name__ == "__main__":
+    main()

--- a/install.bat
+++ b/install.bat
@@ -28,11 +28,11 @@ if /i "%~1"=="--help"    goto :usage
 if /i "%~1"=="help"      goto :usage
 if /i "%~1"=="--with-skills" ( set "WITH_SKILLS=--with-skills" & shift & goto :parse_args )
 if /i "%~1"=="--branch" ( set "INSTALL_BRANCH=%~2" & set "TARBALL_URL=https://github.com/Arize-ai/coding-harness-tracing/archive/refs/heads/%~2.tar.gz" & shift & shift & goto :parse_args )
-for %%C in (claude codex copilot cursor gemini kiro opencode) do if /i "%~1"=="%%C" ( set "COMMAND=%%C" & shift & goto :parse_args )
+for %%C in (claude codex copilot cursor gemini kiro opencode omp) do if /i "%~1"=="%%C" ( set "COMMAND=%%C" & shift & goto :parse_args )
 if /i "%~1"=="update" ( set "COMMAND=update" & shift & goto :parse_args )
 if /i "%~1"=="uninstall" (
     set "COMMAND=uninstall" & shift
-    for %%C in (claude codex copilot cursor gemini kiro opencode) do if /i "%~1"=="%%C" ( set "UNINSTALL_HARNESS=%%C" & shift )
+    for %%C in (claude codex copilot cursor gemini kiro opencode omp) do if /i "%~1"=="%%C" ( set "UNINSTALL_HARNESS=%%C" & shift )
     goto :parse_args
 )
 echo [arize] Unknown argument: %~1 >&2
@@ -41,7 +41,7 @@ goto :usage
 if "%COMMAND%"=="" ( echo [arize] No command specified >&2 & goto :usage )
 
 REM --- Harness name -> directory mapping ---
-REM claude->tracing\claude_code  codex->tracing\codex  copilot->tracing\copilot  cursor->tracing\cursor  gemini->tracing\gemini  kiro->tracing\kiro  opencode->tracing\opencode
+REM claude->tracing\claude_code  codex->tracing\codex  copilot->tracing\copilot  cursor->tracing\cursor  gemini->tracing\gemini  kiro->tracing\kiro  opencode->tracing\opencode  omp->tracing\omp
 
 REM --- Dispatch ---
 if "%COMMAND%"=="update"    goto :cmd_update
@@ -207,6 +207,7 @@ if /i "%~1"=="cursor"      set "HARNESS_DIR=tracing\cursor"
 if /i "%~1"=="gemini"      set "HARNESS_DIR=tracing\gemini"
 if /i "%~1"=="kiro"        set "HARNESS_DIR=tracing\kiro"
 if /i "%~1"=="opencode"    set "HARNESS_DIR=tracing\opencode"
+if /i "%~1"=="omp"         set "HARNESS_DIR=tracing\omp"
 if "%HARNESS_DIR%"=="" ( echo [arize] Unknown harness: %~1 >&2 & exit /b 1 )
 goto :eof
 
@@ -225,6 +226,7 @@ echo     cursor              Install tracing for Cursor IDE
 echo     gemini              Install tracing for Gemini CLI
 echo     kiro                Install tracing for Kiro CLI
 echo     opencode            Install tracing for opencode
+echo     omp                 Install tracing for Oh My Pi (omp)
 echo     update              Update to latest and reinstall all harnesses
 echo     uninstall [harness] Remove one harness or full wipe
 echo.

--- a/install.sh
+++ b/install.sh
@@ -204,6 +204,7 @@ harness_dir() {
         gemini)  echo "tracing/gemini" ;;
         kiro)    echo "tracing/kiro" ;;
         opencode) echo "tracing/opencode" ;;
+        omp)     echo "tracing/omp" ;;
         *)       return 1 ;;
     esac
 }
@@ -242,6 +243,7 @@ Commands:
   gemini      Install and configure tracing for Gemini CLI
   kiro        Install and configure tracing for Kiro CLI
   opencode    Install and configure tracing for opencode
+  omp         Install and configure tracing for Oh My Pi (omp)
   update      Update the installed coding-harness-tracing and re-register all harnesses
   uninstall <harness>   Tear down one harness
   uninstall             Full wipe: venv + repo + shared config
@@ -272,7 +274,7 @@ main() {
     done
 
     case "$cmd" in
-        claude|codex|copilot|cursor|gemini|kiro|opencode)
+        claude|codex|copilot|cursor|gemini|kiro|opencode|omp)
             install_harness "$cmd" "$with_skills"
             ;;
         uninstall)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ arize-hook-cursor = "tracing.cursor.hooks.handlers:main"
 arize-hook-kiro = "tracing.kiro.hooks.handlers:main"
 # opencode hook
 arize-hook-opencode = "tracing.opencode.hooks.handlers:main"
+# omp hook
+arize-hook-omp = "tracing.omp.hooks.handlers:main"
 # Setup wizards
 arize-setup-claude = "core.setup.claude:main"
 arize-setup-codex = "core.setup.codex:main"
@@ -69,6 +71,7 @@ arize-setup-cursor = "core.setup.cursor:main"
 arize-setup-gemini = "core.setup.gemini:main"
 arize-setup-kiro = "core.setup.kiro:main"
 arize-setup-opencode = "core.setup.opencode:main"
+arize-setup-omp = "core.setup.omp:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/core/test_install.py
+++ b/tests/core/test_install.py
@@ -10,7 +10,7 @@ REPO_ROOT = Path(__file__).parent.parent.parent
 INSTALL_SH = REPO_ROOT / "install.sh"
 INSTALL_BAT = REPO_ROOT / "install.bat"
 
-ALL_HARNESSES = ["claude", "codex", "copilot", "cursor", "opencode"]
+ALL_HARNESSES = ["claude", "codex", "copilot", "cursor", "opencode", "omp"]
 
 
 # ---------------------------------------------------------------------------
@@ -152,6 +152,7 @@ def test_install_sh_harness_dir_mapping():
     assert "tracing/copilot" in text
     assert "tracing/cursor" in text
     assert "tracing/opencode" in text
+    assert "tracing/omp" in text
 
 
 def test_install_bat_harness_dir_mapping():
@@ -162,6 +163,7 @@ def test_install_bat_harness_dir_mapping():
     assert "tracing\\copilot" in text
     assert "tracing\\cursor" in text
     assert "tracing\\opencode" in text
+    assert "tracing\\omp" in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_shell_router.py
+++ b/tests/core/test_shell_router.py
@@ -139,6 +139,9 @@ class TestHarnessMapping:
     def test_opencode_maps_to_tracing_opencode(self):
         assert "opencode)" in self.text and '"tracing/opencode"' in self.text
 
+    def test_omp_maps_to_tracing_omp(self):
+        assert "omp)" in self.text and '"tracing/omp"' in self.text
+
 
 # ---------------------------------------------------------------------------
 # Usage output tests
@@ -157,7 +160,7 @@ class TestUsageOutput:
 
     @pytest.mark.parametrize(
         "cmd",
-        ["claude", "codex", "copilot", "cursor", "opencode", "update", "uninstall"],
+        ["claude", "codex", "copilot", "cursor", "opencode", "omp", "update", "uninstall"],
     )
     def test_command_listed(self, cmd):
         assert cmd in self.text
@@ -238,8 +241,8 @@ class TestDispatchLogic:
         self.text = _read_install_sh()
 
     def test_dispatches_harness_commands(self):
-        """claude|codex|copilot|cursor|gemini|kiro|opencode should be dispatched."""
-        assert "claude|codex|copilot|cursor|gemini|kiro|opencode)" in self.text
+        """claude|codex|copilot|cursor|gemini|kiro|opencode|omp should be dispatched."""
+        assert "claude|codex|copilot|cursor|gemini|kiro|opencode|omp)" in self.text
 
     def test_install_harness_called(self):
         """install_harness function should be called for harness commands."""

--- a/tests/core/test_wire_entry_points.py
+++ b/tests/core/test_wire_entry_points.py
@@ -67,6 +67,8 @@ EXPECTED_HARNESS_ENTRY_POINTS = {
     "arize-hook-kiro": "tracing.kiro.hooks.handlers:main",
     # opencode hook
     "arize-hook-opencode": "tracing.opencode.hooks.handlers:main",
+    # omp hook
+    "arize-hook-omp": "tracing.omp.hooks.handlers:main",
 }
 
 # Setup wizards stay on core.setup.*
@@ -78,6 +80,7 @@ EXPECTED_SETUP_ENTRY_POINTS = {
     "arize-setup-gemini": "core.setup.gemini:main",
     "arize-setup-kiro": "core.setup.kiro:main",
     "arize-setup-opencode": "core.setup.opencode:main",
+    "arize-setup-omp": "core.setup.omp:main",
 }
 
 
@@ -236,6 +239,7 @@ class TestHooksDirsInHarnessPackages:
             ("tracing/gemini", ["__init__.py", "adapter.py", "handlers.py"]),
             ("tracing/kiro", ["__init__.py", "adapter.py", "handlers.py"]),
             ("tracing/opencode", ["__init__.py", "adapter.py", "handlers.py"]),
+            ("tracing/omp", ["__init__.py", "adapter.py", "handlers.py"]),
         ],
     )
     def test_hooks_dir_has_expected_files(self, pkg, expected_files):

--- a/tests/tracing/omp/fixtures/agent_end.json
+++ b/tests/tracing/omp/fixtures/agent_end.json
@@ -1,0 +1,15 @@
+{
+  "type": "agent_end",
+  "sessionId": "s_basic",
+  "messages": [
+    {
+      "role": "assistant",
+      "content": [{ "type": "text", "text": "fallback final answer" }],
+      "provider": "anthropic",
+      "model": "claude-sonnet-4",
+      "usage": { "input": 5, "output": 8, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 13, "cost": { "total": 0.0001 } },
+      "stopReason": "end_turn",
+      "timestamp": 6000
+    }
+  ]
+}

--- a/tests/tracing/omp/fixtures/before_agent_start.json
+++ b/tests/tracing/omp/fixtures/before_agent_start.json
@@ -1,0 +1,5 @@
+{
+  "type": "before_agent_start",
+  "sessionId": "omp_sess_1",
+  "prompt": "list files and edit main.py"
+}

--- a/tests/tracing/omp/fixtures/turn_end_basic.json
+++ b/tests/tracing/omp/fixtures/turn_end_basic.json
@@ -1,0 +1,47 @@
+{
+  "type": "turn_end",
+  "sessionId": "s_basic",
+  "turnIndex": 0,
+  "message": {
+    "role": "assistant",
+    "content": [
+      { "type": "text", "text": "I'll list files then edit." },
+      { "type": "thinking", "text": "private reasoning" },
+      { "type": "toolCall", "id": "call_bash_1", "name": "bash", "arguments": { "command": "ls -la" } },
+      { "type": "toolCall", "id": "call_edit_1", "name": "edit", "arguments": { "filePath": "/tmp/main.py" } }
+    ],
+    "api": "messages",
+    "provider": "anthropic",
+    "model": "claude-sonnet-4",
+    "usage": {
+      "input": 100,
+      "output": 50,
+      "cacheRead": 30,
+      "cacheWrite": 5,
+      "totalTokens": 185,
+      "reasoningTokens": 7,
+      "cost": { "input": 0.001, "output": 0.002, "cacheRead": 0.0001, "cacheWrite": 0.00005, "total": 0.0125 }
+    },
+    "stopReason": "tool_use",
+    "timestamp": 5000,
+    "duration": 3000
+  },
+  "toolResults": [
+    {
+      "role": "toolResult",
+      "toolCallId": "call_bash_1",
+      "toolName": "bash",
+      "content": [{ "type": "text", "text": "total 4\nfile.py" }],
+      "isError": false,
+      "timestamp": 5100
+    },
+    {
+      "role": "toolResult",
+      "toolCallId": "call_edit_1",
+      "toolName": "edit",
+      "content": [{ "type": "text", "text": "edited main.py" }],
+      "isError": false,
+      "timestamp": 5200
+    }
+  ]
+}

--- a/tests/tracing/omp/fixtures/turn_end_tool_error.json
+++ b/tests/tracing/omp/fixtures/turn_end_tool_error.json
@@ -1,0 +1,35 @@
+{
+  "type": "turn_end",
+  "sessionId": "s_err",
+  "turnIndex": 0,
+  "message": {
+    "role": "assistant",
+    "content": [
+      { "type": "text", "text": "reading the file" },
+      { "type": "toolCall", "id": "call_read_1", "name": "read", "arguments": { "filePath": "/missing.txt" } }
+    ],
+    "api": "messages",
+    "provider": "anthropic",
+    "model": "claude-sonnet-4",
+    "usage": {
+      "input": 10,
+      "output": 5,
+      "cacheRead": 0,
+      "cacheWrite": 0,
+      "totalTokens": 15,
+      "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0, "total": 0 }
+    },
+    "stopReason": "tool_use",
+    "timestamp": 3000
+  },
+  "toolResults": [
+    {
+      "role": "toolResult",
+      "toolCallId": "call_read_1",
+      "toolName": "read",
+      "content": [{ "type": "text", "text": "ENOENT: no such file or directory, open '/missing.txt'" }],
+      "isError": true,
+      "timestamp": 3100
+    }
+  ]
+}

--- a/tests/tracing/omp/test_install_omp.py
+++ b/tests/tracing/omp/test_install_omp.py
@@ -1,0 +1,873 @@
+"""Tests for tracing.omp.install: install/uninstall of the omp tracing shim.
+
+omp is a **hybrid** of two existing installers:
+
+* The config-prompt flow + ``.ts`` file-drop come from
+  ``tracing/opencode/install.py`` (opencode loads plugins in-process inside its
+  Bun runtime, so delivery is a file drop, not a settings merge).
+* The **JSON settings.json read-merge-write** comes from
+  ``tracing/gemini/install.py`` — unlike opencode, omp does NOT auto-discover a
+  plugin dir. We must register the shim's absolute path in the ``extensions``
+  array of ``~/.omp/agent/settings.json``.
+
+These tests therefore mirror ``tests/tracing/opencode/test_install_opencode.py``
+for the file-drop side and borrow the settings-merge assertions from
+``tests/tracing/gemini/test_install_gemini.py`` for the extensions-array side.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+import tracing.omp.constants as _omp
+import tracing.omp.install as _install
+
+install = _install.install
+uninstall = _install.uninstall
+
+
+# ---------------------------------------------------------------------------
+# Test backend tuples
+# ---------------------------------------------------------------------------
+
+PHOENIX_BACKEND = ("phoenix", {"endpoint": "http://localhost:6006", "api_key": ""})
+ARIZE_BACKEND = (
+    "arize",
+    {"endpoint": "otlp.arize.com:443", "api_key": "test-key", "space_id": "test-space"},
+)
+
+_HEADER_MARKER = "// Arize omp tracing hook (shim)."
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _fake_stdout():
+    """Non-tty stdout to suppress ANSI codes."""
+    return type(
+        "FakeOut",
+        (),
+        {
+            "isatty": lambda self: False,
+            "write": lambda self, s: None,
+            "flush": lambda self: None,
+        },
+    )()
+
+
+def _mock_prompts(monkeypatch, backend=None):
+    """Patch prompt functions on the install module (where they're bound after import)."""
+    if backend is None:
+        backend = PHOENIX_BACKEND
+
+    monkeypatch.setattr(
+        _install,
+        "prompt_backend",
+        lambda existing_harnesses=None: backend,
+    )
+    monkeypatch.setattr(_install, "prompt_project_name", lambda default: default)
+    monkeypatch.setattr(_install, "prompt_user_id", lambda: "")
+    monkeypatch.setattr(
+        _install,
+        "prompt_content_logging",
+        lambda: {"prompts": True, "tool_details": True, "tool_content": True},
+    )
+    monkeypatch.setattr(_install, "write_logging_config", lambda block, config_path=None: None)
+    monkeypatch.setattr("sys.stdout", _fake_stdout())
+
+
+@pytest.fixture
+def cwd_tmp(tmp_path, monkeypatch):
+    """Set cwd to tmp_path and patch core.setup + tracing.omp.constants paths for isolation."""
+    monkeypatch.chdir(tmp_path)
+
+    import core.setup as setup_mod
+
+    monkeypatch.setattr(setup_mod, "INSTALL_DIR", tmp_path / ".arize" / "harness")
+    monkeypatch.setattr(setup_mod, "VENV_DIR", tmp_path / ".arize" / "harness" / "venv")
+    monkeypatch.setattr(setup_mod, "CONFIG_FILE", tmp_path / ".arize" / "harness" / "config.yaml")
+    monkeypatch.setattr(setup_mod, "BIN_DIR", tmp_path / ".arize" / "harness" / "bin")
+    monkeypatch.setattr(setup_mod, "RUN_DIR", tmp_path / ".arize" / "harness" / "run")
+    monkeypatch.setattr(setup_mod, "LOG_DIR", tmp_path / ".arize" / "harness" / "logs")
+    monkeypatch.setattr(setup_mod, "STATE_DIR", tmp_path / ".arize" / "harness" / "state")
+
+    import core.constants as c
+
+    monkeypatch.setattr(c, "BASE_DIR", tmp_path / ".arize" / "harness")
+    monkeypatch.setattr(c, "CONFIG_FILE", tmp_path / ".arize" / "harness" / "config.yaml")
+
+    import core.config as config_mod
+
+    monkeypatch.setattr(config_mod, "CONFIG_FILE", str(tmp_path / ".arize" / "harness" / "config.yaml"))
+
+    # Redirect omp settings + extension paths into the temp tree.
+    settings_dir = tmp_path / ".omp" / "agent"
+    extensions_dir = tmp_path / ".omp" / "extensions"
+    monkeypatch.setattr(_omp, "SETTINGS_DIR", settings_dir)
+    monkeypatch.setattr(_omp, "SETTINGS_FILE", settings_dir / "settings.json")
+    monkeypatch.setattr(_omp, "EXTENSIONS_DIR", extensions_dir)
+    monkeypatch.setattr(_omp, "PLUGIN_FILE", extensions_dir / "arize-tracing.ts")
+
+    return tmp_path
+
+
+@pytest.fixture
+def settings_file(cwd_tmp):
+    """Return the path to the redirected omp settings.json."""
+    return _omp.SETTINGS_FILE
+
+
+@pytest.fixture
+def plugin_file(cwd_tmp):
+    """Return the path to the redirected omp plugin (shim) file."""
+    return _omp.PLUGIN_FILE
+
+
+@pytest.fixture
+def plugin_source_text(cwd_tmp):
+    """Return the text contents of the shipped plugin source asset."""
+    return _omp.PLUGIN_SOURCE.read_text(encoding="utf-8")
+
+
+def _read_settings(settings_file):
+    return json.loads(settings_file.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Install tests — fresh install (config.yaml harness entry)
+# ---------------------------------------------------------------------------
+
+
+class TestInstallFreshWritesFlatHarnessEntry:
+    """Fresh install writes a flat harness entry to config.yaml."""
+
+    @pytest.mark.parametrize(
+        "backend,expected_target",
+        [
+            (PHOENIX_BACKEND, "phoenix"),
+            (ARIZE_BACKEND, "arize"),
+        ],
+        ids=["phoenix", "arize"],
+    )
+    def test_fresh_install_creates_config(self, cwd_tmp, monkeypatch, backend, expected_target):
+        _mock_prompts(monkeypatch, backend=backend)
+        install()
+
+        config_path = cwd_tmp / ".arize" / "harness" / "config.yaml"
+        assert config_path.is_file()
+        config = yaml.safe_load(config_path.read_text())
+        entry = config["harnesses"]["omp"]
+        assert entry["target"] == expected_target
+        assert entry["project_name"] == "omp"
+        assert entry["endpoint"] == backend[1]["endpoint"]
+        assert entry["api_key"] == backend[1]["api_key"]
+
+        if expected_target == "arize":
+            assert entry["space_id"] == backend[1]["space_id"]
+
+        # No collector for omp
+        assert "collector" not in entry
+
+
+# ---------------------------------------------------------------------------
+# Install tests — shim file drop
+# ---------------------------------------------------------------------------
+
+
+class TestInstallCopiesShim:
+    """install() copies the shipped .ts into ~/.omp/extensions/."""
+
+    def test_plugin_file_created(self, plugin_file, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        assert plugin_file.is_file()
+
+    def test_extensions_dir_created(self, plugin_file, monkeypatch):
+        """install should create the extensions parent dir if missing."""
+        _mock_prompts(monkeypatch)
+        assert not plugin_file.parent.exists()
+        install()
+        assert plugin_file.parent.is_dir()
+
+    def test_plugin_file_content_matches_source(self, plugin_file, plugin_source_text, monkeypatch):
+        """The installed shim content must equal the shipped source asset (not inline text)."""
+        _mock_prompts(monkeypatch)
+        install()
+        assert plugin_file.read_text(encoding="utf-8") == plugin_source_text
+
+    def test_plugin_file_has_arize_header_marker(self, plugin_file, monkeypatch):
+        """The shim's first line must carry the Arize header marker (basis for uninstall guard)."""
+        _mock_prompts(monkeypatch)
+        install()
+        text = plugin_file.read_text(encoding="utf-8")
+        assert text.startswith(_HEADER_MARKER)
+
+
+# ---------------------------------------------------------------------------
+# Install tests — extensions-array registration in settings.json
+# ---------------------------------------------------------------------------
+
+
+class TestInstallRegistersExtension:
+    """install() appends the shim's absolute path to settings.json "extensions"."""
+
+    def test_settings_file_created(self, settings_file, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        assert settings_file.is_file()
+
+    def test_settings_dir_created(self, settings_file, monkeypatch):
+        """install should create ~/.omp/agent/ if missing."""
+        _mock_prompts(monkeypatch)
+        assert not settings_file.parent.exists()
+        install()
+        assert settings_file.parent.is_dir()
+
+    def test_extensions_array_contains_plugin_path(self, settings_file, plugin_file, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        data = _read_settings(settings_file)
+        assert isinstance(data.get("extensions"), list)
+        assert str(plugin_file) in data["extensions"]
+
+    def test_settings_json_pretty_printed_with_trailing_newline(self, settings_file, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        text = settings_file.read_text(encoding="utf-8")
+        # Pretty-printed (indented) and ends with a newline.
+        assert "\n  " in text
+        assert text.endswith("\n")
+
+    def test_extensions_entry_is_absolute_path(self, settings_file, plugin_file, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        data = _read_settings(settings_file)
+        entry = [e for e in data["extensions"] if e == str(plugin_file)]
+        assert entry, "shim path missing from extensions array"
+        assert entry[0].endswith("arize-tracing.ts")
+
+
+# ---------------------------------------------------------------------------
+# Install tests — preserve unrelated settings.json content
+# ---------------------------------------------------------------------------
+
+
+class TestInstallPreservesSettings:
+    """install must read-merge-write — never clobber unrelated keys/entries."""
+
+    def test_preserves_unrelated_top_level_key(self, settings_file, plugin_file, monkeypatch):
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        existing = {"theme": "dark", "model": {"provider": "anthropic"}}
+        settings_file.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+
+        _mock_prompts(monkeypatch)
+        install()
+
+        data = _read_settings(settings_file)
+        assert data["theme"] == "dark"
+        assert data["model"] == {"provider": "anthropic"}
+        assert str(plugin_file) in data["extensions"]
+
+    def test_preserves_existing_user_extensions(self, settings_file, plugin_file, monkeypatch):
+        """A user's own extension paths in the array survive install."""
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        user_ext = "/Users/me/.omp/extensions/my-own.ts"
+        existing = {"extensions": [user_ext]}
+        settings_file.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+
+        _mock_prompts(monkeypatch)
+        install()
+
+        data = _read_settings(settings_file)
+        assert user_ext in data["extensions"]
+        assert str(plugin_file) in data["extensions"]
+
+    def test_coerces_non_list_extensions_to_list(self, settings_file, plugin_file, monkeypatch):
+        """A malformed (non-list) extensions value is overwritten with a fresh list."""
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        existing = {"extensions": "not-a-list", "theme": "light"}
+        settings_file.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+
+        _mock_prompts(monkeypatch)
+        install()
+
+        data = _read_settings(settings_file)
+        assert isinstance(data["extensions"], list)
+        assert str(plugin_file) in data["extensions"]
+        # Unrelated key still preserved.
+        assert data["theme"] == "light"
+
+
+# ---------------------------------------------------------------------------
+# Install tests — missing / empty / malformed settings.json
+# ---------------------------------------------------------------------------
+
+
+class TestInstallHandlesMissingSettings:
+    """Install creates settings.json if missing and tolerates an empty file."""
+
+    def test_handles_empty_settings_file(self, settings_file, plugin_file, monkeypatch):
+        """An empty settings.json should be treated as {}."""
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text("", encoding="utf-8")
+
+        _mock_prompts(monkeypatch)
+        install()
+
+        data = _read_settings(settings_file)
+        assert str(plugin_file) in data["extensions"]
+
+    def test_handles_invalid_json_as_empty(self, settings_file, plugin_file, monkeypatch):
+        """Invalid JSON is logged and treated as {} (per spec — not a hard abort)."""
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text("{this is not valid json!!!", encoding="utf-8")
+
+        _mock_prompts(monkeypatch)
+        install()
+
+        data = _read_settings(settings_file)
+        assert str(plugin_file) in data["extensions"]
+
+
+# ---------------------------------------------------------------------------
+# Idempotency tests
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotent:
+    """Re-install is idempotent — one shim file, one array entry."""
+
+    def test_no_duplicate_extension_entry(self, settings_file, plugin_file, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        install()
+        data = _read_settings(settings_file)
+        occurrences = [e for e in data["extensions"] if e == str(plugin_file)]
+        assert len(occurrences) == 1
+
+    def test_no_duplicate_plugin_files(self, plugin_file, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        install()
+        assert plugin_file.is_file()
+        siblings = list(plugin_file.parent.glob("arize-tracing*.ts"))
+        assert siblings == [plugin_file]
+
+    def test_reinstall_content_matches_source(self, plugin_file, plugin_source_text, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        install()
+        assert plugin_file.read_text(encoding="utf-8") == plugin_source_text
+
+
+# ---------------------------------------------------------------------------
+# Second harness (copy-from) + existing entry re-install
+# ---------------------------------------------------------------------------
+
+
+class TestInstallSecondHarnessOffersCopyFrom:
+    """When another harness exists, its credentials are offered to prompt_backend."""
+
+    def test_copy_from_populates_credentials(self, cwd_tmp, monkeypatch):
+        config_dir = cwd_tmp / ".arize" / "harness"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        config_path = config_dir / "config.yaml"
+
+        seed_config = {
+            "harnesses": {
+                "claude-code": {
+                    "project_name": "claude-code",
+                    "target": "arize",
+                    "endpoint": "otlp.arize.com:443",
+                    "api_key": "ak-existing",
+                    "space_id": "space-existing",
+                },
+            },
+        }
+        config_path.write_text(yaml.dump(seed_config))
+
+        captured = {}
+
+        def fake_prompt_backend(existing_harnesses=None):
+            captured["existing_harnesses"] = existing_harnesses
+            return ARIZE_BACKEND
+
+        monkeypatch.setattr(_install, "prompt_backend", fake_prompt_backend)
+        monkeypatch.setattr(_install, "prompt_project_name", lambda default: default)
+        monkeypatch.setattr(_install, "prompt_user_id", lambda: "")
+        monkeypatch.setattr(
+            _install,
+            "prompt_content_logging",
+            lambda: {"prompts": True, "tool_details": True, "tool_content": True},
+        )
+        monkeypatch.setattr(_install, "write_logging_config", lambda block, config_path=None: None)
+        monkeypatch.setattr("sys.stdout", _fake_stdout())
+
+        install()
+
+        assert captured["existing_harnesses"] is not None
+        assert "claude-code" in captured["existing_harnesses"]
+        assert captured["existing_harnesses"]["claude-code"]["target"] == "arize"
+
+        config = yaml.safe_load(config_path.read_text())
+        entry = config["harnesses"]["omp"]
+        assert entry["target"] == "arize"
+        assert entry["endpoint"] == ARIZE_BACKEND[1]["endpoint"]
+        assert entry["api_key"] == ARIZE_BACKEND[1]["api_key"]
+        assert entry["space_id"] == ARIZE_BACKEND[1]["space_id"]
+        assert entry["project_name"] == "omp"
+
+
+class TestInstallExistingOmpEntryOnlyUpdatesProjectName:
+    """Re-install with an existing omp config entry only updates project_name."""
+
+    def test_existing_entry_preserves_target(self, cwd_tmp, monkeypatch):
+        config_dir = cwd_tmp / ".arize" / "harness"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        config_path = config_dir / "config.yaml"
+
+        seed_config = {
+            "harnesses": {
+                "omp": {
+                    "project_name": "omp",
+                    "target": "arize",
+                    "endpoint": "otlp.arize.com:443",
+                    "api_key": "ak-existing",
+                    "space_id": "space-existing",
+                },
+            },
+        }
+        config_path.write_text(yaml.dump(seed_config))
+
+        monkeypatch.setattr(_install, "prompt_project_name", lambda default: "my-omp")
+        monkeypatch.setattr(
+            _install,
+            "prompt_content_logging",
+            lambda: {"prompts": True, "tool_details": True, "tool_content": True},
+        )
+        monkeypatch.setattr(_install, "write_logging_config", lambda block, config_path=None: None)
+        monkeypatch.setattr("sys.stdout", _fake_stdout())
+
+        install()
+
+        config = yaml.safe_load(config_path.read_text())
+        entry = config["harnesses"]["omp"]
+        assert entry["project_name"] == "my-omp"
+        assert entry["target"] == "arize"
+        assert entry["endpoint"] == "otlp.arize.com:443"
+        assert entry["api_key"] == "ak-existing"
+        assert entry["space_id"] == "space-existing"
+
+
+class TestInstallExistingLoggingBlockSkipsPrompt:
+    """When config.yaml already has a logging block, skip the logging prompt."""
+
+    def test_existing_logging_not_reprompted(self, cwd_tmp, monkeypatch):
+        config_dir = cwd_tmp / ".arize" / "harness"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        config_path = config_dir / "config.yaml"
+
+        seed_config = {"logging": {"prompts": False, "tool_details": True, "tool_content": False}}
+        config_path.write_text(yaml.dump(seed_config))
+
+        _mock_prompts(monkeypatch)
+
+        prompt_logging_called = []
+        monkeypatch.setattr(
+            _install,
+            "prompt_content_logging",
+            lambda: prompt_logging_called.append(True) or {"prompts": True, "tool_details": True, "tool_content": True},
+        )
+
+        install()
+
+        assert len(prompt_logging_called) == 0, "prompt_content_logging should not be called"
+
+
+class TestInstallPromptsForLogging:
+    """Install prompts for logging settings when the logging block is missing."""
+
+    def test_install_prompts_for_logging_when_block_missing(self, cwd_tmp, monkeypatch):
+        from unittest.mock import MagicMock
+
+        logging_result = {"prompts": True, "tool_details": True, "tool_content": True}
+        mock_prompt_logging = MagicMock(return_value=logging_result)
+        mock_write_logging = MagicMock()
+
+        monkeypatch.setattr(_install, "prompt_backend", lambda existing_harnesses=None: PHOENIX_BACKEND)
+        monkeypatch.setattr(_install, "prompt_project_name", lambda default: default)
+        monkeypatch.setattr(_install, "prompt_user_id", lambda: "")
+        monkeypatch.setattr(_install, "prompt_content_logging", mock_prompt_logging)
+        monkeypatch.setattr(_install, "write_logging_config", mock_write_logging)
+        monkeypatch.setattr("sys.stdout", _fake_stdout())
+
+        install()
+
+        mock_prompt_logging.assert_called_once()
+        mock_write_logging.assert_called_once_with(logging_result)
+
+
+# ---------------------------------------------------------------------------
+# Plugin source resolution (regression for site-packages FileNotFoundError)
+# ---------------------------------------------------------------------------
+
+
+class TestPluginSourceResolution:
+    """The installer must locate its bundled .ts relative to install.py itself."""
+
+    def test_source_resolved_independently_of_constants(self, cwd_tmp, plugin_file, monkeypatch):
+        _mock_prompts(monkeypatch)
+        # Simulate constants imported from a tree lacking the data asset
+        # (the venv site-packages situation).
+        monkeypatch.setattr(_omp, "PLUGIN_SOURCE", cwd_tmp / "no-such-tree" / "arize-tracing.ts")
+
+        install()
+
+        assert plugin_file.is_file()
+        assert plugin_file.read_text(encoding="utf-8").startswith(_HEADER_MARKER)
+
+    def test_plugin_source_points_at_existing_asset(self):
+        """_plugin_source() resolves to a file that actually exists on disk."""
+        src = _install._plugin_source()
+        assert src.is_file()
+        assert src.name == "arize-tracing.ts"
+
+
+# ---------------------------------------------------------------------------
+# Uninstall tests
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallRemovesEverything:
+    """Uninstall removes the array entry, the shim, and the config entry."""
+
+    def test_config_entry_removed(self, cwd_tmp, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        uninstall()
+        config_path = cwd_tmp / ".arize" / "harness" / "config.yaml"
+        if config_path.is_file():
+            config = yaml.safe_load(config_path.read_text()) or {}
+            harnesses = config.get("harnesses", {})
+            assert "omp" not in harnesses
+
+    def test_plugin_file_removed(self, plugin_file, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        assert plugin_file.is_file()
+        uninstall()
+        assert not plugin_file.is_file()
+
+    def test_extension_entry_removed(self, settings_file, plugin_file, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        assert str(plugin_file) in _read_settings(settings_file)["extensions"]
+        uninstall()
+        if settings_file.is_file():
+            data = _read_settings(settings_file)
+            assert str(plugin_file) not in data.get("extensions", [])
+
+    def test_uninstall_preserves_unrelated_settings(self, settings_file, plugin_file, monkeypatch):
+        """Uninstall must not clobber unrelated keys or other extensions."""
+        _mock_prompts(monkeypatch)
+        install()
+
+        data = _read_settings(settings_file)
+        data["theme"] = "dark"
+        data["extensions"].append("/Users/me/.omp/extensions/my-own.ts")
+        settings_file.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+        uninstall()
+
+        remaining = _read_settings(settings_file)
+        assert remaining["theme"] == "dark"
+        assert "/Users/me/.omp/extensions/my-own.ts" in remaining["extensions"]
+        assert str(plugin_file) not in remaining["extensions"]
+
+
+class TestUninstallIdempotent:
+    """Uninstall is idempotent and tolerant of missing state."""
+
+    def test_uninstall_is_idempotent(self, cwd_tmp, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        uninstall()
+        uninstall()  # second call — no exception
+        config_path = cwd_tmp / ".arize" / "harness" / "config.yaml"
+        if config_path.is_file():
+            config = yaml.safe_load(config_path.read_text()) or {}
+            assert "omp" not in config.get("harnesses", {})
+
+    def test_uninstall_when_no_plugin_file(self, cwd_tmp, monkeypatch):
+        monkeypatch.setattr("sys.stdout", _fake_stdout())
+        assert not _omp.PLUGIN_FILE.is_file()
+        uninstall()  # should not raise
+
+    def test_uninstall_when_no_settings_file(self, cwd_tmp, monkeypatch):
+        monkeypatch.setattr("sys.stdout", _fake_stdout())
+        assert not _omp.SETTINGS_FILE.is_file()
+        uninstall()  # should not raise
+
+    def test_uninstall_when_no_extensions_dir(self, cwd_tmp, monkeypatch):
+        monkeypatch.setattr("sys.stdout", _fake_stdout())
+        assert not _omp.EXTENSIONS_DIR.exists()
+        uninstall()  # should not raise
+
+
+class TestUninstallGuardsForeignPluginFile:
+    """Uninstall must NOT delete a plugin file lacking our header marker."""
+
+    def test_non_arize_file_not_deleted(self, plugin_file, monkeypatch):
+        plugin_file.parent.mkdir(parents=True, exist_ok=True)
+        foreign_text = "// SomeoneElse's extension\nexport default function () {};\n"
+        plugin_file.write_text(foreign_text, encoding="utf-8")
+
+        monkeypatch.setattr("sys.stdout", _fake_stdout())
+        uninstall()
+
+        assert plugin_file.is_file()
+        assert plugin_file.read_text(encoding="utf-8") == foreign_text
+
+    def test_preserves_other_user_extension_files(self, plugin_file, monkeypatch):
+        """Uninstall must not touch unrelated *.ts files in the extensions dir."""
+        _mock_prompts(monkeypatch)
+        install()
+
+        other = plugin_file.parent / "user-extension.ts"
+        other_text = "// user's own extension\nexport const X = 1;\n"
+        other.write_text(other_text, encoding="utf-8")
+
+        uninstall()
+
+        assert not plugin_file.is_file()
+        assert other.is_file()
+        assert other.read_text(encoding="utf-8") == other_text
+
+
+# ---------------------------------------------------------------------------
+# Dry-run tests
+# ---------------------------------------------------------------------------
+
+
+class TestInstallDryRunWritesNothing:
+    """Dry-run install performs no filesystem writes."""
+
+    def test_dry_run_no_plugin_file(self, plugin_file, monkeypatch):
+        monkeypatch.setenv("ARIZE_DRY_RUN", "true")
+        _mock_prompts(monkeypatch)
+        install()
+        assert not plugin_file.is_file()
+
+    def test_dry_run_no_extensions_dir(self, cwd_tmp, monkeypatch):
+        monkeypatch.setenv("ARIZE_DRY_RUN", "true")
+        _mock_prompts(monkeypatch)
+        install()
+        assert not _omp.EXTENSIONS_DIR.exists()
+
+    def test_dry_run_no_settings_file(self, settings_file, monkeypatch):
+        monkeypatch.setenv("ARIZE_DRY_RUN", "true")
+        _mock_prompts(monkeypatch)
+        install()
+        assert not settings_file.is_file()
+
+    def test_dry_run_does_not_modify_existing_settings(self, settings_file, monkeypatch):
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        original = {"theme": "dark", "extensions": ["/Users/me/.omp/extensions/my-own.ts"]}
+        settings_file.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8")
+
+        monkeypatch.setenv("ARIZE_DRY_RUN", "true")
+        _mock_prompts(monkeypatch)
+        install()
+
+        assert _read_settings(settings_file) == original
+
+    def test_dry_run_no_config(self, cwd_tmp, monkeypatch):
+        monkeypatch.setenv("ARIZE_DRY_RUN", "true")
+        _mock_prompts(monkeypatch)
+        install()
+        config_path = cwd_tmp / ".arize" / "harness" / "config.yaml"
+        assert not config_path.is_file()
+
+
+class TestUninstallDryRunWritesNothing:
+    """Dry-run uninstall preserves all on-disk state."""
+
+    def test_dry_run_uninstall_preserves_plugin_file(self, plugin_file, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        original = plugin_file.read_text(encoding="utf-8")
+
+        monkeypatch.setenv("ARIZE_DRY_RUN", "true")
+        uninstall()
+
+        assert plugin_file.is_file()
+        assert plugin_file.read_text(encoding="utf-8") == original
+
+    def test_dry_run_uninstall_preserves_settings(self, settings_file, plugin_file, monkeypatch):
+        _mock_prompts(monkeypatch)
+        install()
+        original = settings_file.read_text(encoding="utf-8")
+
+        monkeypatch.setenv("ARIZE_DRY_RUN", "true")
+        uninstall()
+
+        assert settings_file.read_text(encoding="utf-8") == original
+        assert str(plugin_file) in _read_settings(settings_file)["extensions"]
+
+    def test_dry_run_uninstall_no_state_no_error(self, cwd_tmp, monkeypatch):
+        monkeypatch.setenv("ARIZE_DRY_RUN", "true")
+        monkeypatch.setattr("sys.stdout", _fake_stdout())
+        uninstall()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# CLI main() dispatch tests
+# ---------------------------------------------------------------------------
+
+
+class TestMainDispatch:
+    """main() dispatches install/uninstall based on argv."""
+
+    def test_bad_args_exits_1(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["tracing.omp.install", "bogus"])
+        with pytest.raises(SystemExit) as exc_info:
+            _install.main()
+        assert exc_info.value.code == 1
+
+    def test_no_args_exits_1(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["tracing.omp.install"])
+        with pytest.raises(SystemExit) as exc_info:
+            _install.main()
+        assert exc_info.value.code == 1
+
+    def test_install_arg_calls_install(self, cwd_tmp, monkeypatch):
+        _mock_prompts(monkeypatch)
+        monkeypatch.setattr("sys.argv", ["tracing.omp.install", "install"])
+        called = []
+        monkeypatch.setattr(_install, "install", lambda with_skills=False: called.append("install"))
+        _install.main()
+        assert called == ["install"]
+
+    def test_uninstall_arg_calls_uninstall(self, cwd_tmp, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["tracing.omp.install", "uninstall"])
+        called = []
+        monkeypatch.setattr(_install, "uninstall", lambda: called.append("uninstall"))
+        _install.main()
+        assert called == ["uninstall"]
+
+
+class TestMainDispatchSkillsFlag:
+    """main() parses --with-skills and forwards it to install()."""
+
+    def test_main_install_with_skills_flag(self, cwd_tmp, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["tracing.omp.install", "install", "--with-skills"])
+        captured = {}
+        monkeypatch.setattr(_install, "install", lambda with_skills=False: captured.update(with_skills=with_skills))
+        _install.main()
+        assert captured == {"with_skills": True}
+
+    def test_main_install_without_skills_flag(self, cwd_tmp, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["tracing.omp.install", "install"])
+        captured = {}
+        monkeypatch.setattr(_install, "install", lambda with_skills=False: captured.update(with_skills=with_skills))
+        _install.main()
+        assert captured == {"with_skills": False}
+
+
+# ---------------------------------------------------------------------------
+# Skills wiring (--with-skills)
+# ---------------------------------------------------------------------------
+
+
+class TestInstallSkillsWiring:
+    """install() honors with_skills and symlinks the management skill."""
+
+    def test_install_with_skills_true_calls_symlink(self, cwd_tmp, monkeypatch):
+        _mock_prompts(monkeypatch)
+        calls = []
+        monkeypatch.setattr(_install, "symlink_skills", lambda harness: calls.append(harness))
+        install(with_skills=True)
+        assert calls == ["omp"]
+
+    def test_install_default_does_not_symlink(self, cwd_tmp, monkeypatch):
+        _mock_prompts(monkeypatch)
+        calls = []
+        monkeypatch.setattr(_install, "symlink_skills", lambda harness: calls.append(harness))
+        install()
+        assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Constants verification
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    """Verify omp constants are well-formed."""
+
+    def test_harness_name_is_omp(self):
+        assert _omp.HARNESS_NAME == "omp"
+
+    def test_plugin_file_under_extensions_dir(self):
+        assert _omp.PLUGIN_FILE.parent == _omp.EXTENSIONS_DIR
+
+    def test_plugin_file_name(self):
+        assert _omp.PLUGIN_FILE.name == "arize-tracing.ts"
+
+    def test_settings_file_under_settings_dir(self):
+        assert _omp.SETTINGS_FILE.parent == _omp.SETTINGS_DIR
+
+    def test_settings_file_name(self):
+        assert _omp.SETTINGS_FILE.name == "settings.json"
+
+    def test_plugin_source_exists_in_repo(self):
+        assert _omp.PLUGIN_SOURCE.is_file()
+
+    def test_plugin_source_has_header_marker(self):
+        text = _omp.PLUGIN_SOURCE.read_text(encoding="utf-8")
+        assert text.startswith(_HEADER_MARKER)
+
+
+# ---------------------------------------------------------------------------
+# Setup wizard delegation
+# ---------------------------------------------------------------------------
+
+
+class TestSetupOmpModule:
+    """core/setup/omp.py delegates to tracing.omp.install."""
+
+    def test_setup_module_importable(self):
+        from core.setup.omp import install, main, uninstall
+
+        assert callable(install)
+        assert callable(uninstall)
+        assert callable(main)
+
+    def test_setup_install_delegates(self, cwd_tmp, monkeypatch):
+        import core.setup.omp as setup_omp
+
+        called = []
+        monkeypatch.setattr(_install, "install", lambda: called.append("install"))
+        setup_omp.install()
+        assert called == ["install"]
+
+    def test_setup_uninstall_delegates(self, cwd_tmp, monkeypatch):
+        import core.setup.omp as setup_omp
+
+        called = []
+        monkeypatch.setattr(_install, "uninstall", lambda: called.append("uninstall"))
+        setup_omp.uninstall()
+        assert called == ["uninstall"]
+
+    def test_setup_main_delegates_to_install(self, cwd_tmp, monkeypatch):
+        import core.setup.omp as setup_omp
+
+        called = []
+        monkeypatch.setattr(_install, "install", lambda: called.append("install"))
+        setup_omp.main()
+        assert called == ["install"]

--- a/tests/tracing/omp/test_install_omp.py
+++ b/tests/tracing/omp/test_install_omp.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import json
 
 import pytest
-import yaml
 
 import tracing.omp.constants as _omp
 import tracing.omp.install as _install
@@ -90,7 +89,7 @@ def cwd_tmp(tmp_path, monkeypatch):
 
     monkeypatch.setattr(setup_mod, "INSTALL_DIR", tmp_path / ".arize" / "harness")
     monkeypatch.setattr(setup_mod, "VENV_DIR", tmp_path / ".arize" / "harness" / "venv")
-    monkeypatch.setattr(setup_mod, "CONFIG_FILE", tmp_path / ".arize" / "harness" / "config.yaml")
+    monkeypatch.setattr(setup_mod, "CONFIG_FILE", tmp_path / ".arize" / "harness" / "config.json")
     monkeypatch.setattr(setup_mod, "BIN_DIR", tmp_path / ".arize" / "harness" / "bin")
     monkeypatch.setattr(setup_mod, "RUN_DIR", tmp_path / ".arize" / "harness" / "run")
     monkeypatch.setattr(setup_mod, "LOG_DIR", tmp_path / ".arize" / "harness" / "logs")
@@ -99,11 +98,11 @@ def cwd_tmp(tmp_path, monkeypatch):
     import core.constants as c
 
     monkeypatch.setattr(c, "BASE_DIR", tmp_path / ".arize" / "harness")
-    monkeypatch.setattr(c, "CONFIG_FILE", tmp_path / ".arize" / "harness" / "config.yaml")
+    monkeypatch.setattr(c, "CONFIG_FILE", tmp_path / ".arize" / "harness" / "config.json")
 
     import core.config as config_mod
 
-    monkeypatch.setattr(config_mod, "CONFIG_FILE", str(tmp_path / ".arize" / "harness" / "config.yaml"))
+    monkeypatch.setattr(config_mod, "CONFIG_FILE", str(tmp_path / ".arize" / "harness" / "config.json"))
 
     # Redirect omp settings + extension paths into the temp tree.
     settings_dir = tmp_path / ".omp" / "agent"
@@ -139,12 +138,12 @@ def _read_settings(settings_file):
 
 
 # ---------------------------------------------------------------------------
-# Install tests — fresh install (config.yaml harness entry)
+# Install tests — fresh install (config.json harness entry)
 # ---------------------------------------------------------------------------
 
 
 class TestInstallFreshWritesFlatHarnessEntry:
-    """Fresh install writes a flat harness entry to config.yaml."""
+    """Fresh install writes a flat harness entry to config.json."""
 
     @pytest.mark.parametrize(
         "backend,expected_target",
@@ -158,9 +157,9 @@ class TestInstallFreshWritesFlatHarnessEntry:
         _mock_prompts(monkeypatch, backend=backend)
         install()
 
-        config_path = cwd_tmp / ".arize" / "harness" / "config.yaml"
+        config_path = cwd_tmp / ".arize" / "harness" / "config.json"
         assert config_path.is_file()
-        config = yaml.safe_load(config_path.read_text())
+        config = json.loads(config_path.read_text())
         entry = config["harnesses"]["omp"]
         assert entry["target"] == expected_target
         assert entry["project_name"] == "omp"
@@ -376,7 +375,7 @@ class TestInstallSecondHarnessOffersCopyFrom:
     def test_copy_from_populates_credentials(self, cwd_tmp, monkeypatch):
         config_dir = cwd_tmp / ".arize" / "harness"
         config_dir.mkdir(parents=True, exist_ok=True)
-        config_path = config_dir / "config.yaml"
+        config_path = config_dir / "config.json"
 
         seed_config = {
             "harnesses": {
@@ -389,7 +388,7 @@ class TestInstallSecondHarnessOffersCopyFrom:
                 },
             },
         }
-        config_path.write_text(yaml.dump(seed_config))
+        config_path.write_text(json.dumps(seed_config, indent=2))
 
         captured = {}
 
@@ -414,7 +413,7 @@ class TestInstallSecondHarnessOffersCopyFrom:
         assert "claude-code" in captured["existing_harnesses"]
         assert captured["existing_harnesses"]["claude-code"]["target"] == "arize"
 
-        config = yaml.safe_load(config_path.read_text())
+        config = json.loads(config_path.read_text())
         entry = config["harnesses"]["omp"]
         assert entry["target"] == "arize"
         assert entry["endpoint"] == ARIZE_BACKEND[1]["endpoint"]
@@ -429,7 +428,7 @@ class TestInstallExistingOmpEntryOnlyUpdatesProjectName:
     def test_existing_entry_preserves_target(self, cwd_tmp, monkeypatch):
         config_dir = cwd_tmp / ".arize" / "harness"
         config_dir.mkdir(parents=True, exist_ok=True)
-        config_path = config_dir / "config.yaml"
+        config_path = config_dir / "config.json"
 
         seed_config = {
             "harnesses": {
@@ -442,7 +441,7 @@ class TestInstallExistingOmpEntryOnlyUpdatesProjectName:
                 },
             },
         }
-        config_path.write_text(yaml.dump(seed_config))
+        config_path.write_text(json.dumps(seed_config, indent=2))
 
         monkeypatch.setattr(_install, "prompt_project_name", lambda default: "my-omp")
         monkeypatch.setattr(
@@ -455,7 +454,7 @@ class TestInstallExistingOmpEntryOnlyUpdatesProjectName:
 
         install()
 
-        config = yaml.safe_load(config_path.read_text())
+        config = json.loads(config_path.read_text())
         entry = config["harnesses"]["omp"]
         assert entry["project_name"] == "my-omp"
         assert entry["target"] == "arize"
@@ -465,15 +464,15 @@ class TestInstallExistingOmpEntryOnlyUpdatesProjectName:
 
 
 class TestInstallExistingLoggingBlockSkipsPrompt:
-    """When config.yaml already has a logging block, skip the logging prompt."""
+    """When config.json already has a logging block, skip the logging prompt."""
 
     def test_existing_logging_not_reprompted(self, cwd_tmp, monkeypatch):
         config_dir = cwd_tmp / ".arize" / "harness"
         config_dir.mkdir(parents=True, exist_ok=True)
-        config_path = config_dir / "config.yaml"
+        config_path = config_dir / "config.json"
 
         seed_config = {"logging": {"prompts": False, "tool_details": True, "tool_content": False}}
-        config_path.write_text(yaml.dump(seed_config))
+        config_path.write_text(json.dumps(seed_config, indent=2))
 
         _mock_prompts(monkeypatch)
 
@@ -550,9 +549,9 @@ class TestUninstallRemovesEverything:
         _mock_prompts(monkeypatch)
         install()
         uninstall()
-        config_path = cwd_tmp / ".arize" / "harness" / "config.yaml"
+        config_path = cwd_tmp / ".arize" / "harness" / "config.json"
         if config_path.is_file():
-            config = yaml.safe_load(config_path.read_text()) or {}
+            config = json.loads(config_path.read_text()) or {}
             harnesses = config.get("harnesses", {})
             assert "omp" not in harnesses
 
@@ -598,9 +597,9 @@ class TestUninstallIdempotent:
         install()
         uninstall()
         uninstall()  # second call — no exception
-        config_path = cwd_tmp / ".arize" / "harness" / "config.yaml"
+        config_path = cwd_tmp / ".arize" / "harness" / "config.json"
         if config_path.is_file():
-            config = yaml.safe_load(config_path.read_text()) or {}
+            config = json.loads(config_path.read_text()) or {}
             assert "omp" not in config.get("harnesses", {})
 
     def test_uninstall_when_no_plugin_file(self, cwd_tmp, monkeypatch):
@@ -690,7 +689,7 @@ class TestInstallDryRunWritesNothing:
         monkeypatch.setenv("ARIZE_DRY_RUN", "true")
         _mock_prompts(monkeypatch)
         install()
-        config_path = cwd_tmp / ".arize" / "harness" / "config.yaml"
+        config_path = cwd_tmp / ".arize" / "harness" / "config.json"
         assert not config_path.is_file()
 
 

--- a/tests/tracing/omp/test_install_omp.py
+++ b/tests/tracing/omp/test_install_omp.py
@@ -321,16 +321,18 @@ class TestInstallHandlesMissingSettings:
         data = _read_settings(settings_file)
         assert str(plugin_file) in data["extensions"]
 
-    def test_handles_invalid_json_as_empty(self, settings_file, plugin_file, monkeypatch):
-        """Invalid JSON is logged and treated as {} (per spec — not a hard abort)."""
+    def test_invalid_json_aborts_without_clobbering(self, settings_file, plugin_file, monkeypatch):
+        """Malformed JSON aborts (SystemExit) instead of silently wiping the file."""
         settings_file.parent.mkdir(parents=True, exist_ok=True)
-        settings_file.write_text("{this is not valid json!!!", encoding="utf-8")
+        original = "{this is not valid json!!!"
+        settings_file.write_text(original, encoding="utf-8")
 
         _mock_prompts(monkeypatch)
-        install()
+        with pytest.raises(SystemExit):
+            install()
 
-        data = _read_settings(settings_file)
-        assert str(plugin_file) in data["extensions"]
+        # The user's (malformed) file is left untouched, not overwritten with {}.
+        assert settings_file.read_text(encoding="utf-8") == original
 
 
 # ---------------------------------------------------------------------------
@@ -841,11 +843,11 @@ class TestSetupOmpModule:
     """core/setup/omp.py delegates to tracing.omp.install."""
 
     def test_setup_module_importable(self):
-        from core.setup.omp import install, main, uninstall
+        import core.setup.omp as setup_omp
 
-        assert callable(install)
-        assert callable(uninstall)
-        assert callable(main)
+        assert callable(setup_omp.install)
+        assert callable(setup_omp.uninstall)
+        assert callable(setup_omp.main)
 
     def test_setup_install_delegates(self, cwd_tmp, monkeypatch):
         import core.setup.omp as setup_omp

--- a/tests/tracing/omp/test_omp_adapter.py
+++ b/tests/tracing/omp/test_omp_adapter.py
@@ -13,11 +13,11 @@ snapshot/message payload to mine, so the chain is simply
 """
 from __future__ import annotations
 
+import json
 import os
 import time
 
 import pytest
-import yaml
 
 from core.common import StateManager
 
@@ -43,7 +43,7 @@ def omp_state_dir(tmp_harness_dir, monkeypatch):
 def disable_env_vars(monkeypatch):
     """Clear env vars that could influence session resolution.
 
-    On-disk config.yaml is isolated globally by the autouse ``isolate_config``
+    On-disk config.json is isolated globally by the autouse ``isolate_config``
     fixture combined with ``tmp_harness_dir``'s ``CONFIG_FILE`` redirect, so this
     only needs to clear the env-var inputs.
     """
@@ -98,24 +98,24 @@ class TestResolveSession:
     def test_uses_session_id_from_payload(self, omp_state_dir, disable_env_vars):
         """sessionId in input_json is used as the state file key."""
         sm = adapter.resolve_session({"sessionId": "abc123"})
-        assert sm.state_file == omp_state_dir / "state_abc123.yaml"
+        assert sm.state_file == omp_state_dir / "state_abc123.json"
         assert sm.state_file.exists()
 
     def test_unknown_fallback_when_missing(self, omp_state_dir, disable_env_vars):
         """Missing sessionId -> key off 'unknown'. No PID-based key."""
         sm = adapter.resolve_session({})
-        assert sm.state_file == omp_state_dir / "state_unknown.yaml"
+        assert sm.state_file == omp_state_dir / "state_unknown.json"
         assert sm.state_file.exists()
 
     def test_unknown_fallback_when_empty(self, omp_state_dir, disable_env_vars):
         """Empty sessionId -> key off 'unknown'."""
         sm = adapter.resolve_session({"sessionId": ""})
-        assert sm.state_file == omp_state_dir / "state_unknown.yaml"
+        assert sm.state_file == omp_state_dir / "state_unknown.json"
 
     def test_unknown_fallback_when_none(self, omp_state_dir, disable_env_vars):
         """Explicit None sessionId -> key off 'unknown'."""
         sm = adapter.resolve_session({"sessionId": None})
-        assert sm.state_file == omp_state_dir / "state_unknown.yaml"
+        assert sm.state_file == omp_state_dir / "state_unknown.json"
 
     def test_no_pid_keyed_fallback(self, omp_state_dir, disable_env_vars):
         """Missing sessionId must NOT produce a PID-keyed state file.
@@ -124,7 +124,7 @@ class TestResolveSession:
         """
         adapter.resolve_session({})
         # No state file with a numeric (pid-style) key should exist
-        for f in omp_state_dir.glob("state_*.yaml"):
+        for f in omp_state_dir.glob("state_*.json"):
             key = f.stem.replace("state_", "", 1)
             assert not key.isdigit(), f"PID-keyed state file produced: {f.name}"
 
@@ -132,7 +132,7 @@ class TestResolveSession:
         """Returned StateManager has init_state() called (file exists with {})."""
         sm = adapter.resolve_session({"sessionId": "ses_init"})
         assert sm.state_file.exists()
-        data = yaml.safe_load(sm.state_file.read_text())
+        data = json.loads(sm.state_file.read_text())
         assert data == {}
 
     def test_same_session_id_same_file(self, omp_state_dir, disable_env_vars):
@@ -158,12 +158,12 @@ class TestResolveSession:
         opencode-style ``sessionID`` must fall through to 'unknown'.
         """
         sm = adapter.resolve_session({"sessionID": "WRONG_CASE"})
-        assert sm.state_file == omp_state_dir / "state_unknown.yaml"
+        assert sm.state_file == omp_state_dir / "state_unknown.json"
 
     def test_extra_payload_fields_ignored(self, omp_state_dir, disable_env_vars):
         """Extra payload fields are not used for the session key."""
         sm = adapter.resolve_session({"sessionId": "ses_only", "type": "turn_end", "message": {}})
-        assert sm.state_file == omp_state_dir / "state_ses_only.yaml"
+        assert sm.state_file == omp_state_dir / "state_ses_only.json"
 
 
 # ── ensure_session_initialized tests ─────────────────────────────────────────
@@ -173,7 +173,7 @@ class TestEnsureSessionInitialized:
     def _make_state(self, omp_state_dir, key="test"):
         sm = StateManager(
             state_dir=omp_state_dir,
-            state_file=omp_state_dir / f"state_{key}.yaml",
+            state_file=omp_state_dir / f"state_{key}.json",
             lock_path=omp_state_dir / f".lock_{key}",
         )
         sm.init_state()
@@ -182,7 +182,7 @@ class TestEnsureSessionInitialized:
     def test_sets_all_keys(self, omp_state_dir, disable_env_vars, monkeypatch):
         """First call sets all expected keys."""
         # Source user_id from env so the assertion is hermetic, not leaked from
-        # the developer's on-disk config.yaml.
+        # the developer's on-disk config.json.
         monkeypatch.setenv("ARIZE_USER_ID", "test-user-all-keys")
         sm = self._make_state(omp_state_dir, "all-keys")
         adapter.ensure_session_initialized(sm, {"sessionId": "ses_all"})
@@ -275,7 +275,7 @@ class TestEnsureSessionInitialized:
 class TestGcStaleStateFiles:
     def test_old_file_removed(self, omp_state_dir, disable_env_vars):
         """State file older than 24h is removed."""
-        state_file = omp_state_dir / "state_old-session.yaml"
+        state_file = omp_state_dir / "state_old-session.json"
         state_file.write_text("{}")
         # Set mtime to 25 hours ago
         old_time = time.time() - 90000
@@ -285,7 +285,7 @@ class TestGcStaleStateFiles:
 
     def test_recent_file_kept(self, omp_state_dir, disable_env_vars):
         """State file younger than 24h is kept."""
-        state_file = omp_state_dir / "state_recent-session.yaml"
+        state_file = omp_state_dir / "state_recent-session.json"
         state_file.write_text("{}")
         # mtime is now (just created), which is < 24h old
         adapter.gc_stale_state_files()
@@ -293,7 +293,7 @@ class TestGcStaleStateFiles:
 
     def test_lock_dir_removed(self, omp_state_dir, disable_env_vars):
         """Lock dir is removed when state file is removed."""
-        state_file = omp_state_dir / "state_old-lock-dir.yaml"
+        state_file = omp_state_dir / "state_old-lock-dir.json"
         state_file.write_text("{}")
         lock_dir = omp_state_dir / ".lock_old-lock-dir"
         lock_dir.mkdir()
@@ -305,7 +305,7 @@ class TestGcStaleStateFiles:
 
     def test_lock_file_removed(self, omp_state_dir, disable_env_vars):
         """Lock file is removed when state file is removed."""
-        state_file = omp_state_dir / "state_old-lock-file.yaml"
+        state_file = omp_state_dir / "state_old-lock-file.json"
         state_file.write_text("{}")
         lock_file = omp_state_dir / ".lock_old-lock-file"
         lock_file.write_text("")
@@ -317,7 +317,7 @@ class TestGcStaleStateFiles:
 
     def test_empty_dir_no_error(self, omp_state_dir, disable_env_vars):
         """Empty STATE_DIR causes no errors."""
-        for f in omp_state_dir.glob("state_*.yaml"):
+        for f in omp_state_dir.glob("state_*.json"):
             f.unlink()
         adapter.gc_stale_state_files()  # should not raise
 
@@ -329,7 +329,7 @@ class TestGcStaleStateFiles:
 
     def test_uses_24h_cutoff(self, omp_state_dir, disable_env_vars):
         """Files exactly past the 24h boundary are removed."""
-        state_file = omp_state_dir / "state_boundary.yaml"
+        state_file = omp_state_dir / "state_boundary.json"
         state_file.write_text("{}")
         old_time = time.time() - 86401  # 24h + 1s
         os.utime(state_file, (old_time, old_time))
@@ -342,7 +342,7 @@ class TestGcStaleStateFiles:
         A *recent* numeric-named file should NOT be removed (no liveness check on it).
         """
         # Recent file with digit-style key: must be kept (mtime branch only).
-        state_file = omp_state_dir / "state_99999.yaml"
+        state_file = omp_state_dir / "state_99999.json"
         state_file.write_text("{}")
         # Fresh mtime
         adapter.gc_stale_state_files()
@@ -350,7 +350,7 @@ class TestGcStaleStateFiles:
 
     def test_unknown_key_file_old_removed(self, omp_state_dir, disable_env_vars):
         """The 'unknown' fallback state file is removed once old (mtime branch)."""
-        state_file = omp_state_dir / "state_unknown.yaml"
+        state_file = omp_state_dir / "state_unknown.json"
         state_file.write_text("{}")
         old_time = time.time() - 90000
         os.utime(state_file, (old_time, old_time))
@@ -359,7 +359,7 @@ class TestGcStaleStateFiles:
 
     def test_oserror_on_unlink_is_caught(self, omp_state_dir, disable_env_vars, monkeypatch):
         """OSError on unlink is caught and ignored (best-effort)."""
-        state_file = omp_state_dir / "state_unlink-err.yaml"
+        state_file = omp_state_dir / "state_unlink-err.json"
         state_file.write_text("{}")
         old_time = time.time() - 90000
         os.utime(state_file, (old_time, old_time))

--- a/tests/tracing/omp/test_omp_adapter.py
+++ b/tests/tracing/omp/test_omp_adapter.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Tests for tracing.omp.hooks.adapter — session resolution, init, GC, requirements.
+
+Mirrors tests/tracing/opencode/test_opencode_adapter.py but adapted for omp's
+authoritative ``sessionId`` field (camelCase — the shim stamps it on every
+forwarded payload). omp always supplies a real session id, so there is NO PID /
+grandparent-PID fallback — a missing sessionId keys off the literal string
+"unknown".
+
+omp also differs from opencode in project-name derivation: there is no
+snapshot/message payload to mine, so the chain is simply
+``env.project_name`` -> ``os.path.basename(os.getcwd())`` -> ``HARNESS_NAME``.
+"""
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+import yaml
+
+from core.common import StateManager
+
+# ---------------------------------------------------------------------------
+# We import the adapter module itself so we can monkeypatch its module-level
+# constants.  The actual functions under test are attributes of this module.
+# ---------------------------------------------------------------------------
+from tracing.omp.hooks import adapter
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def omp_state_dir(tmp_harness_dir, monkeypatch):
+    """Point adapter.STATE_DIR to a temp directory and return it."""
+    state_dir = tmp_harness_dir / "state" / "omp"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(adapter, "STATE_DIR", state_dir)
+    return state_dir
+
+
+@pytest.fixture
+def disable_env_vars(monkeypatch):
+    """Clear env vars that could influence session resolution.
+
+    On-disk config.yaml is isolated globally by the autouse ``isolate_config``
+    fixture combined with ``tmp_harness_dir``'s ``CONFIG_FILE`` redirect, so this
+    only needs to clear the env-var inputs.
+    """
+    monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+    monkeypatch.delenv("ARIZE_USER_ID", raising=False)
+    monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+
+
+# ── Module-level constants tests ──────────────────────────────────────────────
+
+
+class TestModuleConstants:
+    def test_service_name(self):
+        """SERVICE_NAME matches the omp harness metadata."""
+        assert adapter.SERVICE_NAME == "omp"
+
+    def test_scope_name(self):
+        """SCOPE_NAME matches the omp harness metadata."""
+        assert adapter.SCOPE_NAME == "arize-omp-plugin"
+
+    def test_state_dir_matches_harness_subdir(self):
+        """STATE_DIR derives from HARNESSES['omp']['state_subdir']."""
+        # The adapter's STATE_DIR is a Path; its leaf must be the configured subdir.
+        assert adapter.STATE_DIR.name == "omp"
+
+
+# ── check_requirements tests ─────────────────────────────────────────────────
+
+
+class TestCheckRequirements:
+    def test_enabled_returns_true(self, tmp_harness_dir, monkeypatch):
+        """trace_enabled=True -> returns True and STATE_DIR exists."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        state_dir = tmp_harness_dir / "state" / "omp-check"
+        monkeypatch.setattr(adapter, "STATE_DIR", state_dir)
+        assert adapter.check_requirements() is True
+        assert state_dir.is_dir()
+
+    def test_disabled_returns_false(self, tmp_harness_dir, monkeypatch):
+        """trace_enabled=False -> returns False, STATE_DIR not created."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "false")
+        state_dir = tmp_harness_dir / "state" / "omp-nope"
+        monkeypatch.setattr(adapter, "STATE_DIR", state_dir)
+        assert adapter.check_requirements() is False
+        assert not state_dir.exists()
+
+
+# ── resolve_session tests ────────────────────────────────────────────────────
+
+
+class TestResolveSession:
+    def test_uses_session_id_from_payload(self, omp_state_dir, disable_env_vars):
+        """sessionId in input_json is used as the state file key."""
+        sm = adapter.resolve_session({"sessionId": "abc123"})
+        assert sm.state_file == omp_state_dir / "state_abc123.yaml"
+        assert sm.state_file.exists()
+
+    def test_unknown_fallback_when_missing(self, omp_state_dir, disable_env_vars):
+        """Missing sessionId -> key off 'unknown'. No PID-based key."""
+        sm = adapter.resolve_session({})
+        assert sm.state_file == omp_state_dir / "state_unknown.yaml"
+        assert sm.state_file.exists()
+
+    def test_unknown_fallback_when_empty(self, omp_state_dir, disable_env_vars):
+        """Empty sessionId -> key off 'unknown'."""
+        sm = adapter.resolve_session({"sessionId": ""})
+        assert sm.state_file == omp_state_dir / "state_unknown.yaml"
+
+    def test_unknown_fallback_when_none(self, omp_state_dir, disable_env_vars):
+        """Explicit None sessionId -> key off 'unknown'."""
+        sm = adapter.resolve_session({"sessionId": None})
+        assert sm.state_file == omp_state_dir / "state_unknown.yaml"
+
+    def test_no_pid_keyed_fallback(self, omp_state_dir, disable_env_vars):
+        """Missing sessionId must NOT produce a PID-keyed state file.
+
+        Unlike gemini, omp adapters never use PID-based keys.
+        """
+        adapter.resolve_session({})
+        # No state file with a numeric (pid-style) key should exist
+        for f in omp_state_dir.glob("state_*.yaml"):
+            key = f.stem.replace("state_", "", 1)
+            assert not key.isdigit(), f"PID-keyed state file produced: {f.name}"
+
+    def test_init_state_called(self, omp_state_dir, disable_env_vars):
+        """Returned StateManager has init_state() called (file exists with {})."""
+        sm = adapter.resolve_session({"sessionId": "ses_init"})
+        assert sm.state_file.exists()
+        data = yaml.safe_load(sm.state_file.read_text())
+        assert data == {}
+
+    def test_same_session_id_same_file(self, omp_state_dir, disable_env_vars):
+        """Calling resolve_session twice with same sessionId produces same file."""
+        sm1 = adapter.resolve_session({"sessionId": "ses_stable"})
+        sm2 = adapter.resolve_session({"sessionId": "ses_stable"})
+        assert sm1.state_file == sm2.state_file
+
+    def test_lock_path_matches_key(self, omp_state_dir, disable_env_vars):
+        """Lock file is named .lock_{key} in STATE_DIR."""
+        sm = adapter.resolve_session({"sessionId": "ses_lock"})
+        assert sm._lock_path == omp_state_dir / ".lock_ses_lock"
+
+    def test_state_dir_attribute(self, omp_state_dir, disable_env_vars):
+        """The StateManager.state_dir attribute matches adapter.STATE_DIR."""
+        sm = adapter.resolve_session({"sessionId": "ses_dir"})
+        assert sm.state_dir == omp_state_dir
+
+    def test_camelcase_session_id_only(self, omp_state_dir, disable_env_vars):
+        """Only camelCase ``sessionId`` is honored — opencode's ``sessionID`` is not.
+
+        The shim stamps ``sessionId`` (camelCase); a payload carrying only the
+        opencode-style ``sessionID`` must fall through to 'unknown'.
+        """
+        sm = adapter.resolve_session({"sessionID": "WRONG_CASE"})
+        assert sm.state_file == omp_state_dir / "state_unknown.yaml"
+
+    def test_extra_payload_fields_ignored(self, omp_state_dir, disable_env_vars):
+        """Extra payload fields are not used for the session key."""
+        sm = adapter.resolve_session({"sessionId": "ses_only", "type": "turn_end", "message": {}})
+        assert sm.state_file == omp_state_dir / "state_ses_only.yaml"
+
+
+# ── ensure_session_initialized tests ─────────────────────────────────────────
+
+
+class TestEnsureSessionInitialized:
+    def _make_state(self, omp_state_dir, key="test"):
+        sm = StateManager(
+            state_dir=omp_state_dir,
+            state_file=omp_state_dir / f"state_{key}.yaml",
+            lock_path=omp_state_dir / f".lock_{key}",
+        )
+        sm.init_state()
+        return sm
+
+    def test_sets_all_keys(self, omp_state_dir, disable_env_vars, monkeypatch):
+        """First call sets all expected keys."""
+        # Source user_id from env so the assertion is hermetic, not leaked from
+        # the developer's on-disk config.yaml.
+        monkeypatch.setenv("ARIZE_USER_ID", "test-user-all-keys")
+        sm = self._make_state(omp_state_dir, "all-keys")
+        adapter.ensure_session_initialized(sm, {"sessionId": "ses_all"})
+        assert sm.get("session_id") is not None
+        assert sm.get("session_start_time") is not None
+        assert sm.get("project_name") is not None
+        assert sm.get("trace_count") == "0"
+        assert sm.get("tool_count") == "0"
+        assert sm.get("user_id") == "test-user-all-keys"
+
+    def test_session_id_matches_session_id_field(self, omp_state_dir, disable_env_vars):
+        """session_id stored in state == the omp sessionId from payload."""
+        sm = self._make_state(omp_state_dir, "sid-from-payload")
+        adapter.ensure_session_initialized(sm, {"sessionId": "ses_xyz789"})
+        assert sm.get("session_id") == "ses_xyz789"
+
+    def test_session_id_unknown_when_missing(self, omp_state_dir, disable_env_vars):
+        """session_id falls back to 'unknown' when payload lacks sessionId."""
+        sm = self._make_state(omp_state_dir, "sid-missing")
+        adapter.ensure_session_initialized(sm, {})
+        assert sm.get("session_id") == "unknown"
+
+    def test_idempotent(self, omp_state_dir, disable_env_vars):
+        """Second call is a no-op — values unchanged."""
+        sm = self._make_state(omp_state_dir, "idempotent")
+        adapter.ensure_session_initialized(sm, {"sessionId": "ses_first"})
+        start_time = sm.get("session_start_time")
+        session_id = sm.get("session_id")
+        # A second call with a *different* sessionId must NOT overwrite
+        adapter.ensure_session_initialized(sm, {"sessionId": "ses_second"})
+        assert sm.get("session_id") == session_id
+        assert sm.get("session_start_time") == start_time
+
+    def test_project_name_from_env(self, omp_state_dir, monkeypatch):
+        """ARIZE_PROJECT_NAME env var takes priority."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.setenv("ARIZE_PROJECT_NAME", "my-env-project")
+        monkeypatch.delenv("ARIZE_USER_ID", raising=False)
+        sm = self._make_state(omp_state_dir, "proj-env")
+        adapter.ensure_session_initialized(sm, {"sessionId": "ses_e"})
+        assert sm.get("project_name") == "my-env-project"
+
+    def test_project_name_fallback_to_cwd_basename(self, omp_state_dir, disable_env_vars):
+        """project_name falls back to basename of os.getcwd() when no env value."""
+        sm = self._make_state(omp_state_dir, "proj-fallback")
+        adapter.ensure_session_initialized(sm, {"sessionId": "ses_f"})
+        project = sm.get("project_name")
+        assert project is not None
+        assert project == os.path.basename(os.getcwd())
+
+    def test_project_name_final_fallback_to_harness_name(self, omp_state_dir, disable_env_vars, monkeypatch):
+        """project_name falls back to HARNESS_NAME ('omp') when cwd basename is empty.
+
+        os.path.basename('/') == '' so the chain reaches its final literal fallback.
+        """
+        monkeypatch.setattr(os, "getcwd", lambda: "/")
+        sm = self._make_state(omp_state_dir, "proj-harness")
+        adapter.ensure_session_initialized(sm, {"sessionId": "ses_h"})
+        assert sm.get("project_name") == "omp"
+
+    def test_counters_start_at_zero(self, omp_state_dir, disable_env_vars):
+        """trace_count and tool_count start at '0' (string)."""
+        sm = self._make_state(omp_state_dir, "counters")
+        adapter.ensure_session_initialized(sm, {"sessionId": "ses_ct"})
+        assert sm.get("trace_count") == "0"
+        assert sm.get("tool_count") == "0"
+
+    def test_user_id_from_env(self, omp_state_dir, monkeypatch):
+        """user_id is resolved via env (ARIZE_USER_ID)."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.setenv("ARIZE_USER_ID", "test-user-456")
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        sm = self._make_state(omp_state_dir, "user-env")
+        adapter.ensure_session_initialized(sm, {"sessionId": "ses_u"})
+        assert sm.get("user_id") == "test-user-456"
+
+    def test_session_start_time_is_string_ms(self, omp_state_dir, disable_env_vars):
+        """session_start_time is a string representation of a positive int (ms)."""
+        sm = self._make_state(omp_state_dir, "start-time")
+        adapter.ensure_session_initialized(sm, {"sessionId": "ses_st"})
+        start = sm.get("session_start_time")
+        assert start is not None
+        assert start.isdigit()
+        assert int(start) > 0
+
+
+# ── gc_stale_state_files tests ───────────────────────────────────────────────
+
+
+class TestGcStaleStateFiles:
+    def test_old_file_removed(self, omp_state_dir, disable_env_vars):
+        """State file older than 24h is removed."""
+        state_file = omp_state_dir / "state_old-session.yaml"
+        state_file.write_text("{}")
+        # Set mtime to 25 hours ago
+        old_time = time.time() - 90000
+        os.utime(state_file, (old_time, old_time))
+        adapter.gc_stale_state_files()
+        assert not state_file.exists()
+
+    def test_recent_file_kept(self, omp_state_dir, disable_env_vars):
+        """State file younger than 24h is kept."""
+        state_file = omp_state_dir / "state_recent-session.yaml"
+        state_file.write_text("{}")
+        # mtime is now (just created), which is < 24h old
+        adapter.gc_stale_state_files()
+        assert state_file.exists()
+
+    def test_lock_dir_removed(self, omp_state_dir, disable_env_vars):
+        """Lock dir is removed when state file is removed."""
+        state_file = omp_state_dir / "state_old-lock-dir.yaml"
+        state_file.write_text("{}")
+        lock_dir = omp_state_dir / ".lock_old-lock-dir"
+        lock_dir.mkdir()
+        old_time = time.time() - 90000
+        os.utime(state_file, (old_time, old_time))
+        adapter.gc_stale_state_files()
+        assert not state_file.exists()
+        assert not lock_dir.exists()
+
+    def test_lock_file_removed(self, omp_state_dir, disable_env_vars):
+        """Lock file is removed when state file is removed."""
+        state_file = omp_state_dir / "state_old-lock-file.yaml"
+        state_file.write_text("{}")
+        lock_file = omp_state_dir / ".lock_old-lock-file"
+        lock_file.write_text("")
+        old_time = time.time() - 90000
+        os.utime(state_file, (old_time, old_time))
+        adapter.gc_stale_state_files()
+        assert not state_file.exists()
+        assert not lock_file.exists()
+
+    def test_empty_dir_no_error(self, omp_state_dir, disable_env_vars):
+        """Empty STATE_DIR causes no errors."""
+        for f in omp_state_dir.glob("state_*.yaml"):
+            f.unlink()
+        adapter.gc_stale_state_files()  # should not raise
+
+    def test_nonexistent_dir_no_error(self, tmp_harness_dir, monkeypatch):
+        """Non-existent STATE_DIR causes no errors."""
+        state_dir = tmp_harness_dir / "state" / "omp-nonexistent"
+        monkeypatch.setattr(adapter, "STATE_DIR", state_dir)
+        adapter.gc_stale_state_files()  # should not raise
+
+    def test_uses_24h_cutoff(self, omp_state_dir, disable_env_vars):
+        """Files exactly past the 24h boundary are removed."""
+        state_file = omp_state_dir / "state_boundary.yaml"
+        state_file.write_text("{}")
+        old_time = time.time() - 86401  # 24h + 1s
+        os.utime(state_file, (old_time, old_time))
+        adapter.gc_stale_state_files()
+        assert not state_file.exists()
+
+    def test_numeric_keyed_file_uses_mtime_not_liveness(self, omp_state_dir, disable_env_vars):
+        """Even a numeric (pid-style) key uses mtime-only, since omp has no PID branch.
+
+        A *recent* numeric-named file should NOT be removed (no liveness check on it).
+        """
+        # Recent file with digit-style key: must be kept (mtime branch only).
+        state_file = omp_state_dir / "state_99999.yaml"
+        state_file.write_text("{}")
+        # Fresh mtime
+        adapter.gc_stale_state_files()
+        assert state_file.exists()
+
+    def test_unknown_key_file_old_removed(self, omp_state_dir, disable_env_vars):
+        """The 'unknown' fallback state file is removed once old (mtime branch)."""
+        state_file = omp_state_dir / "state_unknown.yaml"
+        state_file.write_text("{}")
+        old_time = time.time() - 90000
+        os.utime(state_file, (old_time, old_time))
+        adapter.gc_stale_state_files()
+        assert not state_file.exists()
+
+    def test_oserror_on_unlink_is_caught(self, omp_state_dir, disable_env_vars, monkeypatch):
+        """OSError on unlink is caught and ignored (best-effort)."""
+        state_file = omp_state_dir / "state_unlink-err.yaml"
+        state_file.write_text("{}")
+        old_time = time.time() - 90000
+        os.utime(state_file, (old_time, old_time))
+
+        import pathlib
+
+        orig = pathlib.Path.unlink
+
+        def patched_unlink(self, *args, **kwargs):
+            if "unlink-err" in str(self):
+                raise OSError("permission denied")
+            return orig(self, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, "unlink", patched_unlink)
+        adapter.gc_stale_state_files()  # should not raise
+
+
+# ── module-level log-file env wiring ─────────────────────────────────────────
+
+
+class TestLogFileEnv:
+    def test_log_file_default_points_to_omp_log(self):
+        """The adapter sets ARIZE_LOG_FILE on import unless already set.
+
+        Either it ends with ``omp.log`` (default from this adapter) or it
+        was overridden by the user before import (also acceptable).
+        """
+        val = os.environ.get("ARIZE_LOG_FILE", "")
+        assert val  # set on import either way
+        # Default-case: ends with omp.log
+        # User-override case: simply non-empty.
+        assert val.endswith("omp.log") or val

--- a/tests/tracing/omp/test_omp_adapter.py
+++ b/tests/tracing/omp/test_omp_adapter.py
@@ -4,8 +4,9 @@
 Mirrors tests/tracing/opencode/test_opencode_adapter.py but adapted for omp's
 authoritative ``sessionId`` field (camelCase — the shim stamps it on every
 forwarded payload). omp always supplies a real session id, so there is NO PID /
-grandparent-PID fallback — a missing sessionId keys off the literal string
-"unknown".
+grandparent-PID fallback for real sessions — a missing sessionId keys off a
+per-process ``"unknown-<pid>"`` fallback so concurrent id-less runs don't
+collide on a shared state file.
 
 omp also differs from opencode in project-name derivation: there is no
 snapshot/message payload to mine, so the chain is simply
@@ -102,31 +103,34 @@ class TestResolveSession:
         assert sm.state_file.exists()
 
     def test_unknown_fallback_when_missing(self, omp_state_dir, disable_env_vars):
-        """Missing sessionId -> key off 'unknown'. No PID-based key."""
+        """Missing sessionId -> per-process 'unknown-<pid>' key."""
         sm = adapter.resolve_session({})
-        assert sm.state_file == omp_state_dir / "state_unknown.json"
+        assert sm.state_file == omp_state_dir / f"state_unknown-{os.getpid()}.json"
         assert sm.state_file.exists()
 
     def test_unknown_fallback_when_empty(self, omp_state_dir, disable_env_vars):
-        """Empty sessionId -> key off 'unknown'."""
+        """Empty sessionId -> per-process 'unknown-<pid>' key."""
         sm = adapter.resolve_session({"sessionId": ""})
-        assert sm.state_file == omp_state_dir / "state_unknown.json"
+        assert sm.state_file == omp_state_dir / f"state_unknown-{os.getpid()}.json"
 
     def test_unknown_fallback_when_none(self, omp_state_dir, disable_env_vars):
-        """Explicit None sessionId -> key off 'unknown'."""
+        """Explicit None sessionId -> per-process 'unknown-<pid>' key."""
         sm = adapter.resolve_session({"sessionId": None})
-        assert sm.state_file == omp_state_dir / "state_unknown.json"
+        assert sm.state_file == omp_state_dir / f"state_unknown-{os.getpid()}.json"
 
-    def test_no_pid_keyed_fallback(self, omp_state_dir, disable_env_vars):
-        """Missing sessionId must NOT produce a PID-keyed state file.
+    def test_idless_fallback_is_per_process(self, omp_state_dir, disable_env_vars):
+        """Missing sessionId keys off pid so concurrent id-less runs don't collide.
 
-        Unlike gemini, omp adapters never use PID-based keys.
+        The fallback carries the pid suffix rather than a bare numeric pid key or
+        a shared 'unknown' literal.
         """
         adapter.resolve_session({})
-        # No state file with a numeric (pid-style) key should exist
-        for f in omp_state_dir.glob("state_*.json"):
+        files = list(omp_state_dir.glob("state_*.json"))
+        assert files, "no state file produced"
+        for f in files:
             key = f.stem.replace("state_", "", 1)
-            assert not key.isdigit(), f"PID-keyed state file produced: {f.name}"
+            assert not key.isdigit(), f"bare PID-keyed state file produced: {f.name}"
+            assert key == f"unknown-{os.getpid()}"
 
     def test_init_state_called(self, omp_state_dir, disable_env_vars):
         """Returned StateManager has init_state() called (file exists with {})."""
@@ -155,10 +159,10 @@ class TestResolveSession:
         """Only camelCase ``sessionId`` is honored — opencode's ``sessionID`` is not.
 
         The shim stamps ``sessionId`` (camelCase); a payload carrying only the
-        opencode-style ``sessionID`` must fall through to 'unknown'.
+        opencode-style ``sessionID`` must fall through to the 'unknown-<pid>' key.
         """
         sm = adapter.resolve_session({"sessionID": "WRONG_CASE"})
-        assert sm.state_file == omp_state_dir / "state_unknown.json"
+        assert sm.state_file == omp_state_dir / f"state_unknown-{os.getpid()}.json"
 
     def test_extra_payload_fields_ignored(self, omp_state_dir, disable_env_vars):
         """Extra payload fields are not used for the session key."""
@@ -200,10 +204,10 @@ class TestEnsureSessionInitialized:
         assert sm.get("session_id") == "ses_xyz789"
 
     def test_session_id_unknown_when_missing(self, omp_state_dir, disable_env_vars):
-        """session_id falls back to 'unknown' when payload lacks sessionId."""
+        """session_id falls back to 'unknown-<pid>' when payload lacks sessionId."""
         sm = self._make_state(omp_state_dir, "sid-missing")
         adapter.ensure_session_initialized(sm, {})
-        assert sm.get("session_id") == "unknown"
+        assert sm.get("session_id") == f"unknown-{os.getpid()}"
 
     def test_idempotent(self, omp_state_dir, disable_env_vars):
         """Second call is a no-op — values unchanged."""

--- a/tests/tracing/omp/test_omp_hook.py
+++ b/tests/tracing/omp/test_omp_hook.py
@@ -95,7 +95,7 @@ def _by_kind(spans, kind):
 @pytest.fixture
 def state(tmp_path):
     """StateManager with pre-initialized session keys."""
-    sf = tmp_path / "state_test.yaml"
+    sf = tmp_path / "state_test.json"
     lp = tmp_path / ".lock_test"
     sm = StateManager(state_dir=tmp_path, state_file=sf, lock_path=lp)
     sm.init_state()

--- a/tests/tracing/omp/test_omp_hook.py
+++ b/tests/tracing/omp/test_omp_hook.py
@@ -597,8 +597,9 @@ class TestAgentEnd:
         _handle_agent_end(_load_fixture("agent_end.json"))
         attrs = _get_attrs(_by_kind(captured_spans, "CHAIN")[0])
         assert attrs["input.value"]["stringValue"] == "list files and edit main.py"
-        # output = current_final_output (last turn's text), NOT the agent_end messages.
-        assert attrs["output.value"]["stringValue"] == "I'll list files then edit."
+        # output = the last assistant text in agent_end.messages (authoritative
+        # and race-free), NOT the racing current_final_output accumulator.
+        assert attrs["output.value"]["stringValue"] == "fallback final answer"
 
     def test_chain_start_time_from_trace_start(self, mock_resolve, mock_ensure, state, captured_spans):
         _handle_before_agent_start(_load_fixture("before_agent_start.json"))
@@ -608,14 +609,36 @@ class TestAgentEnd:
         chain = _by_kind(captured_spans, "CHAIN")[0]
         assert _get_span(chain)["startTimeUnixNano"] == f"{int(start_time)}000000"
 
-    def test_output_fallback_to_messages_when_no_turn_end(self, mock_resolve, mock_ensure, state, captured_spans):
-        """If current_final_output is empty (no turn_end ran), the Turn output
-        falls back to the last text of agent_end.messages."""
+    def test_output_prefers_messages_over_stale_accumulator(self, mock_resolve, mock_ensure, state, captured_spans):
+        """The final answer fires its own turn_end AND lands in agent_end.messages.
+        Because each event runs in a separate detached process racing on shared
+        state, agent_end must read its own messages payload, not the accumulator."""
         _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        # Simulate a stale accumulator: a prior turn's text is what a racing
+        # turn_end would have left behind when agent_end's process reads state.
+        state.set("current_final_output", "intermediate turn text")
         _handle_agent_end(_load_fixture("agent_end.json"))
-        chain = _by_kind(captured_spans, "CHAIN")[0]
-        attrs = _get_attrs(chain)
+        attrs = _get_attrs(_by_kind(captured_spans, "CHAIN")[0])
         assert attrs["output.value"]["stringValue"] == "fallback final answer"
+
+    def test_output_fallback_to_accumulator_when_messages_lack_assistant_text(
+        self, mock_resolve, mock_ensure, state, captured_spans
+    ):
+        """When agent_end.messages carries no assistant text (e.g. only a tool
+        result), the Turn output falls back to current_final_output."""
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        state.set("current_final_output", "accumulated final text")
+        _handle_agent_end(
+            {
+                "type": "agent_end",
+                "sessionId": "omp_sess_1",
+                "messages": [
+                    {"role": "toolResult", "content": [{"type": "text", "text": "tool output"}]},
+                ],
+            }
+        )
+        attrs = _get_attrs(_by_kind(captured_spans, "CHAIN")[0])
+        assert attrs["output.value"]["stringValue"] == "accumulated final text"
 
     def test_clears_current_trace_state(self, mock_resolve, mock_ensure, state, captured_spans):
         _run_basic_turn(state)

--- a/tests/tracing/omp/test_omp_hook.py
+++ b/tests/tracing/omp/test_omp_hook.py
@@ -1,0 +1,966 @@
+#!/usr/bin/env python3
+r"""Tests for tracing.omp.hooks.handlers — the omp stateful event handler.
+
+omp is in-process (Bun runtime): a tiny TypeScript shim spawns this Python
+entry point once per lifecycle event, piping the event payload to stdin as a
+single JSON object of the form:
+
+    { "type": "before_agent_start" | "turn_end" | "agent_end" | "session_shutdown",
+      "sessionId": "abc123",
+      "...": "type-specific fields" }
+
+Unlike opencode, omp's lifecycle events fire EXACTLY ONCE each and already
+carry final, structured data (the prompt, the completed AssistantMessage with
+inline usage + model, and that turn's toolResults). So this handler is a small
+state machine keyed by session id — structurally like the gemini handler — and
+needs NO message-id / callID dedup.
+
+Span tree (one trace per agent run):
+    Turn (CHAIN, root)             <- before_agent_start opens it, agent_end closes it
+      |- LLM: <model> (LLM)        <- one per turn_end
+      \- <tool> (TOOL)             <- one per ToolResultMessage, child of the Turn root
+
+Tests are modelled after tests/tracing/opencode/test_opencode_hook.py.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from core.common import StateManager
+
+# Force synchronous send_span path in any handler that spawns a fork.
+os.environ["ARIZE_DISABLE_FORK"] = "true"
+
+# Import handlers (this import is what fails first in pure-TDD: the module does
+# not exist yet). The remaining tests then exercise its surface.
+from tracing.omp.hooks.handlers import (  # noqa: E402
+    _assistant_text,
+    _handle_agent_end,
+    _handle_before_agent_start,
+    _handle_session_shutdown,
+    _handle_turn_end,
+    _read_stdin,
+    _send_span_async,
+    _text_of_content,
+    _tool_calls,
+    _user_prompt,
+    main,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_span(span_payload):
+    return span_payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+
+
+def _get_attrs(span_payload):
+    span = _get_span(span_payload)
+    return {a["key"]: a["value"] for a in span["attributes"]}
+
+
+def _kind(payload):
+    return _get_attrs(payload)["openinference.span.kind"]["stringValue"]
+
+
+def _name(payload):
+    return _get_span(payload)["name"]
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _by_kind(spans, kind):
+    return [s for s in spans if _kind(s) == kind]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def state(tmp_path):
+    """StateManager with pre-initialized session keys."""
+    sf = tmp_path / "state_test.yaml"
+    lp = tmp_path / ".lock_test"
+    sm = StateManager(state_dir=tmp_path, state_file=sf, lock_path=lp)
+    sm.init_state()
+    sm.set("session_id", "omp_sess_1")
+    sm.set("project_name", "test-omp-project")
+    sm.set("trace_count", "0")
+    sm.set("tool_count", "0")
+    sm.set("user_id", "test-user")
+    sm.set("session_start_time", "1000")
+    return sm
+
+
+@pytest.fixture
+def mock_resolve(state):
+    with mock.patch("tracing.omp.hooks.handlers.resolve_session", return_value=state) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_ensure():
+    with mock.patch("tracing.omp.hooks.handlers.ensure_session_initialized") as m:
+        yield m
+
+
+@pytest.fixture
+def captured_spans():
+    """Patch _send_span_async to capture emitted span payloads in order."""
+    sent = []
+    with mock.patch(
+        "tracing.omp.hooks.handlers._send_span_async",
+        side_effect=lambda s: sent.append(s),
+    ):
+        yield sent
+
+
+def _run_basic_turn(state):
+    """Drive before_agent_start + turn_end_basic, returning (trace_id, span_id)
+    captured BEFORE agent_end clears them."""
+    _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+    _handle_turn_end(_load_fixture("turn_end_basic.json"))
+    return state.get("current_trace_id"), state.get("current_trace_span_id")
+
+
+# ---------------------------------------------------------------------------
+# Pure helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_assistant_text_joins_text_items_only(self):
+        message = {
+            "content": [
+                {"type": "text", "text": "Hello "},
+                {"type": "thinking", "text": "SECRET"},
+                {"type": "toolCall", "id": "c1", "name": "bash", "arguments": {}},
+                {"type": "text", "text": "world"},
+            ]
+        }
+        assert _assistant_text(message) == "Hello world"
+
+    def test_assistant_text_empty_when_no_text(self):
+        message = {"content": [{"type": "toolCall", "id": "c1", "name": "x", "arguments": {}}]}
+        assert _assistant_text(message) == ""
+
+    def test_assistant_text_handles_missing_content(self):
+        assert _assistant_text({}) == ""
+        assert _assistant_text({"content": None}) == ""
+
+    def test_user_prompt_returns_string_as_is(self):
+        assert _user_prompt("do the thing") == "do the thing"
+
+    def test_user_prompt_coerces_non_string_to_empty(self):
+        assert _user_prompt(None) == ""
+        assert _user_prompt(["a", "b"]) == ""
+        assert _user_prompt({"x": 1}) == ""
+        assert _user_prompt(1) == ""
+
+    def test_tool_calls_maps_id_to_name_and_args(self):
+        message = {
+            "content": [
+                {"type": "text", "text": "ok"},
+                {"type": "toolCall", "id": "c1", "name": "bash", "arguments": {"command": "ls"}},
+                {"type": "toolCall", "id": "c2", "name": "edit", "arguments": {"filePath": "/a"}},
+            ]
+        }
+        calls = _tool_calls(message)
+        assert set(calls.keys()) == {"c1", "c2"}
+        assert calls["c1"]["name"] == "bash"
+        assert calls["c1"]["arguments"] == {"command": "ls"}
+        assert calls["c2"]["arguments"] == {"filePath": "/a"}
+
+    def test_tool_calls_empty_when_no_tool_calls(self):
+        assert _tool_calls({"content": [{"type": "text", "text": "hi"}]}) == {}
+        assert _tool_calls({}) == {}
+
+    def test_text_of_content_joins_text_parts(self):
+        content = [
+            {"type": "text", "text": "a"},
+            {"type": "image"},
+            {"type": "text", "text": "b"},
+        ]
+        assert _text_of_content(content) == "ab"
+
+    def test_text_of_content_handles_empty(self):
+        assert _text_of_content([]) == ""
+        assert _text_of_content(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# _read_stdin
+# ---------------------------------------------------------------------------
+
+
+class TestReadStdin:
+    def test_empty_stdin(self):
+        with mock.patch.object(sys, "stdin", new=io.StringIO("")):
+            assert _read_stdin() == {}
+
+    def test_malformed_json(self):
+        with mock.patch.object(sys, "stdin", new=io.StringIO("not json")):
+            assert _read_stdin() == {}
+
+    def test_valid_json(self):
+        with mock.patch.object(sys, "stdin", new=io.StringIO('{"type":"agent_end","sessionId":"x"}')):
+            assert _read_stdin() == {"type": "agent_end", "sessionId": "x"}
+
+
+# ---------------------------------------------------------------------------
+# _send_span_async (test fork-disable)
+# ---------------------------------------------------------------------------
+
+
+class TestSendSpanAsync:
+    def test_uses_sync_send_when_fork_disabled(self, monkeypatch):
+        """ARIZE_DISABLE_FORK=true -> bypass fork, call send_span synchronously."""
+        monkeypatch.setenv("ARIZE_DISABLE_FORK", "true")
+        with mock.patch("tracing.omp.hooks.handlers.send_span") as ss:
+            _send_span_async({"resourceSpans": []})
+        ss.assert_called_once_with({"resourceSpans": []})
+
+
+# ---------------------------------------------------------------------------
+# before_agent_start — opens a trace (one per agent run)
+# ---------------------------------------------------------------------------
+
+
+class TestBeforeAgentStart:
+    def test_opens_trace_state(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        assert state.get("current_trace_id") is not None
+        assert len(state.get("current_trace_id")) == 32
+        assert state.get("current_trace_span_id") is not None
+        assert len(state.get("current_trace_span_id")) == 16
+        assert state.get("current_trace_prompt") == "list files and edit main.py"
+        assert state.get("current_trace_start_time") is not None
+        # current_final_output initialized to empty string.
+        assert state.get("current_final_output") == ""
+
+    def test_emits_no_span_on_open(self, mock_resolve, mock_ensure, state, captured_spans):
+        """Opening a trace does NOT emit a span (the Turn root is emitted on agent_end)."""
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        assert captured_spans == []
+
+    def test_increments_trace_count(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        assert state.get("trace_count") == "1"
+
+    def test_force_closes_prior_open_trace(self, mock_resolve, mock_ensure, state, captured_spans):
+        """A still-open prior trace is force-closed (CHAIN emitted) before the new one opens."""
+        state.set("current_trace_id", "p" * 32)
+        state.set("current_trace_span_id", "q" * 16)
+        state.set("current_trace_start_time", "500")
+        state.set("current_trace_prompt", "prior prompt")
+        state.set("current_final_output", "")
+
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+
+        chains = _by_kind(captured_spans, "CHAIN")
+        assert len(chains) == 1
+        span = _get_span(chains[0])
+        assert span["traceId"] == "p" * 32
+        assert span["spanId"] == "q" * 16
+        assert "parentSpanId" not in span
+        # New trace has fresh ids and the new prompt.
+        assert state.get("current_trace_id") != "p" * 32
+        assert state.get("current_trace_prompt") == "list files and edit main.py"
+
+
+# ---------------------------------------------------------------------------
+# turn_end — emits LLM + TOOL children of the open Turn root
+# ---------------------------------------------------------------------------
+
+
+class TestTurnEndBasic:
+    def test_emits_one_llm_and_two_tool_spans(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        assert len(captured_spans) == 3
+        kinds = sorted(_kind(s) for s in captured_spans)
+        assert kinds == ["LLM", "TOOL", "TOOL"]
+
+    def test_no_chain_on_turn_end(self, mock_resolve, mock_ensure, state, captured_spans):
+        """A turn_end emits child spans only — never the Turn CHAIN root."""
+        _run_basic_turn(state)
+        assert not _by_kind(captured_spans, "CHAIN")
+
+    def test_causal_order_llm_then_tools(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        assert _kind(captured_spans[0]) == "LLM"
+        assert _kind(captured_spans[1]) == "TOOL"
+        assert _kind(captured_spans[2]) == "TOOL"
+
+    def test_increments_tool_count(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        assert state.get("tool_count") == "2"
+
+    def test_lazily_opens_trace_when_none(self, mock_resolve, mock_ensure, state, captured_spans):
+        """A turn_end with no open trace lazily opens one (empty prompt) so spans
+        always get a root to hang from."""
+        _handle_turn_end(_load_fixture("turn_end_basic.json"))
+        assert state.get("current_trace_id") is not None
+        assert state.get("current_trace_span_id") is not None
+        # Lazily opened trace has an empty prompt.
+        assert state.get("current_trace_prompt") == ""
+        # The child spans still got emitted under the lazily-opened root.
+        for s in captured_spans:
+            assert _get_span(s)["traceId"] == state.get("current_trace_id")
+            assert _get_span(s)["parentSpanId"] == state.get("current_trace_span_id")
+
+
+class TestTurnEndLLMSpan:
+    def test_llm_span_name_includes_model(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        llm = _by_kind(captured_spans, "LLM")[0]
+        assert _name(llm) == "LLM: claude-sonnet-4"
+
+    def test_llm_token_counts(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        attrs = _get_attrs(_by_kind(captured_spans, "LLM")[0])
+        # OpenInference: prompt is the inclusive total
+        # = input(100) + cacheRead(30) + cacheWrite(5) = 135
+        assert attrs["llm.token_count.prompt"]["intValue"] == 135
+        assert attrs["llm.token_count.completion"]["intValue"] == 50
+        assert attrs["llm.token_count.total"]["intValue"] == 185
+        assert attrs["llm.token_count.completion_details.reasoning"]["intValue"] == 7
+        assert attrs["llm.token_count.prompt_details.cache_read"]["intValue"] == 30
+        assert attrs["llm.token_count.prompt_details.cache_write"]["intValue"] == 5
+
+    def test_llm_model_and_provider(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        attrs = _get_attrs(_by_kind(captured_spans, "LLM")[0])
+        assert attrs["llm.model_name"]["stringValue"] == "claude-sonnet-4"
+        assert attrs["llm.provider"]["stringValue"] == "anthropic"
+
+    def test_llm_cost(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        attrs = _get_attrs(_by_kind(captured_spans, "LLM")[0])
+        cost = attrs["llm.cost"]
+        cost_val = cost.get("doubleValue") if isinstance(cost, dict) else None
+        if cost_val is None:
+            cost_val = float(next(iter(cost.values())))
+        assert cost_val == pytest.approx(0.0125)
+
+    def test_llm_input_output_values(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        attrs = _get_attrs(_by_kind(captured_spans, "LLM")[0])
+        # input.value = the turn prompt (from before_agent_start)
+        assert attrs["input.value"]["stringValue"] == "list files and edit main.py"
+        # output.value = the assistant text (thinking/toolCall items skipped)
+        assert attrs["output.value"]["stringValue"] == "I'll list files then edit."
+
+    def test_llm_common_attrs(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        attrs = _get_attrs(_by_kind(captured_spans, "LLM")[0])
+        assert attrs["session.id"]["stringValue"] == "omp_sess_1"
+        assert attrs["project.name"]["stringValue"] == "test-omp-project"
+        assert attrs["openinference.span.kind"]["stringValue"] == "LLM"
+
+    def test_llm_timing_uses_timestamp_and_duration(self, mock_resolve, mock_ensure, state, captured_spans):
+        """end = message.timestamp (5000ms); start = end - duration (3000ms) = 2000ms."""
+        _run_basic_turn(state)
+        span = _get_span(_by_kind(captured_spans, "LLM")[0])
+        assert span["endTimeUnixNano"] == "5000000000"
+        assert span["startTimeUnixNano"] == "2000000000"
+
+    def test_llm_child_of_turn_root(self, mock_resolve, mock_ensure, state, captured_spans):
+        trace_id, span_id = _run_basic_turn(state)
+        span = _get_span(_by_kind(captured_spans, "LLM")[0])
+        assert span["traceId"] == trace_id
+        assert span["parentSpanId"] == span_id
+
+    def test_llm_timing_no_duration_uses_timestamp_for_both(self, mock_resolve, mock_ensure, state, captured_spans):
+        """A turn_end whose message has no duration uses timestamp for both ends."""
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_load_fixture("turn_end_tool_error.json"))
+        span = _get_span(_by_kind(captured_spans, "LLM")[0])
+        assert span["startTimeUnixNano"] == "3000000000"
+        assert span["endTimeUnixNano"] == "3000000000"
+
+    def test_sets_current_final_output(self, mock_resolve, mock_ensure, state, captured_spans):
+        """The last turn's assistant text is stashed so agent_end can report it."""
+        _run_basic_turn(state)
+        assert state.get("current_final_output") == "I'll list files then edit."
+
+
+class TestTurnEndToolSpans:
+    def test_tool_spans_pair_args_with_results(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        tools = _by_kind(captured_spans, "TOOL")
+        bash = next(s for s in tools if _name(s) == "bash")
+        edit = next(s for s in tools if _name(s) == "edit")
+        bash_attrs = _get_attrs(bash)
+        edit_attrs = _get_attrs(edit)
+        # input.value = json.dumps of the matched ToolCall.arguments
+        assert bash_attrs["input.value"]["stringValue"] == json.dumps({"command": "ls -la"})
+        assert edit_attrs["input.value"]["stringValue"] == json.dumps({"filePath": "/tmp/main.py"})
+        # output.value = joined text of the ToolResultMessage.content
+        assert bash_attrs["output.value"]["stringValue"] == "total 4\nfile.py"
+        assert edit_attrs["output.value"]["stringValue"] == "edited main.py"
+
+    def test_tool_name_attr(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        bash = next(s for s in _by_kind(captured_spans, "TOOL") if _name(s) == "bash")
+        assert _get_attrs(bash)["tool.name"]["stringValue"] == "bash"
+
+    def test_tools_are_children_of_turn_root_not_llm(self, mock_resolve, mock_ensure, state, captured_spans):
+        """TOOL spans hang off the Turn root span id, NOT the LLM span."""
+        trace_id, span_id = _run_basic_turn(state)
+        llm_span_id = _get_span(_by_kind(captured_spans, "LLM")[0])["spanId"]
+        for tool in _by_kind(captured_spans, "TOOL"):
+            span = _get_span(tool)
+            assert span["traceId"] == trace_id
+            assert span["parentSpanId"] == span_id
+            assert span["parentSpanId"] != llm_span_id
+
+    def test_tool_timing_from_result_timestamp(self, mock_resolve, mock_ensure, state, captured_spans):
+        """TOOL span end uses ToolResultMessage.timestamp (bash result = 5100ms)."""
+        _run_basic_turn(state)
+        bash = next(s for s in _by_kind(captured_spans, "TOOL") if _name(s) == "bash")
+        assert _get_span(bash)["endTimeUnixNano"] == "5100000000"
+
+    def test_per_tool_bash_command(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        bash = next(s for s in _by_kind(captured_spans, "TOOL") if _name(s) == "bash")
+        assert _get_attrs(bash)["tool.command"]["stringValue"] == "ls -la"
+
+    def test_per_tool_edit_file_path(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        edit = next(s for s in _by_kind(captured_spans, "TOOL") if _name(s) == "edit")
+        assert _get_attrs(edit)["tool.file_path"]["stringValue"] == "/tmp/main.py"
+
+    def test_user_id_included(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        for s in captured_spans:
+            assert _get_attrs(s)["user.id"]["stringValue"] == "test-user"
+
+    def test_user_id_omitted_when_empty(self, mock_resolve, mock_ensure, state, captured_spans):
+        state.set("user_id", "")
+        _run_basic_turn(state)
+        for s in captured_spans:
+            assert "user.id" not in _get_attrs(s)
+
+    def test_result_without_matching_call_emits_args_unknown(self, mock_resolve, mock_ensure, state, captured_spans):
+        """A toolResult with no matching ToolCall in this payload still emits a
+        TOOL span — with empty args (args unknown)."""
+        payload = {
+            "type": "turn_end",
+            "sessionId": "omp_sess_1",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "ok"}],
+                "model": "claude-sonnet-4",
+                "provider": "anthropic",
+                "usage": {"input": 1, "output": 1, "cacheRead": 0, "cacheWrite": 0},
+                "timestamp": 100,
+            },
+            "toolResults": [
+                {
+                    "role": "toolResult",
+                    "toolCallId": "orphan_call",
+                    "toolName": "bash",
+                    "content": [{"type": "text", "text": "out"}],
+                    "isError": False,
+                    "timestamp": 120,
+                }
+            ],
+        }
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(payload)
+        tool = _by_kind(captured_spans, "TOOL")[0]
+        attrs = _get_attrs(tool)
+        assert attrs["tool.name"]["stringValue"] == "bash"
+        assert attrs["input.value"]["stringValue"] == json.dumps({})
+        assert attrs["output.value"]["stringValue"] == "out"
+
+
+# ---------------------------------------------------------------------------
+# Multiple turn_ends between one before_agent_start and one agent_end
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleTurnEnds:
+    def test_two_turn_ends_emit_two_llm_under_same_root(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        trace_id = state.get("current_trace_id")
+        span_id = state.get("current_trace_span_id")
+
+        _handle_turn_end(_load_fixture("turn_end_basic.json"))
+        _handle_turn_end(_load_fixture("turn_end_tool_error.json"))
+
+        llms = _by_kind(captured_spans, "LLM")
+        assert len(llms) == 2
+        for llm in llms:
+            span = _get_span(llm)
+            assert span["traceId"] == trace_id
+            assert span["parentSpanId"] == span_id
+        # trace_count stays at 1 (one agent run), tools accumulate (2 + 1).
+        assert state.get("trace_count") == "1"
+        assert state.get("tool_count") == "3"
+
+    def test_final_output_reflects_last_turn(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_load_fixture("turn_end_basic.json"))
+        _handle_turn_end(_load_fixture("turn_end_tool_error.json"))
+        assert state.get("current_final_output") == "reading the file"
+
+
+# ---------------------------------------------------------------------------
+# Error tool span — status_code = 2 (ERROR)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorTool:
+    def test_error_tool_status_code_2(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_load_fixture("turn_end_tool_error.json"))
+        tool = _by_kind(captured_spans, "TOOL")[0]
+        assert _get_span(tool)["status"]["code"] == 2
+
+    def test_error_tool_status_message(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_load_fixture("turn_end_tool_error.json"))
+        tool = _by_kind(captured_spans, "TOOL")[0]
+        assert "ENOENT" in _get_span(tool)["status"].get("message", "")
+
+    def test_error_tool_output_is_error_text(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_load_fixture("turn_end_tool_error.json"))
+        tool = _by_kind(captured_spans, "TOOL")[0]
+        assert "ENOENT" in _get_attrs(tool)["output.value"]["stringValue"]
+
+    def test_error_tool_file_path_attr(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_load_fixture("turn_end_tool_error.json"))
+        tool = _by_kind(captured_spans, "TOOL")[0]
+        assert _get_attrs(tool)["tool.file_path"]["stringValue"] == "/missing.txt"
+
+    def test_error_tool_increments_tool_count(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_load_fixture("turn_end_tool_error.json"))
+        assert state.get("tool_count") == "1"
+
+
+# ---------------------------------------------------------------------------
+# agent_end — emits the Turn CHAIN root and clears state
+# ---------------------------------------------------------------------------
+
+
+class TestAgentEnd:
+    def test_full_flow_emits_llm_tools_and_chain(self, mock_resolve, mock_ensure, state, captured_spans):
+        """before_agent_start + turn_end (1 LLM + 2 TOOL) + agent_end => 4 spans,
+        the CHAIN emitted last (causal order)."""
+        _run_basic_turn(state)
+        _handle_agent_end(_load_fixture("agent_end.json"))
+        assert len(captured_spans) == 4
+        assert len(_by_kind(captured_spans, "LLM")) == 1
+        assert len(_by_kind(captured_spans, "TOOL")) == 2
+        assert len(_by_kind(captured_spans, "CHAIN")) == 1
+        # CHAIN is emitted last.
+        assert _kind(captured_spans[-1]) == "CHAIN"
+
+    def test_chain_name_and_kind(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        _handle_agent_end(_load_fixture("agent_end.json"))
+        chain = _by_kind(captured_spans, "CHAIN")[0]
+        assert _name(chain) == "Turn"
+        assert _kind(chain) == "CHAIN"
+
+    def test_chain_uses_turn_root_ids_no_parent(self, mock_resolve, mock_ensure, state, captured_spans):
+        trace_id, span_id = _run_basic_turn(state)
+        _handle_agent_end(_load_fixture("agent_end.json"))
+        chain = _by_kind(captured_spans, "CHAIN")[0]
+        span = _get_span(chain)
+        assert span["traceId"] == trace_id
+        assert span["spanId"] == span_id
+        assert "parentSpanId" not in span
+
+    def test_chain_input_and_output(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        _handle_agent_end(_load_fixture("agent_end.json"))
+        attrs = _get_attrs(_by_kind(captured_spans, "CHAIN")[0])
+        assert attrs["input.value"]["stringValue"] == "list files and edit main.py"
+        # output = current_final_output (last turn's text), NOT the agent_end messages.
+        assert attrs["output.value"]["stringValue"] == "I'll list files then edit."
+
+    def test_chain_start_time_from_trace_start(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        start_time = state.get("current_trace_start_time")
+        _handle_turn_end(_load_fixture("turn_end_basic.json"))
+        _handle_agent_end(_load_fixture("agent_end.json"))
+        chain = _by_kind(captured_spans, "CHAIN")[0]
+        assert _get_span(chain)["startTimeUnixNano"] == f"{int(start_time)}000000"
+
+    def test_output_fallback_to_messages_when_no_turn_end(self, mock_resolve, mock_ensure, state, captured_spans):
+        """If current_final_output is empty (no turn_end ran), the Turn output
+        falls back to the last text of agent_end.messages."""
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_agent_end(_load_fixture("agent_end.json"))
+        chain = _by_kind(captured_spans, "CHAIN")[0]
+        attrs = _get_attrs(chain)
+        assert attrs["output.value"]["stringValue"] == "fallback final answer"
+
+    def test_clears_current_trace_state(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        _handle_agent_end(_load_fixture("agent_end.json"))
+        assert state.get("current_trace_id") is None
+        assert state.get("current_trace_span_id") is None
+        assert state.get("current_trace_start_time") is None
+        assert state.get("current_trace_prompt") is None
+        assert state.get("current_final_output") is None
+
+    def test_agent_end_without_open_trace_is_noop(self, mock_resolve, mock_ensure, state, captured_spans):
+        """agent_end with no open trace emits nothing (and does not raise)."""
+        _handle_agent_end(_load_fixture("agent_end.json"))
+        assert captured_spans == []
+
+
+# ---------------------------------------------------------------------------
+# session_shutdown — fail-safe close of a still-open trace
+# ---------------------------------------------------------------------------
+
+
+class TestSessionShutdown:
+    def test_open_trace_emits_chain_failsafe(self, mock_resolve, mock_ensure, state, captured_spans):
+        """A still-open trace at session_shutdown emits its Turn CHAIN root."""
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        trace_id = state.get("current_trace_id")
+        span_id = state.get("current_trace_span_id")
+
+        _handle_session_shutdown({"type": "session_shutdown", "sessionId": "omp_sess_1"})
+
+        chains = _by_kind(captured_spans, "CHAIN")
+        assert len(chains) == 1
+        span = _get_span(chains[0])
+        assert span["traceId"] == trace_id
+        assert span["spanId"] == span_id
+        assert "parentSpanId" not in span
+
+    def test_failsafe_output_uses_final_output_when_present(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_load_fixture("turn_end_basic.json"))
+        _handle_session_shutdown({"type": "session_shutdown", "sessionId": "omp_sess_1"})
+        chain = _by_kind(captured_spans, "CHAIN")[0]
+        assert _get_attrs(chain)["output.value"]["stringValue"] == "I'll list files then edit."
+
+    def test_failsafe_output_uses_reason_when_no_final_output(self, mock_resolve, mock_ensure, state, captured_spans):
+        """Shutdown right after before_agent_start (no turn) closes with a reason marker."""
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_session_shutdown({"type": "session_shutdown", "sessionId": "omp_sess_1"})
+        chain = _by_kind(captured_spans, "CHAIN")[0]
+        out = _get_attrs(chain)["output.value"]["stringValue"]
+        assert "closed" in out.lower()
+
+    def test_clears_state(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_session_shutdown({"type": "session_shutdown", "sessionId": "omp_sess_1"})
+        assert state.get("current_trace_id") is None
+        assert state.get("current_trace_span_id") is None
+
+    def test_no_open_trace_is_noop(self, mock_resolve, mock_ensure, state, captured_spans):
+        """session_shutdown with no open trace emits nothing and does not raise."""
+        _handle_session_shutdown({"type": "session_shutdown", "sessionId": "omp_sess_1"})
+        assert captured_spans == []
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+class TestRedaction:
+    def test_redacts_prompt_and_response_when_log_prompts_false(
+        self, mock_resolve, mock_ensure, state, captured_spans, monkeypatch
+    ):
+        monkeypatch.setenv("ARIZE_LOG_PROMPTS", "false")
+        _run_basic_turn(state)
+        _handle_agent_end(_load_fixture("agent_end.json"))
+        llm = _by_kind(captured_spans, "LLM")[0]
+        attrs = _get_attrs(llm)
+        assert "redacted" in attrs["input.value"]["stringValue"]
+        assert "redacted" in attrs["output.value"]["stringValue"]
+        # The CHAIN root prompt/output are also redacted.
+        chain = _by_kind(captured_spans, "CHAIN")[0]
+        cattrs = _get_attrs(chain)
+        assert "redacted" in cattrs["input.value"]["stringValue"]
+        assert "redacted" in cattrs["output.value"]["stringValue"]
+
+    def test_redacts_tool_content_when_log_tool_content_false(
+        self, mock_resolve, mock_ensure, state, captured_spans, monkeypatch
+    ):
+        monkeypatch.setenv("ARIZE_LOG_TOOL_CONTENT", "false")
+        _run_basic_turn(state)
+        for t in _by_kind(captured_spans, "TOOL"):
+            attrs = _get_attrs(t)
+            assert "redacted" in attrs["input.value"]["stringValue"]
+            assert "redacted" in attrs["output.value"]["stringValue"]
+
+    def test_redacts_tool_details_when_log_tool_details_false(
+        self, mock_resolve, mock_ensure, state, captured_spans, monkeypatch
+    ):
+        monkeypatch.setenv("ARIZE_LOG_TOOL_DETAILS", "false")
+        _run_basic_turn(state)
+        bash = next(s for s in _by_kind(captured_spans, "TOOL") if _name(s) == "bash")
+        assert "redacted" in _get_attrs(bash)["tool.command"]["stringValue"]
+
+    def test_tool_name_not_redacted(self, mock_resolve, mock_ensure, state, captured_spans, monkeypatch):
+        monkeypatch.setenv("ARIZE_LOG_TOOL_DETAILS", "false")
+        monkeypatch.setenv("ARIZE_LOG_TOOL_CONTENT", "false")
+        _run_basic_turn(state)
+        bash = next(s for s in _by_kind(captured_spans, "TOOL") if _name(s) == "bash")
+        assert _get_attrs(bash)["tool.name"]["stringValue"] == "bash"
+
+
+# ---------------------------------------------------------------------------
+# Per-tool specialized attribute mapping
+# ---------------------------------------------------------------------------
+
+
+def _make_turn_end_with_tool(tool_name, arguments):
+    """A turn_end payload with a single tool call+result for the given tool."""
+    return {
+        "type": "turn_end",
+        "sessionId": "omp_sess_1",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "ok"},
+                {"type": "toolCall", "id": "call_x", "name": tool_name, "arguments": arguments},
+            ],
+            "model": "claude-sonnet-4",
+            "provider": "anthropic",
+            "usage": {"input": 1, "output": 1, "cacheRead": 0, "cacheWrite": 0, "cost": {"total": 0}},
+            "timestamp": 200,
+        },
+        "toolResults": [
+            {
+                "role": "toolResult",
+                "toolCallId": "call_x",
+                "toolName": tool_name,
+                "content": [{"type": "text", "text": "tool-out"}],
+                "isError": False,
+                "timestamp": 220,
+            }
+        ],
+    }
+
+
+class TestPerToolAttributeMapping:
+    def test_read_sets_file_path(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_make_turn_end_with_tool("read", {"filePath": "/a/b.py"}))
+        tool = _by_kind(captured_spans, "TOOL")[0]
+        assert _get_attrs(tool)["tool.file_path"]["stringValue"] == "/a/b.py"
+
+    def test_write_sets_file_path(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_make_turn_end_with_tool("write", {"filePath": "/a/c.py"}))
+        tool = _by_kind(captured_spans, "TOOL")[0]
+        assert _get_attrs(tool)["tool.file_path"]["stringValue"] == "/a/c.py"
+
+    def test_file_path_falls_back_to_path_key(self, mock_resolve, mock_ensure, state, captured_spans):
+        """When `filePath` is absent the handler falls back to `path`."""
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_make_turn_end_with_tool("read", {"path": "/a/d.py"}))
+        tool = _by_kind(captured_spans, "TOOL")[0]
+        assert _get_attrs(tool)["tool.file_path"]["stringValue"] == "/a/d.py"
+
+    def test_grep_sets_query(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_make_turn_end_with_tool("grep", {"pattern": "TODO"}))
+        tool = _by_kind(captured_spans, "TOOL")[0]
+        assert _get_attrs(tool)["tool.query"]["stringValue"] == "TODO"
+
+    def test_glob_sets_query(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_make_turn_end_with_tool("glob", {"pattern": "**/*.py"}))
+        tool = _by_kind(captured_spans, "TOOL")[0]
+        assert _get_attrs(tool)["tool.query"]["stringValue"] == "**/*.py"
+
+    def test_unknown_tool_no_specialized_attrs(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_make_turn_end_with_tool("custom_thing", {"foo": "bar"}))
+        tool = _by_kind(captured_spans, "TOOL")[0]
+        attrs = _get_attrs(tool)
+        assert "tool.command" not in attrs
+        assert "tool.file_path" not in attrs
+        assert "tool.url" not in attrs
+        assert "tool.query" not in attrs
+        # tool.name is still present.
+        assert attrs["tool.name"]["stringValue"] == "custom_thing"
+
+
+# ---------------------------------------------------------------------------
+# Token-detail omission rules
+# ---------------------------------------------------------------------------
+
+
+class TestTokenDetailOmissions:
+    def test_zero_reasoning_omitted(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_make_turn_end_with_tool("read", {"filePath": "/x"}))
+        attrs = _get_attrs(_by_kind(captured_spans, "LLM")[0])
+        assert "llm.token_count.completion_details.reasoning" not in attrs
+
+    def test_zero_cache_omitted(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_make_turn_end_with_tool("read", {"filePath": "/x"}))
+        attrs = _get_attrs(_by_kind(captured_spans, "LLM")[0])
+        assert "llm.token_count.prompt_details.cache_read" not in attrs
+        assert "llm.token_count.prompt_details.cache_write" not in attrs
+
+    def test_zero_cost_omitted(self, mock_resolve, mock_ensure, state, captured_spans):
+        _handle_before_agent_start(_load_fixture("before_agent_start.json"))
+        _handle_turn_end(_make_turn_end_with_tool("read", {"filePath": "/x"}))
+        attrs = _get_attrs(_by_kind(captured_spans, "LLM")[0])
+        assert "llm.cost" not in attrs
+
+
+# ---------------------------------------------------------------------------
+# main() entry point dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMainEntryPoint:
+    def _run_main(self, payload):
+        with (
+            mock.patch("tracing.omp.hooks.handlers.check_requirements", return_value=True),
+            mock.patch.object(sys, "stdin", new=io.StringIO(json.dumps(payload))),
+            mock.patch("tracing.omp.hooks.handlers._handle_before_agent_start") as bas,
+            mock.patch("tracing.omp.hooks.handlers._handle_turn_end") as te,
+            mock.patch("tracing.omp.hooks.handlers._handle_agent_end") as ae,
+            mock.patch("tracing.omp.hooks.handlers._handle_session_shutdown") as ss,
+        ):
+            main()
+        return bas, te, ae, ss
+
+    def test_dispatches_before_agent_start(self, monkeypatch):
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        payload = {"type": "before_agent_start", "sessionId": "x", "prompt": "hi"}
+        bas, te, ae, ss = self._run_main(payload)
+        bas.assert_called_once_with(payload)
+        te.assert_not_called()
+        ae.assert_not_called()
+        ss.assert_not_called()
+
+    def test_dispatches_turn_end(self, monkeypatch):
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        payload = {"type": "turn_end", "sessionId": "x", "message": {}, "toolResults": []}
+        bas, te, ae, ss = self._run_main(payload)
+        te.assert_called_once_with(payload)
+        bas.assert_not_called()
+
+    def test_dispatches_agent_end(self, monkeypatch):
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        payload = {"type": "agent_end", "sessionId": "x", "messages": []}
+        bas, te, ae, ss = self._run_main(payload)
+        ae.assert_called_once_with(payload)
+
+    def test_dispatches_session_shutdown(self, monkeypatch):
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        payload = {"type": "session_shutdown", "sessionId": "x"}
+        bas, te, ae, ss = self._run_main(payload)
+        ss.assert_called_once_with(payload)
+
+    def test_unknown_type_does_not_dispatch(self, monkeypatch):
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        payload = {"type": "something-else", "sessionId": "x"}
+        bas, te, ae, ss = self._run_main(payload)
+        for m in (bas, te, ae, ss):
+            m.assert_not_called()
+
+    def test_requirements_not_met_short_circuits(self, monkeypatch):
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "false")
+        payload = {"type": "turn_end", "sessionId": "x"}
+        with (
+            mock.patch("tracing.omp.hooks.handlers.check_requirements", return_value=False),
+            mock.patch.object(sys, "stdin", new=io.StringIO(json.dumps(payload))),
+            mock.patch("tracing.omp.hooks.handlers._handle_turn_end") as te,
+        ):
+            main()
+        te.assert_not_called()
+
+    def test_malformed_stdin_no_crash(self, monkeypatch):
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("tracing.omp.hooks.handlers.check_requirements", return_value=True),
+            mock.patch.object(sys, "stdin", new=io.StringIO("not-json")),
+            mock.patch("tracing.omp.hooks.handlers._handle_turn_end") as te,
+        ):
+            main()  # must not raise
+        te.assert_not_called()
+
+    def test_handler_exception_is_caught(self, monkeypatch):
+        """A raised exception in a handler must be caught — never escape main()."""
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        payload = {"type": "turn_end", "sessionId": "x"}
+        with (
+            mock.patch("tracing.omp.hooks.handlers.check_requirements", return_value=True),
+            mock.patch.object(sys, "stdin", new=io.StringIO(json.dumps(payload))),
+            mock.patch(
+                "tracing.omp.hooks.handlers._handle_turn_end",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            main()  # must not raise
+
+    def test_no_system_exit_on_unknown(self, monkeypatch):
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        payload = {"type": "???"}
+        with (
+            mock.patch("tracing.omp.hooks.handlers.check_requirements", return_value=True),
+            mock.patch.object(sys, "stdin", new=io.StringIO(json.dumps(payload))),
+        ):
+            try:
+                main()
+            except SystemExit:
+                pytest.fail("main() raised SystemExit on unknown type")
+
+    def test_empty_stdin_no_crash(self, monkeypatch):
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        with (
+            mock.patch("tracing.omp.hooks.handlers.check_requirements", return_value=True),
+            mock.patch.object(sys, "stdin", new=io.StringIO("")),
+            mock.patch("tracing.omp.hooks.handlers._handle_turn_end") as te,
+        ):
+            main()  # must not raise
+        te.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Service / scope metadata
+# ---------------------------------------------------------------------------
+
+
+class TestSpanServiceMetadata:
+    def test_service_name_omp(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        _handle_agent_end(_load_fixture("agent_end.json"))
+        s = captured_spans[0]
+        svc = s["resourceSpans"][0]["resource"]["attributes"][0]
+        assert svc["key"] == "service.name"
+        assert svc["value"]["stringValue"] == "omp"
+
+    def test_scope_name_arize_omp_plugin(self, mock_resolve, mock_ensure, state, captured_spans):
+        _run_basic_turn(state)
+        _handle_agent_end(_load_fixture("agent_end.json"))
+        s = captured_spans[0]
+        scope = s["resourceSpans"][0]["scopeSpans"][0]["scope"]
+        assert scope["name"] == "arize-omp-plugin"

--- a/tracing/omp/README.md
+++ b/tracing/omp/README.md
@@ -27,30 +27,38 @@ Because omp's lifecycle events fire exactly once each and carry final data, ther
 
 ## Setup
 
-The installer prompts for your backend (Phoenix or Arize AX) and project name, writes credentials to `~/.arize/harness/config.yaml`, copies the hook shim into `~/.omp/extensions/arize-tracing.ts`, **and** registers the shim's absolute path in the `extensions` array of `~/.omp/agent/settings.json`. omp does **not** auto-discover an extensions directory ([extension loading docs](https://omp.sh/docs/hooks)) — explicit registration is required, and the installer handles it. Spans are sent directly to the backend from the handler — no separate buffer/collector service is required.
+The installer prompts for your backend (Phoenix or Arize AX) and project name, writes credentials to `~/.arize/harness/config.json`, copies the hook shim into `~/.omp/extensions/arize-tracing.ts`, **and** registers the shim's absolute path in the `extensions` array of `~/.omp/agent/settings.json`. omp does **not** auto-discover an extensions directory ([extension loading docs](https://omp.sh/docs/hooks)) — explicit registration is required, and the installer handles it. Spans are sent directly to the backend from the handler — no separate buffer/collector service is required.
 
 Pass `--with-skills` to also symlink the `manage-omp-tracing` skill into the current directory's `.agents/skills/` so coding agents in this workspace can help manage omp tracing configuration.
 
 ### Remote setup
 
-macOS / Linux:
+#### macOS / Linux
+
+Install:
 
 ```bash
-# Install
 curl -sSL https://raw.githubusercontent.com/Arize-ai/coding-harness-tracing/main/install.sh | bash -s -- omp
+```
 
-# Uninstall
+Uninstall:
+
+```bash
 curl -sSL https://raw.githubusercontent.com/Arize-ai/coding-harness-tracing/main/install.sh | bash -s -- uninstall omp
 ```
 
-Windows (PowerShell):
+#### Windows (PowerShell)
+
+Install:
 
 ```powershell
-# Install
 iwr -useb https://raw.githubusercontent.com/Arize-ai/coding-harness-tracing/main/install.bat -OutFile $env:TEMP\install.bat
 & $env:TEMP\install.bat omp
+```
 
-# Uninstall
+Uninstall:
+
+```powershell
 iwr -useb https://raw.githubusercontent.com/Arize-ai/coding-harness-tracing/main/install.bat -OutFile $env:TEMP\install.bat
 & $env:TEMP\install.bat uninstall omp
 ```
@@ -62,27 +70,35 @@ git clone https://github.com/Arize-ai/coding-harness-tracing.git
 cd coding-harness-tracing
 ```
 
-macOS / Linux:
+**macOS / Linux**
+
+Install:
 
 ```bash
-# Install
 ./install.sh omp
+```
 
-# Uninstall
+Uninstall:
+
+```bash
 ./install.sh uninstall omp
 ```
 
-Windows:
+**Windows (PowerShell)**
+
+Install:
 
 ```powershell
-# Install
 install.bat omp
+```
 
-# Uninstall
+Uninstall:
+
+```powershell
 install.bat uninstall omp
 ```
 
-Uninstall removes the shim's path from the `extensions` array in `~/.omp/agent/settings.json`, deletes the hook file at `~/.omp/extensions/arize-tracing.ts` (only if it carries the Arize header marker — your own extensions are left alone), and removes the `harnesses.omp` block from `~/.arize/harness/config.yaml`.
+Uninstall removes the shim's path from the `extensions` array in `~/.omp/agent/settings.json`, deletes the hook file at `~/.omp/extensions/arize-tracing.ts` (only if it carries the Arize header marker — your own extensions are left alone), and removes the `harnesses.omp` block from `~/.arize/harness/config.json`.
 
 ## Default Settings
 
@@ -106,6 +122,6 @@ Run any omp session as you normally would. omp loads the registered extension on
 
 - Errors and handler stderr land in `~/.arize/harness/logs/omp.log` always (the adapter redirects Python stderr there via `ARIZE_LOG_FILE`); set `export ARIZE_VERBOSE=true` before launching omp to also see routine handler activity (event dispatch, span emits, state transitions).
 - Confirm spans appear in your configured project in Arize AX or Phoenix.
-- Set `ARIZE_TRACE_DEBUG=true` to dump the raw event payloads under `~/.arize/harness/state/debug/` (files are named `omp_before_agent_start_<ts>.yaml`, `omp_turn_end_<ts>.yaml`, `omp_agent_end_<ts>.yaml`, `omp_session_shutdown_<ts>.yaml`) for inspection.
+- Set `ARIZE_TRACE_DEBUG=true` to dump the raw event payloads under `~/.arize/harness/state/debug/` (files are named `omp_before_agent_start_<ts>.json`, `omp_turn_end_<ts>.json`, `omp_agent_end_<ts>.json`, `omp_session_shutdown_<ts>.json`) for inspection.
 
 See the [main README's Environment variables section](../../README.md#environment-variables) for the full list of runtime overrides (`ARIZE_TRACE_ENABLED`, `ARIZE_DRY_RUN`, `ARIZE_USER_ID`, `ARIZE_PROJECT_NAME`, `ARIZE_VERBOSE`, `ARIZE_TRACE_DEBUG`, etc.).

--- a/tracing/omp/README.md
+++ b/tracing/omp/README.md
@@ -1,0 +1,111 @@
+# omp Tracing
+
+Automatic [OpenInference](https://github.com/Arize-ai/openinference) tracing for [Oh My Pi (omp)](https://github.com/can1357/oh-my-pi) terminal coding sessions. Spans are exported to [Arize AX](https://arize.com) or [Phoenix](https://github.com/Arize-ai/phoenix).
+
+## What gets traced
+
+One trace per **agent run** — one user prompt → the agent's internal turn/tool-use loop → its final answer. A single agent run usually contains several model calls (omp re-prompts the model after each round of tool calls), so one trace covers all of them. Each trace is a tree:
+
+| Span | Kind | Notes |
+|------|------|-------|
+| `Turn` | CHAIN | Root span. `input.value` is the user prompt (from `before_agent_start`); `output.value` is the final assistant message's text. One per agent run. |
+| `LLM: <model>` | LLM | Child of `Turn`. One per `turn_end` (one per model call in the loop). Carries `llm.model_name`, `llm.provider`, prompt/completion/reasoning token counts, cache read/write tokens, and `llm.cost`. |
+| `<tool>` | TOOL | Child of `Turn`. One per `ToolResultMessage` in a `turn_end`, paired with its originating `ToolCall` by id. Records `tool.name`, redacted input args + output, and tool-specific attributes. Errors are recorded with span status. |
+
+Token usage **is** captured — omp surfaces cumulative `usage` (input/output/reasoning tokens, cache read/write, and cost) inline on each assistant message, unlike vendors that withhold it from local surfaces.
+
+Timestamps come from omp's own millisecond clocks where present (`AssistantMessage.timestamp` / `duration`, `turn_start.timestamp`, `ToolResultMessage.timestamp`), falling back to wall-clock time on the tracing process when absent.
+
+## Architecture
+
+omp loads its extensions **in-process** inside its Bun runtime ([hook docs](https://omp.sh/docs/hooks)) — there is no per-event subprocess and no host-spawned hook. Unlike opencode, omp exposes rich, **once-fired** lifecycle events that already carry final, structured data, so the integration is a straightforward stateful event-forward (no snapshot reconciliation, no dedup). It is split into two pieces:
+
+1. **TypeScript hook shim** (`~/.omp/extensions/arize-tracing.ts`). A dumb bridge. On a small whitelist of lifecycle events — `before_agent_start` (carries the prompt), `turn_end` (carries the completed `AssistantMessage` with inline token usage + model, plus that turn's `toolResults`), `agent_end` (run finished), and `session_shutdown` — it spawns `arize-hook-omp` detached and pipes the event payload to stdin. The shim contains no tracing logic and never blocks omp's event loop.
+2. **Python event handler** (`arize-hook-omp`). A small state machine keyed by session id. It dispatches on `payload["type"]`, accumulates per-session state, and emits `Turn`/`LLM`/`TOOL` spans on receipt. Pairs each `ToolCall` with its `ToolResultMessage` by id to build TOOL spans with both input args and output.
+
+Because omp's lifecycle events fire exactly once each and carry final data, there is no message-id or callID dedup — spans are emitted as events arrive.
+
+## Setup
+
+The installer prompts for your backend (Phoenix or Arize AX) and project name, writes credentials to `~/.arize/harness/config.yaml`, copies the hook shim into `~/.omp/extensions/arize-tracing.ts`, **and** registers the shim's absolute path in the `extensions` array of `~/.omp/agent/settings.json`. omp does **not** auto-discover an extensions directory ([extension loading docs](https://omp.sh/docs/hooks)) — explicit registration is required, and the installer handles it. Spans are sent directly to the backend from the handler — no separate buffer/collector service is required.
+
+Pass `--with-skills` to also symlink the `manage-omp-tracing` skill into the current directory's `.agents/skills/` so coding agents in this workspace can help manage omp tracing configuration.
+
+### Remote setup
+
+macOS / Linux:
+
+```bash
+# Install
+curl -sSL https://raw.githubusercontent.com/Arize-ai/coding-harness-tracing/main/install.sh | bash -s -- omp
+
+# Uninstall
+curl -sSL https://raw.githubusercontent.com/Arize-ai/coding-harness-tracing/main/install.sh | bash -s -- uninstall omp
+```
+
+Windows (PowerShell):
+
+```powershell
+# Install
+iwr -useb https://raw.githubusercontent.com/Arize-ai/coding-harness-tracing/main/install.bat -OutFile $env:TEMP\install.bat
+& $env:TEMP\install.bat omp
+
+# Uninstall
+iwr -useb https://raw.githubusercontent.com/Arize-ai/coding-harness-tracing/main/install.bat -OutFile $env:TEMP\install.bat
+& $env:TEMP\install.bat uninstall omp
+```
+
+### Local setup
+
+```bash
+git clone https://github.com/Arize-ai/coding-harness-tracing.git
+cd coding-harness-tracing
+```
+
+macOS / Linux:
+
+```bash
+# Install
+./install.sh omp
+
+# Uninstall
+./install.sh uninstall omp
+```
+
+Windows:
+
+```powershell
+# Install
+install.bat omp
+
+# Uninstall
+install.bat uninstall omp
+```
+
+Uninstall removes the shim's path from the `extensions` array in `~/.omp/agent/settings.json`, deletes the hook file at `~/.omp/extensions/arize-tracing.ts` (only if it carries the Arize header marker — your own extensions are left alone), and removes the `harnesses.omp` block from `~/.arize/harness/config.yaml`.
+
+## Default Settings
+
+| Setting | Default |
+|---------|---------|
+| Harness key | `omp` |
+| Project name | `omp` |
+| Phoenix endpoint | `http://localhost:6006` |
+| Arize AX endpoint | `otlp.arize.com:443` |
+| Hook file | `~/.omp/extensions/arize-tracing.ts` |
+| Registration | absolute path in `extensions` array of `~/.omp/agent/settings.json` |
+| Lifecycle events forwarded | `before_agent_start`, `turn_end`, `agent_end`, `session_shutdown` |
+| Span tree | `Turn` (CHAIN) → `LLM` / `TOOL` |
+| Trace granularity | one trace per agent run |
+| State directory | `~/.arize/harness/state/omp/` |
+| Log file | `~/.arize/harness/logs/omp.log` |
+
+## Verifying tracing
+
+Run any omp session as you normally would. omp loads the registered extension on startup; the shim forwards lifecycle events to the Python handler.
+
+- Errors and handler stderr land in `~/.arize/harness/logs/omp.log` always (the adapter redirects Python stderr there via `ARIZE_LOG_FILE`); set `export ARIZE_VERBOSE=true` before launching omp to also see routine handler activity (event dispatch, span emits, state transitions).
+- Confirm spans appear in your configured project in Arize AX or Phoenix.
+- Set `ARIZE_TRACE_DEBUG=true` to dump the raw event payloads under `~/.arize/harness/state/debug/` (files are named `omp_before_agent_start_<ts>.yaml`, `omp_turn_end_<ts>.yaml`, `omp_agent_end_<ts>.yaml`, `omp_session_shutdown_<ts>.yaml`) for inspection.
+
+See the [main README's Environment variables section](../../README.md#environment-variables) for the full list of runtime overrides (`ARIZE_TRACE_ENABLED`, `ARIZE_DRY_RUN`, `ARIZE_USER_ID`, `ARIZE_PROJECT_NAME`, `ARIZE_VERBOSE`, `ARIZE_TRACE_DEBUG`, etc.).

--- a/tracing/omp/__init__.py
+++ b/tracing/omp/__init__.py
@@ -1,0 +1,1 @@
+"""omp (Oh My Pi) tracing harness package."""

--- a/tracing/omp/constants.py
+++ b/tracing/omp/constants.py
@@ -1,0 +1,25 @@
+"""Constants for the omp (Oh My Pi) tracing harness installer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+HARNESS_NAME = "omp"
+DISPLAY_NAME = "Oh My Pi (omp)"
+
+# omp settings live in ~/.omp/agent/settings.json. The `extensions` array there
+# is an explicit list of file/dir paths omp loads (no auto-discovery), so the
+# shim's absolute path must be registered there on install.
+SETTINGS_DIR = Path.home() / ".omp" / "agent"
+SETTINGS_FILE = SETTINGS_DIR / "settings.json"
+
+# The shim itself is file-dropped into ~/.omp/extensions/.
+EXTENSIONS_DIR = Path.home() / ".omp" / "extensions"
+PLUGIN_FILE = EXTENSIONS_DIR / "arize-tracing.ts"
+
+# Repo-shipped source asset copied on install.
+PLUGIN_SOURCE = Path(__file__).parent / "plugin" / "arize-tracing.ts"
+
+# Soft install detection (presence check + binary lookup fallback).
+HARNESS_HOME = ".omp"
+HARNESS_BIN = "omp"

--- a/tracing/omp/constants.py
+++ b/tracing/omp/constants.py
@@ -1,0 +1,22 @@
+"""Constants for the omp (Oh My Pi) tracing harness installer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+HARNESS_NAME = "omp"
+DISPLAY_NAME = "Oh My Pi (omp)"
+
+# omp config root + extension registration (per https://omp.sh/docs/hooks).
+OMP_CONFIG_DIR = Path.home() / ".omp"
+SETTINGS_DIR = OMP_CONFIG_DIR / "agent"
+SETTINGS_FILE = SETTINGS_DIR / "settings.json"  # has an "extensions": [paths] array
+EXTENSIONS_DIR = OMP_CONFIG_DIR / "extensions"
+PLUGIN_FILE = EXTENSIONS_DIR / "arize-tracing.ts"  # where the installer drops the shim
+
+# Repo-shipped source asset copied on install:
+PLUGIN_SOURCE = Path(__file__).parent / "plugin" / "arize-tracing.ts"
+
+# Soft install detection:
+HARNESS_HOME = ".omp"
+HARNESS_BIN = "omp"

--- a/tracing/omp/hooks/__init__.py
+++ b/tracing/omp/hooks/__init__.py
@@ -1,0 +1,1 @@
+"""omp tracing hook handlers and session adapter."""

--- a/tracing/omp/hooks/adapter.py
+++ b/tracing/omp/hooks/adapter.py
@@ -47,7 +47,7 @@ def resolve_session(input_json: dict) -> StateManager:
     """
     key = input_json.get("sessionId") or "unknown"
 
-    state_file = STATE_DIR / f"state_{key}.yaml"
+    state_file = STATE_DIR / f"state_{key}.json"
     lock_path = STATE_DIR / f".lock_{key}"
 
     sm = StateManager(
@@ -90,7 +90,7 @@ def gc_stale_state_files() -> None:
     if not STATE_DIR.is_dir():
         return
     cutoff = time.time() - 86400
-    for f in STATE_DIR.glob("state_*.yaml"):
+    for f in STATE_DIR.glob("state_*.json"):
         try:
             key = f.stem.replace("state_", "", 1)
             if f.stat().st_mtime >= cutoff:

--- a/tracing/omp/hooks/adapter.py
+++ b/tracing/omp/hooks/adapter.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""omp (Oh My Pi) adapter — session resolution, initialization, and GC.
+
+omp always supplies an authoritative ``sessionId`` (camelCase — the TypeScript
+shim stamps it on every forwarded payload, reading it from the hook context for
+events whose payload is empty). So, like opencode, this adapter has no PID /
+grandparent-PID heuristics. Missing/empty ``sessionId`` keys off the literal
+string ``"unknown"``.
+
+Unlike opencode there is no snapshot/message payload to mine for the project
+name, so the derivation chain is simply
+``env.project_name`` -> ``os.path.basename(os.getcwd())`` -> ``HARNESS_NAME``.
+"""
+from __future__ import annotations
+
+import os
+import time
+
+from core.common import StateManager, env, get_timestamp_ms, log, redirect_stderr_to_log_file
+from core.constants import HARNESSES, STATE_BASE_DIR
+from tracing.omp.constants import HARNESS_NAME
+
+# --- Module-level constants derived from HARNESSES ---
+_HARNESS = HARNESSES["omp"]
+SERVICE_NAME = _HARNESS["service_name"]  # "omp"
+SCOPE_NAME = _HARNESS["scope_name"]  # "arize-omp-plugin"
+STATE_DIR = STATE_BASE_DIR / _HARNESS["state_subdir"]  # ~/.arize/harness/state/omp
+
+# Route hook stderr to a per-harness log file unless the user already set one.
+os.environ.setdefault("ARIZE_LOG_FILE", str(_HARNESS["default_log_file"]))
+redirect_stderr_to_log_file()
+
+
+def check_requirements() -> bool:
+    """Return True if env.trace_enabled is True. Create STATE_DIR if so."""
+    if not env.trace_enabled:
+        return False
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    return True
+
+
+def resolve_session(input_json: dict) -> StateManager:
+    """Build a StateManager keyed off the omp ``sessionId`` payload field.
+
+    Missing/empty sessionId falls back to the literal key ``"unknown"`` — omp
+    adapters never use PID-based keys.
+    """
+    key = input_json.get("sessionId") or "unknown"
+
+    state_file = STATE_DIR / f"state_{key}.yaml"
+    lock_path = STATE_DIR / f".lock_{key}"
+
+    sm = StateManager(
+        state_dir=STATE_DIR,
+        state_file=state_file,
+        lock_path=lock_path,
+    )
+    sm.init_state()
+    return sm
+
+
+def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
+    """Idempotent session initialization."""
+    existing = state.get("session_id")
+    if existing is not None:
+        return
+
+    session_id = input_json.get("sessionId") or "unknown"
+
+    project_name = env.project_name
+    if not project_name:
+        project_name = os.path.basename(os.getcwd()) or HARNESS_NAME
+
+    state.set("session_id", session_id)
+    state.set("session_start_time", str(get_timestamp_ms()))
+    state.set("project_name", project_name)
+    state.set("trace_count", "0")
+    state.set("tool_count", "0")
+    state.set("user_id", env.get_user_id(SERVICE_NAME))
+
+    log(f"Session initialized: {session_id}")
+
+
+def gc_stale_state_files() -> None:
+    """Remove state files (and their lock files) older than 24h by mtime.
+
+    omp keys are session IDs (not PIDs), so this is the mtime-only branch — no
+    PID-liveness check.
+    """
+    if not STATE_DIR.is_dir():
+        return
+    cutoff = time.time() - 86400
+    for f in STATE_DIR.glob("state_*.yaml"):
+        try:
+            key = f.stem.replace("state_", "", 1)
+            if f.stat().st_mtime >= cutoff:
+                continue
+
+            try:
+                f.unlink(missing_ok=True)
+            except OSError as e:
+                log(f"GC: failed to remove stale state file {f}: {e}")
+
+            lock_path = STATE_DIR / f".lock_{key}"
+            if lock_path.is_dir():
+                try:
+                    lock_path.rmdir()
+                except OSError as e:
+                    log(f"GC: failed to remove stale lock directory {lock_path}: {e}")
+            elif lock_path.is_file():
+                try:
+                    lock_path.unlink(missing_ok=True)
+                except OSError as e:
+                    log(f"GC: failed to remove stale lock file {lock_path}: {e}")
+        except OSError as e:
+            log(f"GC: failed to inspect stale state candidate {f}: {e}")

--- a/tracing/omp/hooks/adapter.py
+++ b/tracing/omp/hooks/adapter.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""omp adapter: session resolution, initialization, and GC."""
+
+from __future__ import annotations
+
+import os
+import time
+
+from core.common import StateManager, env, get_timestamp_ms, log, redirect_stderr_to_log_file
+from core.constants import HARNESSES, STATE_BASE_DIR
+
+_HARNESS = HARNESSES["omp"]
+SERVICE_NAME = _HARNESS["service_name"]
+SCOPE_NAME = _HARNESS["scope_name"]
+STATE_DIR = STATE_BASE_DIR / _HARNESS["state_subdir"]
+
+os.environ.setdefault("ARIZE_LOG_FILE", str(_HARNESS["default_log_file"]))
+redirect_stderr_to_log_file()
+
+
+def check_requirements() -> bool:
+    """Return True when tracing is enabled and the state directory is ready."""
+    if not env.trace_enabled:
+        return False
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    return True
+
+
+def resolve_session(input_json: dict) -> StateManager:
+    """Build a StateManager keyed by the shim-stamped omp sessionId."""
+    key = input_json.get("sessionId") or "unknown"
+    sm = StateManager(
+        state_dir=STATE_DIR,
+        state_file=STATE_DIR / f"state_{key}.yaml",
+        lock_path=STATE_DIR / f".lock_{key}",
+    )
+    sm.init_state()
+    return sm
+
+
+def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
+    """Initialize session state once."""
+    if state.get("session_id") is not None:
+        return
+
+    session_id = input_json.get("sessionId") or "unknown"
+    project_name = env.project_name or os.path.basename(os.getcwd())
+
+    state.set("session_id", session_id)
+    state.set("session_start_time", str(get_timestamp_ms()))
+    state.set("project_name", project_name)
+    state.set("trace_count", "0")
+    state.set("tool_count", "0")
+    state.set("user_id", env.get_user_id(SERVICE_NAME))
+
+    log(f"Session initialized: {session_id}")
+
+
+def gc_stale_state_files() -> None:
+    """Remove omp state and lock files older than 24h by mtime."""
+    if not STATE_DIR.is_dir():
+        return
+
+    cutoff = time.time() - 86400
+    for state_file in STATE_DIR.glob("state_*.yaml"):
+        try:
+            key = state_file.stem.replace("state_", "", 1)
+            if state_file.stat().st_mtime >= cutoff:
+                continue
+
+            try:
+                state_file.unlink(missing_ok=True)
+            except OSError as exc:
+                log(f"GC: failed to remove stale state file {state_file}: {exc}")
+
+            lock_path = STATE_DIR / f".lock_{key}"
+            if lock_path.is_dir():
+                try:
+                    lock_path.rmdir()
+                except OSError as exc:
+                    log(f"GC: failed to remove stale lock directory {lock_path}: {exc}")
+            elif lock_path.is_file():
+                try:
+                    lock_path.unlink(missing_ok=True)
+                except OSError as exc:
+                    log(f"GC: failed to remove stale lock file {lock_path}: {exc}")
+        except OSError as exc:
+            log(f"GC: failed to inspect stale state candidate {state_file}: {exc}")

--- a/tracing/omp/hooks/adapter.py
+++ b/tracing/omp/hooks/adapter.py
@@ -4,8 +4,9 @@
 omp always supplies an authoritative ``sessionId`` (camelCase — the TypeScript
 shim stamps it on every forwarded payload, reading it from the hook context for
 events whose payload is empty). So, like opencode, this adapter has no PID /
-grandparent-PID heuristics. Missing/empty ``sessionId`` keys off the literal
-string ``"unknown"``.
+grandparent-PID heuristics. Missing/empty ``sessionId`` keys off a per-process
+``"unknown-<pid>"`` fallback (see ``_session_key``) so two concurrent id-less
+runs cannot collide on a single shared state file.
 
 Unlike opencode there is no snapshot/message payload to mine for the project
 name, so the derivation chain is simply
@@ -39,13 +40,28 @@ def check_requirements() -> bool:
     return True
 
 
+def _session_key(input_json: dict) -> str:
+    """Return the omp ``sessionId``, or a per-process fallback when it is absent.
+
+    omp normally supplies an authoritative ``sessionId``. When it is missing or
+    empty we key off ``"unknown-<pid>"`` rather than a shared ``"unknown"``
+    literal, so two concurrent id-less runs cannot clobber each other's state
+    file. Within a single event's process the pid is stable, so ``resolve_session``
+    and ``ensure_session_initialized`` agree on the key; span correlation across a
+    run's separate detached processes is already impossible without a real
+    ``sessionId``, so no correlation is lost by using the pid here.
+    """
+    return input_json.get("sessionId") or f"unknown-{os.getpid()}"
+
+
 def resolve_session(input_json: dict) -> StateManager:
     """Build a StateManager keyed off the omp ``sessionId`` payload field.
 
-    Missing/empty sessionId falls back to the literal key ``"unknown"`` — omp
-    adapters never use PID-based keys.
+    Missing/empty sessionId falls back to a per-process ``"unknown-<pid>"`` key
+    (see ``_session_key``) — omp adapters never use PID-based keys for real
+    sessions.
     """
-    key = input_json.get("sessionId") or "unknown"
+    key = _session_key(input_json)
 
     state_file = STATE_DIR / f"state_{key}.json"
     lock_path = STATE_DIR / f".lock_{key}"
@@ -65,7 +81,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     if existing is not None:
         return
 
-    session_id = input_json.get("sessionId") or "unknown"
+    session_id = _session_key(input_json)
 
     project_name = env.project_name
     if not project_name:

--- a/tracing/omp/hooks/handlers.py
+++ b/tracing/omp/hooks/handlers.py
@@ -66,6 +66,7 @@ def _send_span_async(span_dict: dict) -> None:
         try:
             os.waitpid(pid, 0)
         except OSError:
+            # Best-effort reap: failure here should not interrupt the caller.
             pass
         return
 

--- a/tracing/omp/hooks/handlers.py
+++ b/tracing/omp/hooks/handlers.py
@@ -85,8 +85,10 @@ def _send_span_async(span_dict: dict) -> None:
                 # Best-effort stdio detachment in child process; ignore per-fd dup failures.
                 pass
         os.close(devnull)
-    except OSError:
-        pass
+    except OSError as exc:
+        # Best-effort stdio detachment in forked child; ignore failures to avoid
+        # impacting host execution, but emit debug context for diagnostics.
+        debug_dump({"event": "omp_stdio_detach_failed", "error": str(exc)})
 
     try:
         send_span(span_dict)

--- a/tracing/omp/hooks/handlers.py
+++ b/tracing/omp/hooks/handlers.py
@@ -409,15 +409,24 @@ def _handle_agent_end(input_json: dict) -> None:
     if not state.get("current_trace_id") or not state.get("current_trace_span_id"):
         return
 
-    final_output = state.get("current_final_output") or ""
-    if not final_output:
-        messages = input_json.get("messages") or []
-        if isinstance(messages, list):
-            for message in reversed(messages):
+    # Prefer the final assistant text from agent_end's OWN payload. Each omp
+    # lifecycle event is forwarded to a separate, detached Python process, so
+    # the final turn_end and this agent_end race on the shared state file:
+    # current_final_output may still hold a prior turn's text when this process
+    # reads it. agent_end.messages is self-contained and authoritative — the
+    # last assistant message is the run's final answer. Fall back to the state
+    # accumulator only when the payload carries no assistant text.
+    final_output = ""
+    messages = input_json.get("messages") or []
+    if isinstance(messages, list):
+        for message in reversed(messages):
+            if isinstance(message, dict) and message.get("role") == "assistant":
                 text = _assistant_text(message)
                 if text:
                     final_output = text
                     break
+    if not final_output:
+        final_output = state.get("current_final_output") or ""
 
     _emit_turn_root(state, redact_content(env.log_prompts, final_output))
 

--- a/tracing/omp/hooks/handlers.py
+++ b/tracing/omp/hooks/handlers.py
@@ -93,6 +93,7 @@ def _send_span_async(span_dict: dict) -> None:
     try:
         send_span(span_dict)
     except Exception:
+        # Best-effort tracing in detached child: never propagate failures.
         pass
     os._exit(0)
 

--- a/tracing/omp/hooks/handlers.py
+++ b/tracing/omp/hooks/handlers.py
@@ -82,6 +82,7 @@ def _send_span_async(span_dict: dict) -> None:
             try:
                 os.dup2(devnull, fd)
             except OSError:
+                # Best-effort stdio detachment in child process; ignore per-fd dup failures.
                 pass
         os.close(devnull)
     except OSError:

--- a/tracing/omp/hooks/handlers.py
+++ b/tracing/omp/hooks/handlers.py
@@ -88,7 +88,7 @@ def _send_span_async(span_dict: dict) -> None:
     except OSError as exc:
         # Best-effort stdio detachment in forked child; ignore failures to avoid
         # impacting host execution, but emit debug context for diagnostics.
-        debug_dump({"event": "omp_stdio_detach_failed", "error": str(exc)})
+        debug_dump("send_span", {"event": "omp_stdio_detach_failed", "error": str(exc)})
 
     try:
         send_span(span_dict)
@@ -118,7 +118,7 @@ def _user_prompt(prompt_field: Any) -> str:
 
 def _tool_calls(message: Any) -> dict:
     """Map ToolCall.id to its name and arguments."""
-    calls = {}
+    calls: dict = {}
     if not isinstance(message, dict):
         return calls
     for item in message.get("content") or []:
@@ -171,7 +171,7 @@ def _timestamp_or_now(value: Any) -> int:
 
 def _per_tool_attrs(tool_name: str, tool_input: Any) -> dict:
     """Return raw specialized tool attrs for known omp tools."""
-    attrs = {}
+    attrs: dict = {}
     if not isinstance(tool_input, dict):
         return attrs
     if tool_name == "bash":

--- a/tracing/omp/hooks/handlers.py
+++ b/tracing/omp/hooks/handlers.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""omp hook handlers: stateful event-forward tracing.
+
+The TypeScript shim forwards each once-fired omp lifecycle event to this entry
+point. This module keeps per-session trace state and emits Turn, LLM, and TOOL
+spans without snapshot reconciliation or deduplication.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+from core.common import (
+    StateManager,
+    build_span,
+    debug_dump,
+    env,
+    error,
+    generate_span_id,
+    generate_trace_id,
+    get_timestamp_ms,
+    log,
+    redact_content,
+    send_span,
+)
+from tracing.omp.hooks.adapter import (
+    SCOPE_NAME,
+    SERVICE_NAME,
+    check_requirements,
+    ensure_session_initialized,
+    resolve_session,
+)
+
+
+def _read_stdin() -> dict:
+    """Read JSON from stdin. Return {} on empty or invalid input."""
+    try:
+        raw = sys.stdin.read()
+        if not raw:
+            return {}
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _send_span_async(span_dict: dict) -> None:
+    """Send a span without blocking the host process."""
+    if os.environ.get("ARIZE_DISABLE_FORK", "").lower() == "true":
+        send_span(span_dict)
+        return
+    if not hasattr(os, "fork"):
+        send_span(span_dict)
+        return
+
+    try:
+        pid = os.fork()
+    except OSError:
+        send_span(span_dict)
+        return
+
+    if pid > 0:
+        try:
+            os.waitpid(pid, 0)
+        except OSError:
+            pass
+        return
+
+    try:
+        if os.fork() > 0:
+            os._exit(0)
+    except OSError:
+        os._exit(0)
+
+    try:
+        devnull = os.open(os.devnull, os.O_RDWR)
+        for fd in (0, 1, 2):
+            try:
+                os.dup2(devnull, fd)
+            except OSError:
+                pass
+        os.close(devnull)
+    except OSError:
+        pass
+
+    try:
+        send_span(span_dict)
+    except Exception:
+        pass
+    os._exit(0)
+
+
+def _assistant_text(message: Any) -> str:
+    """Concatenate text content items from an AssistantMessage."""
+    if not isinstance(message, dict):
+        return ""
+    chunks = []
+    for item in message.get("content") or []:
+        if isinstance(item, dict) and item.get("type") == "text":
+            text = item.get("text") or ""
+            if text:
+                chunks.append(str(text))
+    return "".join(chunks)
+
+
+def _user_prompt(prompt_field: Any) -> str:
+    """Return before_agent_start.prompt as-is when it is a string."""
+    return prompt_field if isinstance(prompt_field, str) else ""
+
+
+def _tool_calls(message: Any) -> dict:
+    """Map ToolCall.id to its name and arguments."""
+    calls = {}
+    if not isinstance(message, dict):
+        return calls
+    for item in message.get("content") or []:
+        if not isinstance(item, dict) or item.get("type") != "toolCall":
+            continue
+        call_id = item.get("id") or ""
+        if not call_id:
+            continue
+        arguments = item.get("arguments") or {}
+        calls[call_id] = {
+            "name": item.get("name") or "",
+            "arguments": arguments if isinstance(arguments, dict) else {},
+        }
+    return calls
+
+
+def _text_of_content(content_list: Any) -> str:
+    """Concatenate text content items from a ToolResultMessage content list."""
+    if not isinstance(content_list, list):
+        return ""
+    chunks = []
+    for item in content_list:
+        if isinstance(item, dict) and item.get("type") == "text":
+            text = item.get("text") or ""
+            if text:
+                chunks.append(str(text))
+    return "".join(chunks)
+
+
+def _int_or_zero(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float_or_zero(value: Any) -> float:
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _timestamp_or_now(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return get_timestamp_ms()
+
+
+def _per_tool_attrs(tool_name: str, tool_input: Any) -> dict:
+    """Return raw specialized tool attrs for known omp tools."""
+    attrs = {}
+    if not isinstance(tool_input, dict):
+        return attrs
+    if tool_name == "bash":
+        command = tool_input.get("command") or ""
+        if command:
+            attrs["tool.command"] = str(command)
+    elif tool_name in ("read", "edit", "write"):
+        file_path = tool_input.get("filePath") or tool_input.get("path") or ""
+        if file_path:
+            attrs["tool.file_path"] = str(file_path)
+    elif tool_name in ("grep", "glob"):
+        query = tool_input.get("pattern") or ""
+        if query:
+            attrs["tool.query"] = str(query)
+    elif tool_name in ("webfetch", "web_fetch", "fetch"):
+        url = tool_input.get("url") or ""
+        if url:
+            attrs["tool.url"] = str(url)
+    return attrs
+
+
+def _open_trace(state: StateManager, prompt: str) -> None:
+    state.set("current_trace_id", generate_trace_id())
+    state.set("current_trace_span_id", generate_span_id())
+    state.set("current_trace_start_time", str(get_timestamp_ms()))
+    state.set("current_trace_prompt", prompt)
+    state.set("current_final_output", "")
+    state.increment("trace_count")
+
+
+def _clear_trace_state(state: StateManager) -> None:
+    for key in (
+        "current_trace_id",
+        "current_trace_span_id",
+        "current_trace_start_time",
+        "current_trace_prompt",
+        "current_final_output",
+    ):
+        state.delete(key)
+
+
+def _emit_turn_root(state: StateManager, output_value: str) -> None:
+    trace_id = state.get("current_trace_id")
+    span_id = state.get("current_trace_span_id")
+    if not trace_id or not span_id:
+        return
+
+    attrs: dict[str, Any] = {
+        "session.id": state.get("session_id") or "",
+        "project.name": state.get("project_name") or "",
+        "openinference.span.kind": "CHAIN",
+        "input.value": redact_content(env.log_prompts, state.get("current_trace_prompt") or ""),
+        "output.value": output_value,
+    }
+    user_id = state.get("user_id") or ""
+    if user_id:
+        attrs["user.id"] = user_id
+
+    span = build_span(
+        "Turn",
+        "CHAIN",
+        span_id,
+        trace_id,
+        "",
+        state.get("current_trace_start_time") or str(get_timestamp_ms()),
+        str(get_timestamp_ms()),
+        attrs,
+        SERVICE_NAME,
+        SCOPE_NAME,
+    )
+    _send_span_async(span)
+    _clear_trace_state(state)
+
+
+def _close_pending_turn(state: StateManager, reason: str = "(closed by fail-safe)") -> None:
+    """Emit the pending Turn root, preferring the latest assistant text."""
+    if not state.get("current_trace_id") or not state.get("current_trace_span_id"):
+        return
+    final_output = state.get("current_final_output") or ""
+    output_value = redact_content(env.log_prompts, final_output) if final_output else reason
+    _emit_turn_root(state, output_value)
+
+
+def _emit_llm_span(state: StateManager, message: Any) -> None:
+    if not isinstance(message, dict):
+        return
+    trace_id = state.get("current_trace_id")
+    parent_span_id = state.get("current_trace_span_id")
+    if not trace_id or not parent_span_id:
+        return
+
+    usage = message.get("usage") or {}
+    if not isinstance(usage, dict):
+        usage = {}
+    cost_block = usage.get("cost") or {}
+    if not isinstance(cost_block, dict):
+        cost_block = {}
+
+    input_tokens = _int_or_zero(usage.get("input"))
+    output_tokens = _int_or_zero(usage.get("output"))
+    cache_read = _int_or_zero(usage.get("cacheRead"))
+    cache_write = _int_or_zero(usage.get("cacheWrite"))
+    prompt_tokens = input_tokens + cache_read + cache_write
+    reasoning_tokens = _int_or_zero(usage.get("reasoningTokens"))
+    cost = _float_or_zero(cost_block.get("total"))
+
+    end_ms = _timestamp_or_now(message.get("timestamp"))
+    duration_ms = _int_or_zero(message.get("duration"))
+    start_ms = end_ms - duration_ms if duration_ms else end_ms
+
+    model = message.get("model") or ""
+    output_text = _assistant_text(message)
+    attrs: dict[str, Any] = {
+        "session.id": state.get("session_id") or "",
+        "project.name": state.get("project_name") or "",
+        "openinference.span.kind": "LLM",
+        "llm.model_name": model,
+        "llm.provider": message.get("provider") or "",
+        "llm.token_count.prompt": prompt_tokens,
+        "llm.token_count.completion": output_tokens,
+        "llm.token_count.total": prompt_tokens + output_tokens,
+        "input.value": redact_content(env.log_prompts, state.get("current_trace_prompt") or ""),
+        "output.value": redact_content(env.log_prompts, output_text),
+    }
+    if reasoning_tokens:
+        attrs["llm.token_count.completion_details.reasoning"] = reasoning_tokens
+    if cache_read:
+        attrs["llm.token_count.prompt_details.cache_read"] = cache_read
+    if cache_write:
+        attrs["llm.token_count.prompt_details.cache_write"] = cache_write
+    if cost:
+        attrs["llm.cost"] = cost
+
+    user_id = state.get("user_id") or ""
+    if user_id:
+        attrs["user.id"] = user_id
+
+    span = build_span(
+        f"LLM: {model}" if model else "LLM",
+        "LLM",
+        generate_span_id(),
+        trace_id,
+        parent_span_id,
+        start_ms,
+        end_ms,
+        attrs,
+        SERVICE_NAME,
+        SCOPE_NAME,
+    )
+    _send_span_async(span)
+    state.set("current_final_output", output_text)
+
+
+def _emit_tool_span(state: StateManager, tool_result: dict, calls: dict) -> None:
+    trace_id = state.get("current_trace_id")
+    parent_span_id = state.get("current_trace_span_id")
+    if not trace_id or not parent_span_id:
+        return
+
+    tool_name = tool_result.get("toolName") or "unknown"
+    call_id = tool_result.get("toolCallId") or ""
+    arguments = calls.get(call_id, {}).get("arguments", {})
+    if not isinstance(arguments, dict):
+        arguments = {}
+
+    input_text = json.dumps(arguments)
+    output_text = _text_of_content(tool_result.get("content"))
+    attrs: dict[str, Any] = {
+        "session.id": state.get("session_id") or "",
+        "project.name": state.get("project_name") or "",
+        "openinference.span.kind": "TOOL",
+        "tool.name": tool_name,
+        "input.value": redact_content(env.log_tool_content, input_text),
+        "output.value": redact_content(env.log_tool_content, output_text),
+    }
+    for key, value in _per_tool_attrs(tool_name, arguments).items():
+        attrs[key] = redact_content(env.log_tool_details, value)
+
+    user_id = state.get("user_id") or ""
+    if user_id:
+        attrs["user.id"] = user_id
+
+    is_error = bool(tool_result.get("isError"))
+    status_message = redact_content(env.log_tool_content, output_text) if is_error else ""
+    timestamp = _timestamp_or_now(tool_result.get("timestamp"))
+    span = build_span(
+        tool_name,
+        "TOOL",
+        generate_span_id(),
+        trace_id,
+        parent_span_id,
+        timestamp,
+        timestamp,
+        attrs,
+        SERVICE_NAME,
+        SCOPE_NAME,
+        status_code=2 if is_error else 1,
+        status_message=status_message,
+    )
+    _send_span_async(span)
+    state.increment("tool_count")
+
+
+def _handle_before_agent_start(input_json: dict) -> None:
+    debug_dump("omp_before_agent_start", input_json)
+    state = resolve_session(input_json)
+    ensure_session_initialized(state, input_json)
+    if state.get("current_trace_id"):
+        _close_pending_turn(state)
+    _open_trace(state, _user_prompt(input_json.get("prompt")))
+
+
+def _handle_turn_end(input_json: dict) -> None:
+    debug_dump("omp_turn_end", input_json)
+    state = resolve_session(input_json)
+    ensure_session_initialized(state, input_json)
+    if not state.get("current_trace_id"):
+        _open_trace(state, "")
+
+    message = input_json.get("message")
+    if not isinstance(message, dict):
+        message = {}
+    _emit_llm_span(state, message)
+
+    calls = _tool_calls(message)
+    for tool_result in input_json.get("toolResults") or []:
+        if isinstance(tool_result, dict):
+            _emit_tool_span(state, tool_result, calls)
+
+
+def _handle_agent_end(input_json: dict) -> None:
+    debug_dump("omp_agent_end", input_json)
+    state = resolve_session(input_json)
+    ensure_session_initialized(state, input_json)
+    if not state.get("current_trace_id") or not state.get("current_trace_span_id"):
+        return
+
+    final_output = state.get("current_final_output") or ""
+    if not final_output:
+        messages = input_json.get("messages") or []
+        if isinstance(messages, list):
+            for message in reversed(messages):
+                text = _assistant_text(message)
+                if text:
+                    final_output = text
+                    break
+
+    _emit_turn_root(state, redact_content(env.log_prompts, final_output))
+
+
+def _handle_session_shutdown(input_json: dict) -> None:
+    debug_dump("omp_session_shutdown", input_json)
+    state = resolve_session(input_json)
+    ensure_session_initialized(state, input_json)
+    _close_pending_turn(state)
+
+
+def main() -> None:
+    """Hook entry point. Never raises."""
+    try:
+        if not check_requirements():
+            return
+        input_json = _read_stdin()
+        if not input_json:
+            return
+
+        kind = input_json.get("type")
+        try:
+            if kind == "before_agent_start":
+                _handle_before_agent_start(input_json)
+            elif kind == "turn_end":
+                _handle_turn_end(input_json)
+            elif kind == "agent_end":
+                _handle_agent_end(input_json)
+            elif kind == "session_shutdown":
+                _handle_session_shutdown(input_json)
+            else:
+                log(f"omp: unknown type {kind!r}")
+        except Exception as exc:
+            error(f"omp {kind!r} failed: {exc!r}")
+    except Exception as exc:
+        error(f"omp main() crashed: {exc!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tracing/omp/install.py
+++ b/tracing/omp/install.py
@@ -39,7 +39,7 @@ from core.setup import (
     write_config,
     write_logging_config,
 )
-from tracing.omp.constants import HARNESS_NAME
+import tracing.omp.constants as _c
 
 # Header-marker the installer writes into the shim and checks on uninstall so
 # we never delete a user's own extension file.
@@ -52,26 +52,18 @@ _HEADER_MARKER = "// Arize omp tracing hook (shim)."
 
 
 def _extensions_dir():
-    import tracing.omp.constants as _c
-
     return _c.EXTENSIONS_DIR
 
 
 def _plugin_file():
-    import tracing.omp.constants as _c
-
     return _c.PLUGIN_FILE
 
 
 def _settings_dir():
-    import tracing.omp.constants as _c
-
     return _c.SETTINGS_DIR
 
 
 def _settings_file():
-    import tracing.omp.constants as _c
-
     return _c.SETTINGS_FILE
 
 

--- a/tracing/omp/install.py
+++ b/tracing/omp/install.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""omp (Oh My Pi) tracing harness installer.
+
+A hybrid of two existing installers:
+
+* The config-prompt flow + ``.ts`` file-drop come from
+  ``tracing/opencode/install.py`` (omp loads extensions **in-process** inside its
+  Bun runtime, so the shim is a file drop).
+* The JSON ``settings.json`` read-merge-write comes from
+  ``tracing/gemini/install.py`` — unlike opencode, omp does NOT auto-discover a
+  plugin dir. We must register the shim's absolute path in the ``extensions``
+  array of ``~/.omp/agent/settings.json``.
+
+Usage (called by the shell router):
+    python tracing/omp/install.py install [--with-skills]
+    python tracing/omp/install.py uninstall
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+from core.config import get_value, load_config
+from core.setup import (
+    dry_run,
+    ensure_shared_runtime,
+    info,
+    merge_harness_entry,
+    prompt_backend,
+    prompt_content_logging,
+    prompt_project_name,
+    prompt_user_id,
+    remove_harness_entry,
+    symlink_skills,
+    unlink_skills,
+    write_config,
+    write_logging_config,
+)
+from tracing.omp.constants import HARNESS_NAME
+
+# Header-marker the installer writes into the shim and checks on uninstall so
+# we never delete a user's own extension file.
+_HEADER_MARKER = "// Arize omp tracing hook (shim)."
+
+
+# ---------------------------------------------------------------------------
+# Path helpers (re-read constants each call so tests can monkeypatch them)
+# ---------------------------------------------------------------------------
+
+
+def _extensions_dir():
+    import tracing.omp.constants as _c
+
+    return _c.EXTENSIONS_DIR
+
+
+def _plugin_file():
+    import tracing.omp.constants as _c
+
+    return _c.PLUGIN_FILE
+
+
+def _settings_dir():
+    import tracing.omp.constants as _c
+
+    return _c.SETTINGS_DIR
+
+
+def _settings_file():
+    import tracing.omp.constants as _c
+
+    return _c.SETTINGS_FILE
+
+
+def _plugin_source():
+    """Resolve the bundled shim asset relative to THIS installer file.
+
+    Deliberately NOT via ``constants.PLUGIN_SOURCE``: at runtime the shell router
+    executes install.py from the rsynced ~/.arize/harness tree (where the .ts
+    ships alongside it), while ``tracing.omp.constants`` is imported from the venv
+    site-packages copy, which does not carry the data asset. Resolving from
+    install.py's own location works in every delivery (repo, INSTALL_DIR) and
+    avoids the FileNotFoundError seen in real installs.
+    """
+    return Path(__file__).resolve().parent / "plugin" / "arize-tracing.ts"
+
+
+# ---------------------------------------------------------------------------
+# JSON settings helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_settings() -> dict:
+    """Read settings.json, returning ``{}`` on missing/empty/invalid JSON.
+
+    Unlike Gemini's installer, malformed JSON is logged and treated as ``{}``
+    rather than aborting — omp's settings file is more likely to be hand-edited.
+    """
+    path = _settings_file()
+    if not path.is_file():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        info(f"Cannot read {path}: {exc}; treating as empty")
+        return {}
+    if not text.strip():
+        info("settings.json is empty, treating as {}")
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        info(f"{path} contains invalid JSON; treating as empty.\n  {exc}")
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_settings(data: dict) -> None:
+    """Write *data* as pretty-printed JSON to settings.json."""
+    _settings_dir().mkdir(parents=True, exist_ok=True)
+    _settings_file().write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Shim file-drop / removal
+# ---------------------------------------------------------------------------
+
+
+def _install_plugin() -> None:
+    """Copy the shipped shim source into omp's extensions dir."""
+    plugin_file = _plugin_file()
+
+    if dry_run():
+        info(f"would write omp hook to {plugin_file}")
+        return
+
+    _extensions_dir().mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(_plugin_source(), plugin_file)
+
+
+def _uninstall_plugin() -> None:
+    """Delete the shim file only when it carries our header marker."""
+    plugin_file = _plugin_file()
+    if not plugin_file.is_file():
+        return
+
+    try:
+        text = plugin_file.read_text(encoding="utf-8")
+    except OSError:
+        return
+
+    if not text.startswith(_HEADER_MARKER):
+        return
+
+    if dry_run():
+        info(f"would remove omp hook {plugin_file}")
+        return
+
+    plugin_file.unlink()
+
+
+# ---------------------------------------------------------------------------
+# extensions-array registration in settings.json
+# ---------------------------------------------------------------------------
+
+
+def _register_extension() -> None:
+    """Append the shim's absolute path to the ``extensions`` array (idempotent)."""
+    if dry_run():
+        info(f"would register omp extension in {_settings_file()}")
+        return
+
+    data = _read_settings()
+    exts = data.get("extensions")
+    if not isinstance(exts, list):
+        if exts is not None:
+            info("settings.json 'extensions' was not a list; overwriting with a fresh array")
+        exts = []
+        data["extensions"] = exts
+
+    plugin_path = str(_plugin_file())
+    if plugin_path not in exts:
+        exts.append(plugin_path)
+
+    _write_settings(data)
+
+
+def _unregister_extension() -> None:
+    """Remove the shim's path from the ``extensions`` array. No-op if absent."""
+    path = _settings_file()
+    if not path.is_file():
+        return
+
+    if dry_run():
+        info(f"would unregister omp extension from {path}")
+        return
+
+    data = _read_settings()
+    exts = data.get("extensions")
+    if not isinstance(exts, list):
+        return
+
+    plugin_path = str(_plugin_file())
+    data["extensions"] = [e for e in exts if e != plugin_path]
+    _write_settings(data)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def install(with_skills: bool = False) -> None:
+    """Install the omp tracing shim and register in config.yaml."""
+    ensure_shared_runtime()
+
+    config = load_config()
+    existing_entry = get_value(config, f"harnesses.{HARNESS_NAME}")
+
+    if not existing_entry or not isinstance(existing_entry, dict) or "target" not in existing_entry:
+        existing_harnesses = config.get("harnesses") if config else None
+        target, credentials = prompt_backend(existing_harnesses)
+        project_name = prompt_project_name(HARNESS_NAME)
+        user_id = prompt_user_id()
+        if not dry_run():
+            write_config(target, credentials, HARNESS_NAME, project_name, user_id=user_id)
+        else:
+            info("would write config.yaml with backend credentials")
+    else:
+        project_name = prompt_project_name(existing_entry.get("project_name") or HARNESS_NAME)
+        merge_harness_entry(HARNESS_NAME, project_name)
+
+    # Logging settings are global. Prompt only if no `logging:` block exists yet.
+    if (config.get("logging") if config else None) is None:
+        logging_block = prompt_content_logging()
+        write_logging_config(logging_block)
+    else:
+        info("Using existing logging settings from config.yaml")
+
+    _install_plugin()
+    _register_extension()
+
+    if with_skills:
+        symlink_skills(HARNESS_NAME)
+
+    info("omp tracing installed")
+
+
+def uninstall() -> None:
+    """Remove the omp tracing shim and deregister from config.yaml."""
+    _unregister_extension()
+    _uninstall_plugin()
+
+    remove_harness_entry(HARNESS_NAME)
+    unlink_skills(HARNESS_NAME)
+    info("omp tracing uninstalled")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Dispatch install / uninstall from the command line."""
+    if len(sys.argv) < 2 or sys.argv[1] not in ("install", "uninstall"):
+        print(f"usage: {sys.argv[0]} {{install|uninstall}} [--with-skills]", file=sys.stderr)
+        sys.exit(1)
+
+    action = sys.argv[1]
+    flags = set(sys.argv[2:])
+
+    if action == "install":
+        install(with_skills="--with-skills" in flags)
+    else:
+        uninstall()
+
+
+if __name__ == "__main__":
+    main()

--- a/tracing/omp/install.py
+++ b/tracing/omp/install.py
@@ -214,7 +214,7 @@ def _unregister_extension() -> None:
 
 
 def install(with_skills: bool = False) -> None:
-    """Install the omp tracing shim and register in config.yaml."""
+    """Install the omp tracing shim and register in config.json."""
     ensure_shared_runtime()
 
     config = load_config()
@@ -228,7 +228,7 @@ def install(with_skills: bool = False) -> None:
         if not dry_run():
             write_config(target, credentials, HARNESS_NAME, project_name, user_id=user_id)
         else:
-            info("would write config.yaml with backend credentials")
+            info("would write config.json with backend credentials")
     else:
         project_name = prompt_project_name(existing_entry.get("project_name") or HARNESS_NAME)
         merge_harness_entry(HARNESS_NAME, project_name)
@@ -238,7 +238,7 @@ def install(with_skills: bool = False) -> None:
         logging_block = prompt_content_logging()
         write_logging_config(logging_block)
     else:
-        info("Using existing logging settings from config.yaml")
+        info("Using existing logging settings from config.json")
 
     _install_plugin()
     _register_extension()
@@ -250,7 +250,7 @@ def install(with_skills: bool = False) -> None:
 
 
 def uninstall() -> None:
-    """Remove the omp tracing shim and deregister from config.yaml."""
+    """Remove the omp tracing shim and deregister from config.json."""
     _unregister_extension()
     _uninstall_plugin()
 

--- a/tracing/omp/install.py
+++ b/tracing/omp/install.py
@@ -39,7 +39,7 @@ from core.setup import (
     write_config,
     write_logging_config,
 )
-import tracing.omp.constants as _c
+from tracing.omp.constants import HARNESS_NAME
 
 # Header-marker the installer writes into the shim and checks on uninstall so
 # we never delete a user's own extension file.
@@ -52,18 +52,26 @@ _HEADER_MARKER = "// Arize omp tracing hook (shim)."
 
 
 def _extensions_dir():
+    import tracing.omp.constants as _c
+
     return _c.EXTENSIONS_DIR
 
 
 def _plugin_file():
+    import tracing.omp.constants as _c
+
     return _c.PLUGIN_FILE
 
 
 def _settings_dir():
+    import tracing.omp.constants as _c
+
     return _c.SETTINGS_DIR
 
 
 def _settings_file():
+    import tracing.omp.constants as _c
+
     return _c.SETTINGS_FILE
 
 

--- a/tracing/omp/install.py
+++ b/tracing/omp/install.py
@@ -23,10 +23,11 @@ import shutil
 import sys
 from pathlib import Path
 
+import tracing.omp.constants as omp_constants
 from core.config import get_value, load_config
+from core.setup import dry_run, ensure_shared_runtime
+from core.setup import err as _err
 from core.setup import (
-    dry_run,
-    ensure_shared_runtime,
     info,
     merge_harness_entry,
     prompt_backend,
@@ -39,12 +40,10 @@ from core.setup import (
     write_config,
     write_logging_config,
 )
-from tracing.omp.constants import HARNESS_NAME
 
 # Header-marker the installer writes into the shim and checks on uninstall so
 # we never delete a user's own extension file.
 _HEADER_MARKER = "// Arize omp tracing hook (shim)."
-
 
 # ---------------------------------------------------------------------------
 # Path helpers (re-read constants each call so tests can monkeypatch them)
@@ -94,10 +93,12 @@ def _plugin_source():
 
 
 def _read_settings() -> dict:
-    """Read settings.json, returning ``{}`` on missing/empty/invalid JSON.
+    """Read settings.json, returning ``{}`` on a missing or empty file.
 
-    Unlike Gemini's installer, malformed JSON is logged and treated as ``{}``
-    rather than aborting — omp's settings file is more likely to be hand-edited.
+    Like Gemini's installer, an unreadable file or malformed JSON raises
+    ``SystemExit(1)`` rather than being treated as ``{}``: rewriting an empty
+    dict back would silently wipe a hand-edited ``settings.json``. The user must
+    fix the file and retry.
     """
     path = _settings_file()
     if not path.is_file():
@@ -105,16 +106,18 @@ def _read_settings() -> dict:
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
-        info(f"Cannot read {path}: {exc}; treating as empty")
-        return {}
+
+        _err(f"Cannot read {path}: {exc}")
+        sys.exit(1)
     if not text.strip():
         info("settings.json is empty, treating as {}")
         return {}
     try:
         data = json.loads(text)
     except json.JSONDecodeError as exc:
-        info(f"{path} contains invalid JSON; treating as empty.\n  {exc}")
-        return {}
+
+        _err(f"{path} contains invalid JSON; aborting. Please fix the file and retry.\n  {exc}")
+        sys.exit(1)
     return data if isinstance(data, dict) else {}
 
 
@@ -204,8 +207,18 @@ def _unregister_extension() -> None:
         return
 
     plugin_path = str(_plugin_file())
-    data["extensions"] = [e for e in exts if e != plugin_path]
-    _write_settings(data)
+    remaining = [e for e in exts if e != plugin_path]
+    if remaining:
+        data["extensions"] = remaining
+    else:
+        # Don't leave a stray {"extensions": []} behind; drop the now-empty key
+        # and remove the file entirely if we were the only thing in it.
+        data.pop("extensions", None)
+
+    if not data:
+        path.unlink()
+    else:
+        _write_settings(data)
 
 
 # ---------------------------------------------------------------------------
@@ -218,20 +231,20 @@ def install(with_skills: bool = False) -> None:
     ensure_shared_runtime()
 
     config = load_config()
-    existing_entry = get_value(config, f"harnesses.{HARNESS_NAME}")
+    existing_entry = get_value(config, f"harnesses.{omp_constants.HARNESS_NAME}")
 
     if not existing_entry or not isinstance(existing_entry, dict) or "target" not in existing_entry:
         existing_harnesses = config.get("harnesses") if config else None
         target, credentials = prompt_backend(existing_harnesses)
-        project_name = prompt_project_name(HARNESS_NAME)
+        project_name = prompt_project_name(omp_constants.HARNESS_NAME)
         user_id = prompt_user_id()
         if not dry_run():
-            write_config(target, credentials, HARNESS_NAME, project_name, user_id=user_id)
+            write_config(target, credentials, omp_constants.HARNESS_NAME, project_name, user_id=user_id)
         else:
             info("would write config.json with backend credentials")
     else:
-        project_name = prompt_project_name(existing_entry.get("project_name") or HARNESS_NAME)
-        merge_harness_entry(HARNESS_NAME, project_name)
+        project_name = prompt_project_name(existing_entry.get("project_name") or omp_constants.HARNESS_NAME)
+        merge_harness_entry(omp_constants.HARNESS_NAME, project_name)
 
     # Logging settings are global. Prompt only if no `logging:` block exists yet.
     if (config.get("logging") if config else None) is None:
@@ -244,7 +257,7 @@ def install(with_skills: bool = False) -> None:
     _register_extension()
 
     if with_skills:
-        symlink_skills(HARNESS_NAME)
+        symlink_skills(omp_constants.HARNESS_NAME)
 
     info("omp tracing installed")
 
@@ -254,8 +267,8 @@ def uninstall() -> None:
     _unregister_extension()
     _uninstall_plugin()
 
-    remove_harness_entry(HARNESS_NAME)
-    unlink_skills(HARNESS_NAME)
+    remove_harness_entry(omp_constants.HARNESS_NAME)
+    unlink_skills(omp_constants.HARNESS_NAME)
     info("omp tracing uninstalled")
 
 

--- a/tracing/omp/plugin/arize-tracing.ts
+++ b/tracing/omp/plugin/arize-tracing.ts
@@ -1,0 +1,96 @@
+// Arize omp tracing hook (shim).
+//
+// This file ships in the repo and is copied into the user's omp extensions
+// dir (~/.omp/extensions/) by the installer, then registered by absolute path
+// in the "extensions" array of ~/.omp/agent/settings.json (omp does NOT
+// auto-discover an extensions dir). omp loads it in-process inside its own Bun
+// runtime. The shim is a DUMB BRIDGE: it contains no tracing logic. On a small
+// whitelist of once-fired lifecycle events it spawns the Python entry point
+// `arize-hook-omp` (detached, fire-and-forget) with the event payload piped to
+// stdin. ALL parsing, span building, and token math happens in the Python
+// handler (tracing/omp/hooks/handlers.py).
+//
+// Verified against omp's HookAPI / examples (https://omp.sh/docs/hooks and
+// packages/coding-agent/examples/hooks/*.ts, e.g. auto-commit-on-exit.ts):
+//   - a hook default-exports a factory `function (pi: HookAPI)`;
+//   - handlers register via `pi.on(eventName, (event, ctx) => ...)`;
+//   - `session_shutdown` fires with an empty event, so the session id is read
+//     from the hook context (ctx.sessionManager / ctx.session), not the event.
+// `import type` is erasable, so Bun runs this file directly with no npm deps.
+//
+// Forwarded payload contract (do not change top-level type/sessionId without
+// updating the Python handler):
+//   { type, sessionId, ...eventFields }
+
+import { spawn } from "node:child_process";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import type { HookAPI } from "@oh-my-pi/pi-coding-agent";
+
+function binaryPath(): string {
+  const base = join(homedir(), ".arize", "harness", "venv");
+  return platform() === "win32"
+    ? join(base, "Scripts", "arize-hook-omp.exe")
+    : join(base, "bin", "arize-hook-omp");
+}
+
+function forward(payload: unknown): void {
+  try {
+    const child = spawn(binaryPath(), [], {
+      stdio: ["pipe", "ignore", "ignore"],
+      detached: true,
+    });
+    child.on("error", () => {});
+    child.stdin?.write(JSON.stringify(payload));
+    child.stdin?.end();
+    child.unref();
+  } catch {
+    /* fail-soft: tracing must never break the host */
+  }
+}
+
+// Resolve the omp session id from the hook context. session_shutdown's event
+// payload is empty, so every payload is stamped with the id read from ctx.
+function sessionIdOf(ctx: any): string {
+  return ctx?.sessionManager?.sessionId ?? ctx?.session?.id ?? ctx?.sessionId ?? "";
+}
+
+export default function (pi: HookAPI): void {
+  pi.on("before_agent_start", async (event: any, ctx: any) => {
+    try {
+      forward({ type: "before_agent_start", sessionId: sessionIdOf(ctx), prompt: event?.prompt });
+    } catch {
+      /* fail-soft */
+    }
+  });
+
+  pi.on("turn_end", async (event: any, ctx: any) => {
+    try {
+      forward({
+        type: "turn_end",
+        sessionId: sessionIdOf(ctx),
+        turnIndex: event?.turnIndex,
+        message: event?.message,
+        toolResults: event?.toolResults,
+      });
+    } catch {
+      /* fail-soft */
+    }
+  });
+
+  pi.on("agent_end", async (event: any, ctx: any) => {
+    try {
+      forward({ type: "agent_end", sessionId: sessionIdOf(ctx), messages: event?.messages });
+    } catch {
+      /* fail-soft */
+    }
+  });
+
+  pi.on("session_shutdown", async (_event: any, ctx: any) => {
+    try {
+      forward({ type: "session_shutdown", sessionId: sessionIdOf(ctx) });
+    } catch {
+      /* fail-soft */
+    }
+  });
+}

--- a/tracing/omp/plugin/arize-tracing.ts
+++ b/tracing/omp/plugin/arize-tracing.ts
@@ -15,7 +15,7 @@
 //   - a hook default-exports a factory `function (pi: HookAPI)`;
 //   - handlers register via `pi.on(eventName, (event, ctx) => ...)`;
 //   - `session_shutdown` fires with an empty event, so the session id is read
-//     from the hook context (ctx.sessionManager / ctx.session), not the event.
+//     from the hook context via ctx.sessionManager.getSessionId(), not the event.
 // `import type` is erasable, so Bun runs this file directly with no npm deps.
 //
 // Forwarded payload contract (do not change top-level type/sessionId without
@@ -25,7 +25,7 @@
 import { spawn } from "node:child_process";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
-import type { HookAPI } from "@oh-my-pi/pi-coding-agent";
+import type { HookAPI, HookContext } from "@oh-my-pi/pi-coding-agent";
 
 function binaryPath(): string {
   const base = join(homedir(), ".arize", "harness", "venv");
@@ -51,42 +51,48 @@ function forward(payload: unknown): void {
 
 // Resolve the omp session id from the hook context. session_shutdown's event
 // payload is empty, so every payload is stamped with the id read from ctx.
-function sessionIdOf(ctx: any): string {
-  return ctx?.sessionManager?.sessionId ?? ctx?.session?.id ?? ctx?.sessionId ?? "";
+// ReadonlySessionManager exposes getSessionId() (a method) — verified against
+// packages/coding-agent/src/session/session-manager.ts.
+function sessionIdOf(ctx: HookContext): string {
+  try {
+    return ctx.sessionManager.getSessionId() || "";
+  } catch {
+    return "";
+  }
 }
 
 export default function (pi: HookAPI): void {
-  pi.on("before_agent_start", async (event: any, ctx: any) => {
+  pi.on("before_agent_start", async (event, ctx) => {
     try {
-      forward({ type: "before_agent_start", sessionId: sessionIdOf(ctx), prompt: event?.prompt });
+      forward({ type: "before_agent_start", sessionId: sessionIdOf(ctx), prompt: event.prompt });
     } catch {
       /* fail-soft */
     }
   });
 
-  pi.on("turn_end", async (event: any, ctx: any) => {
+  pi.on("turn_end", async (event, ctx) => {
     try {
       forward({
         type: "turn_end",
         sessionId: sessionIdOf(ctx),
-        turnIndex: event?.turnIndex,
-        message: event?.message,
-        toolResults: event?.toolResults,
+        turnIndex: event.turnIndex,
+        message: event.message,
+        toolResults: event.toolResults,
       });
     } catch {
       /* fail-soft */
     }
   });
 
-  pi.on("agent_end", async (event: any, ctx: any) => {
+  pi.on("agent_end", async (event, ctx) => {
     try {
-      forward({ type: "agent_end", sessionId: sessionIdOf(ctx), messages: event?.messages });
+      forward({ type: "agent_end", sessionId: sessionIdOf(ctx), messages: event.messages });
     } catch {
       /* fail-soft */
     }
   });
 
-  pi.on("session_shutdown", async (_event: any, ctx: any) => {
+  pi.on("session_shutdown", async (_event, ctx) => {
     try {
       forward({ type: "session_shutdown", sessionId: sessionIdOf(ctx) });
     } catch {

--- a/tracing/omp/skills/manage-omp-tracing/SKILL.md
+++ b/tracing/omp/skills/manage-omp-tracing/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: manage-omp-tracing
+description: Set up and configure Arize tracing for Oh My Pi (omp) terminal coding sessions. Use when users want to set up tracing, configure Arize AX or Phoenix for Oh My Pi, enable/disable omp tracing, or troubleshoot tracing issues. Triggers on "set up omp tracing", "configure Arize for Oh My Pi", "configure Phoenix for omp", "enable omp tracing", "setup-omp-tracing", or any request about connecting omp / Oh My Pi to Arize or Phoenix for observability.
+---
+
+# Setup omp Tracing
+
+Configure OpenInference tracing for **Oh My Pi (omp)** terminal coding sessions to Arize AX (cloud) or Phoenix (self-hosted). Like opencode, omp loads its extensions [in-process inside its Bun runtime](https://omp.sh/docs/hooks) — there is no per-event subprocess. The integration ships as a small TypeScript hook shim that forwards omp's once-fired lifecycle events to a Python handler (`arize-hook-omp`) which emits spans. Spans are sent directly to the backend from the handler — no separate buffer/collector service is required.
+
+## How to Use This Skill
+
+**This skill follows a decision tree workflow.** Start by asking the user where they are in the setup process:
+
+1. **Is the harness already installed?**
+   - Check `~/.omp/extensions/arize-tracing.ts` for the Arize hook shim
+   - Check `~/.omp/agent/settings.json` for the shim's path in the `extensions` array
+   - Check `~/.arize/harness/config.yaml` for the `harnesses.omp` block
+   - If all are present -> Jump to [Validate](#validate) or [Troubleshoot](#troubleshoot)
+
+2. **Do they already have credentials?**
+   - Yes -> Jump to [Configure Settings](#configure-settings)
+   - No -> Continue to step 3
+
+3. **Which backend do they want to use?**
+   - Phoenix (self-hosted) -> Go to [Set Up Phoenix](#set-up-phoenix)
+   - Arize AX (cloud) -> Go to [Set Up Arize AX](#set-up-arize-ax)
+
+4. **Are they troubleshooting?**
+   - Yes -> Jump to [Troubleshoot](#troubleshoot)
+
+**Important:** Only follow the relevant path for the user's needs. Don't go through all sections.
+
+## Set Up Phoenix
+
+Phoenix is self-hosted. No Python dependencies are needed for tracing -- spans are sent directly via `send_span()` using stdlib `urllib`.
+
+### Install Phoenix
+
+Ask if they already have Phoenix running. If not, walk through:
+
+```bash
+# Option A: pip
+pip install arize-phoenix && phoenix serve
+
+# Option B: Docker
+docker run -p 6006:6006 arizephoenix/phoenix:latest
+```
+
+Phoenix UI will be available at `http://localhost:6006`. Confirm it's running:
+
+```bash
+curl -sf http://localhost:6006/v1/traces >/dev/null && echo "Phoenix is running" || echo "Phoenix not reachable"
+```
+
+Then proceed to [Configure Settings](#configure-settings) with the Phoenix endpoint.
+
+## Set Up Arize AX
+
+Arize AX is available as a SaaS platform or as an on-prem deployment. Users need an account, a space, and an API key.
+
+**First, ask the user: "Are you using the Arize SaaS platform or an on-prem instance?"**
+
+- **SaaS** -> Uses the default endpoint (`otlp.arize.com:443`). Continue below.
+- **On-prem** -> The user will need to provide their custom OTLP endpoint (e.g., `otlp.mycompany.arize.com:443`). Ask for it and note it for the [Configure Settings](#configure-settings) step.
+
+### 1. Create an account
+
+If the user doesn't have an Arize account:
+- **SaaS**: Sign up at https://app.arize.com/auth/join
+- **On-prem**: Contact their administrator for access to the on-prem instance
+
+### 2. Get Space ID and API key
+
+Walk the user through finding their credentials:
+1. Log in to their Arize instance (https://app.arize.com for SaaS, or their on-prem URL)
+2. Click **Settings** (gear icon) in the left sidebar
+3. The **Space ID** is shown on the Space Settings page
+4. Go to the **API Keys** tab
+5. Click **Create API Key** or copy an existing one
+
+Both `api_key` and `space_id` are required for the shared config.
+
+**No Python dependencies are needed.** Both Phoenix and Arize AX use HTTP/JSON -- no additional Python dependencies are needed.
+
+Then proceed to [Configure Settings](#configure-settings). If the user is on an on-prem instance, remind them to provide their custom endpoint.
+
+## Configure Settings
+
+**Important:** Users must run this setup before tracing will work. The `send_span()` function requires `~/.arize/harness/config.yaml` to exist for backend credential resolution.
+
+### Ask the user for:
+
+1. **Backend choice**: Phoenix or Arize AX
+2. **Credentials** (only if no existing config):
+   - Phoenix: endpoint URL (default: `http://localhost:6006`), optional API key
+   - Arize AX: API key and Space ID
+3. **OTLP Endpoint** (Arize AX only, optional): For hosted Arize instances using a custom endpoint. Defaults to `otlp.arize.com:443`.
+4. **Project name** (optional): defaults to `"omp"`, stored under `harnesses.omp.project_name`
+5. **User ID** (optional): Set `ARIZE_USER_ID` env var to identify spans by user (useful for teams)
+
+### Write the config
+
+The config file at `~/.arize/harness/config.yaml` is the single source of truth for backend credentials and per-harness settings. Create the directory structure if needed: `mkdir -p ~/.arize/harness/{bin,run,logs,state/omp}`
+
+**Important: read-merge-write.** If `~/.arize/harness/config.yaml` already exists, read it first, then merge in the new or updated fields (e.g., add/update the `harnesses.omp` entry) while preserving existing backend credentials. Only prompt for backend credentials if no existing config is found.
+
+**Phoenix:**
+```yaml
+harnesses:
+  omp:
+    project_name: omp
+    target: phoenix
+    endpoint: <endpoint>
+    api_key: ""   # set when the Phoenix instance requires auth (Phoenix Cloud)
+```
+
+If Phoenix requires authentication (e.g. Phoenix Cloud), set the API key here under
+`api_key`, or export `PHOENIX_API_KEY` in the environment — it is sent as a
+`Authorization: Bearer <key>` header. The env var takes precedence over the YAML value.
+Leave `api_key: ""` for an unauthenticated local Phoenix.
+
+**Arize AX:**
+```yaml
+harnesses:
+  omp:
+    project_name: omp
+    target: arize
+    endpoint: otlp.arize.com:443
+    api_key: <key>
+    space_id: <id>
+```
+
+If the user has a custom OTLP endpoint, set it in `harnesses.omp.endpoint`.
+
+### Activate the omp hook
+
+omp does **not** auto-discover an extensions directory — the `extensions` key in `~/.omp/agent/settings.json` is an explicit array of file/dir paths omp loads ([hook docs](https://omp.sh/docs/hooks)). The installer drops the Arize hook shim at `~/.omp/extensions/arize-tracing.ts` **and** registers that absolute path in the `extensions` array, e.g.:
+
+```json
+{ "extensions": ["/Users/me/.omp/extensions/arize-tracing.ts"] }
+```
+
+omp picks up the registered extension on next launch.
+
+Install or reinstall via the installer:
+
+```bash
+./install.sh omp
+```
+
+To uninstall:
+
+```bash
+./install.sh uninstall omp
+```
+
+Uninstall removes the shim's path from the `extensions` array, deletes the hook file at `~/.omp/extensions/arize-tracing.ts` (only if it carries the Arize header marker — the installer never touches the user's own extensions), and removes the `harnesses.omp` block from `~/.arize/harness/config.yaml`.
+
+### Validate
+
+1. **Config exists**: Run `cat ~/.arize/harness/config.yaml` to verify the config file exists and has correct backend credentials under `harnesses.omp`.
+2. **Phoenix** (if applicable): Run `curl -sf <endpoint>/v1/traces >/dev/null` to check connectivity.
+3. **Hook installed**: Verify `~/.omp/extensions/arize-tracing.ts` exists and starts with the Arize header marker.
+4. **Hook registered**: Verify the shim's absolute path appears in the `extensions` array of `~/.omp/agent/settings.json` (omp does not auto-discover — registration is required).
+5. **Handler entry point**: Verify the handler binary exists at `~/.arize/harness/venv/bin/arize-hook-omp` (or `~/.arize/harness/venv/Scripts/arize-hook-omp.exe` on Windows). The shim spawns this binary by absolute path — it does not rely on PATH resolution. `install.sh` installs it as a venv entry point.
+
+### Confirm
+
+Tell the user:
+- Config saved to `~/.arize/harness/config.yaml`
+- omp hook shim installed at `~/.omp/extensions/arize-tracing.ts`
+- Shim path registered in the `extensions` array of `~/.omp/agent/settings.json` — omp requires explicit registration (no auto-discovery)
+- Spans are sent directly to the backend from the handler — no background process needed
+- After saving, open a new omp session and traces will appear in their Phoenix UI or Arize AX dashboard under the project name
+- Mention `ARIZE_DRY_RUN=true` to test without sending data (set as env var before launching omp)
+- Mention `ARIZE_VERBOSE=true` for debug output
+- Errors and handler stderr are always written to `~/.arize/harness/logs/omp.log` (the adapter redirects Python stderr there via `ARIZE_LOG_FILE`); set `ARIZE_VERBOSE=true` in the shell before launching omp to also capture routine handler activity (event dispatch, span emits, state transitions)
+- Toggle tracing on/off via `ARIZE_TRACE_ENABLED` env var (must be exported in the user's shell before launching omp — the shim and handler inherit host env vars)
+- Tail the log file at `~/.arize/harness/logs/omp.log` for real-time debugging
+- Mention `ARIZE_TRACE_DEBUG=true` to dump raw event payloads under `~/.arize/harness/state/debug/` (files are named `omp_before_agent_start_<ts>.yaml` / `omp_turn_end_<ts>.yaml` / `omp_agent_end_<ts>.yaml` / `omp_session_shutdown_<ts>.yaml`) for inspection
+
+## Architecture (How spans are produced)
+
+omp loads its extensions **in-process** inside its Bun runtime ([hook docs](https://omp.sh/docs/hooks)). Unlike opencode, omp exposes rich, **once-fired** lifecycle events that already carry final, structured data, so the Arize integration is a stateful event-forward (no snapshot reconciliation, no dedup). It is split into two pieces:
+
+1. **TypeScript hook shim** at `~/.omp/extensions/arize-tracing.ts`. A dumb bridge. On a whitelist of lifecycle events — `before_agent_start` (the prompt), `turn_end` (the completed `AssistantMessage` with inline token usage + model, plus that turn's `toolResults`), `agent_end` (run finished), and `session_shutdown` — it spawns `arize-hook-omp` detached and pipes the event payload to stdin. The shim contains no tracing logic and never blocks omp's event loop.
+2. **Python event handler** (`arize-hook-omp`). A small state machine keyed by session id. It dispatches on `payload["type"]`, accumulates per-session state, and emits `Turn`/`LLM`/`TOOL` spans on receipt. Pairs each `ToolCall` with its `ToolResultMessage` by id to build TOOL spans with both input args and output.
+
+## Span tree
+
+Each trace covers one **agent run** (one user prompt → the agent's internal turn/tool-use loop → its final answer). A run usually contains several model calls; one trace covers all of them. The tree:
+
+| Span | Kind | Description |
+|------|------|-------------|
+| `Turn` | CHAIN | Root span. `input.value` is the user prompt (from `before_agent_start`); `output.value` is the final assistant message's text. One per agent run. |
+| `LLM: <model>` | LLM | Child of `Turn`. One per `turn_end` (one per model call in the loop). Carries `llm.model_name`, `llm.provider`, prompt/completion/reasoning token counts, cache read/write tokens, and `llm.cost`. omp surfaces token usage inline on the assistant message, so it **is** captured. |
+| `<tool>` | TOOL | Child of `Turn`. One per `ToolResultMessage` in a `turn_end`, paired with its originating `ToolCall` by id. Records `tool.name`, redacted input args + output, and tool-specific attributes; errors are recorded with span status. |
+
+## Troubleshoot
+
+Common issues and fixes for omp:
+
+| Problem | Fix |
+|---------|-----|
+| Traces not appearing | Verify config exists: `cat ~/.arize/harness/config.yaml`. Check handler log: `tail -20 ~/.arize/harness/logs/omp.log`. Confirm the hook is in place: `ls ~/.omp/extensions/arize-tracing.ts`. |
+| Hook not loading | omp does **not** auto-discover an extensions dir. Confirm the shim's absolute path is in the `extensions` array of `~/.omp/agent/settings.json`, then restart omp and check its CLI output for extension errors. |
+| Handler entry point missing | The shim spawns the handler by absolute path; verify the binary exists at `~/.arize/harness/venv/bin/arize-hook-omp` (or `~/.arize/harness/venv/Scripts/arize-hook-omp.exe` on Windows). Rerun `./install.sh omp` to reinstall the venv entry point. |
+| Missing LLM or tool spans | Spans emit on `turn_end` (one LLM span per model call, one TOOL span per tool result). If a turn hasn't completed yet, its spans won't appear until the event fires. Wait for the agent run to finish (`agent_end`). |
+| Trace missing the final answer | `output.value` on the `Turn` span comes from the final assistant message. Confirm the run reached `agent_end`. |
+| Phoenix unreachable | Verify Phoenix is running: `curl -sf <endpoint>/v1/traces` |
+| Want to test without sending | Set `ARIZE_DRY_RUN=true` env var before launching omp |
+| Want verbose logging | Set `ARIZE_VERBOSE=true` env var before launching omp |
+| Want raw event payloads for inspection | Set `ARIZE_TRACE_DEBUG=true` env var; payloads land under `~/.arize/harness/state/debug/` as `omp_before_agent_start_<ts>.yaml` / `omp_turn_end_<ts>.yaml` / `omp_agent_end_<ts>.yaml` / `omp_session_shutdown_<ts>.yaml` |
+| Wrong project name | Set `harnesses.omp.project_name` in `~/.arize/harness/config.yaml` (default: `"omp"`) |
+| Spans missing user attribution | Set `ARIZE_USER_ID` env var before launching omp |
+| Tracing not toggling | Ensure `ARIZE_TRACE_ENABLED` is exported in your shell, not just set — the omp process and any shim-spawned handler inherit host env vars |

--- a/tracing/omp/skills/manage-omp-tracing/SKILL.md
+++ b/tracing/omp/skills/manage-omp-tracing/SKILL.md
@@ -14,7 +14,7 @@ Configure OpenInference tracing for **Oh My Pi (omp)** terminal coding sessions 
 1. **Is the harness already installed?**
    - Check `~/.omp/extensions/arize-tracing.ts` for the Arize hook shim
    - Check `~/.omp/agent/settings.json` for the shim's path in the `extensions` array
-   - Check `~/.arize/harness/config.yaml` for the `harnesses.omp` block
+   - Check `~/.arize/harness/config.json` for the `harnesses.omp` block
    - If all are present -> Jump to [Validate](#validate) or [Troubleshoot](#troubleshoot)
 
 2. **Do they already have credentials?**
@@ -86,7 +86,7 @@ Then proceed to [Configure Settings](#configure-settings). If the user is on an 
 
 ## Configure Settings
 
-**Important:** Users must run this setup before tracing will work. The `send_span()` function requires `~/.arize/harness/config.yaml` to exist for backend credential resolution.
+**Important:** Users must run this setup before tracing will work. The `send_span()` function requires `~/.arize/harness/config.json` to exist for backend credential resolution.
 
 ### Ask the user for:
 
@@ -100,34 +100,42 @@ Then proceed to [Configure Settings](#configure-settings). If the user is on an 
 
 ### Write the config
 
-The config file at `~/.arize/harness/config.yaml` is the single source of truth for backend credentials and per-harness settings. Create the directory structure if needed: `mkdir -p ~/.arize/harness/{bin,run,logs,state/omp}`
+The config file at `~/.arize/harness/config.json` is the single source of truth for backend credentials and per-harness settings. Create the directory structure if needed: `mkdir -p ~/.arize/harness/{bin,run,logs,state/omp}`
 
-**Important: read-merge-write.** If `~/.arize/harness/config.yaml` already exists, read it first, then merge in the new or updated fields (e.g., add/update the `harnesses.omp` entry) while preserving existing backend credentials. Only prompt for backend credentials if no existing config is found.
+**Important: read-merge-write.** If `~/.arize/harness/config.json` already exists, read it first, then merge in the new or updated fields (e.g., add/update the `harnesses.omp` entry) while preserving existing backend credentials. Only prompt for backend credentials if no existing config is found.
 
 **Phoenix:**
-```yaml
-harnesses:
-  omp:
-    project_name: omp
-    target: phoenix
-    endpoint: <endpoint>
-    api_key: ""   # set when the Phoenix instance requires auth (Phoenix Cloud)
+```json
+{
+  "harnesses": {
+    "omp": {
+      "project_name": "omp",
+      "target": "phoenix",
+      "endpoint": "<endpoint>",
+      "api_key": ""
+    }
+  }
+}
 ```
 
 If Phoenix requires authentication (e.g. Phoenix Cloud), set the API key here under
 `api_key`, or export `PHOENIX_API_KEY` in the environment — it is sent as a
-`Authorization: Bearer <key>` header. The env var takes precedence over the YAML value.
+`Authorization: Bearer <key>` header. The env var takes precedence over the config value.
 Leave `api_key: ""` for an unauthenticated local Phoenix.
 
 **Arize AX:**
-```yaml
-harnesses:
-  omp:
-    project_name: omp
-    target: arize
-    endpoint: otlp.arize.com:443
-    api_key: <key>
-    space_id: <id>
+```json
+{
+  "harnesses": {
+    "omp": {
+      "project_name": "omp",
+      "target": "arize",
+      "endpoint": "otlp.arize.com:443",
+      "api_key": "<key>",
+      "space_id": "<id>"
+    }
+  }
+}
 ```
 
 If the user has a custom OTLP endpoint, set it in `harnesses.omp.endpoint`.
@@ -154,11 +162,11 @@ To uninstall:
 ./install.sh uninstall omp
 ```
 
-Uninstall removes the shim's path from the `extensions` array, deletes the hook file at `~/.omp/extensions/arize-tracing.ts` (only if it carries the Arize header marker — the installer never touches the user's own extensions), and removes the `harnesses.omp` block from `~/.arize/harness/config.yaml`.
+Uninstall removes the shim's path from the `extensions` array, deletes the hook file at `~/.omp/extensions/arize-tracing.ts` (only if it carries the Arize header marker — the installer never touches the user's own extensions), and removes the `harnesses.omp` block from `~/.arize/harness/config.json`.
 
 ### Validate
 
-1. **Config exists**: Run `cat ~/.arize/harness/config.yaml` to verify the config file exists and has correct backend credentials under `harnesses.omp`.
+1. **Config exists**: Run `cat ~/.arize/harness/config.json` to verify the config file exists and has correct backend credentials under `harnesses.omp`.
 2. **Phoenix** (if applicable): Run `curl -sf <endpoint>/v1/traces >/dev/null` to check connectivity.
 3. **Hook installed**: Verify `~/.omp/extensions/arize-tracing.ts` exists and starts with the Arize header marker.
 4. **Hook registered**: Verify the shim's absolute path appears in the `extensions` array of `~/.omp/agent/settings.json` (omp does not auto-discover — registration is required).
@@ -167,7 +175,7 @@ Uninstall removes the shim's path from the `extensions` array, deletes the hook 
 ### Confirm
 
 Tell the user:
-- Config saved to `~/.arize/harness/config.yaml`
+- Config saved to `~/.arize/harness/config.json`
 - omp hook shim installed at `~/.omp/extensions/arize-tracing.ts`
 - Shim path registered in the `extensions` array of `~/.omp/agent/settings.json` — omp requires explicit registration (no auto-discovery)
 - Spans are sent directly to the backend from the handler — no background process needed
@@ -177,7 +185,7 @@ Tell the user:
 - Errors and handler stderr are always written to `~/.arize/harness/logs/omp.log` (the adapter redirects Python stderr there via `ARIZE_LOG_FILE`); set `ARIZE_VERBOSE=true` in the shell before launching omp to also capture routine handler activity (event dispatch, span emits, state transitions)
 - Toggle tracing on/off via `ARIZE_TRACE_ENABLED` env var (must be exported in the user's shell before launching omp — the shim and handler inherit host env vars)
 - Tail the log file at `~/.arize/harness/logs/omp.log` for real-time debugging
-- Mention `ARIZE_TRACE_DEBUG=true` to dump raw event payloads under `~/.arize/harness/state/debug/` (files are named `omp_before_agent_start_<ts>.yaml` / `omp_turn_end_<ts>.yaml` / `omp_agent_end_<ts>.yaml` / `omp_session_shutdown_<ts>.yaml`) for inspection
+- Mention `ARIZE_TRACE_DEBUG=true` to dump raw event payloads under `~/.arize/harness/state/debug/` (files are named `omp_before_agent_start_<ts>.json` / `omp_turn_end_<ts>.json` / `omp_agent_end_<ts>.json` / `omp_session_shutdown_<ts>.json`) for inspection
 
 ## Architecture (How spans are produced)
 
@@ -202,7 +210,7 @@ Common issues and fixes for omp:
 
 | Problem | Fix |
 |---------|-----|
-| Traces not appearing | Verify config exists: `cat ~/.arize/harness/config.yaml`. Check handler log: `tail -20 ~/.arize/harness/logs/omp.log`. Confirm the hook is in place: `ls ~/.omp/extensions/arize-tracing.ts`. |
+| Traces not appearing | Verify config exists: `cat ~/.arize/harness/config.json`. Check handler log: `tail -20 ~/.arize/harness/logs/omp.log`. Confirm the hook is in place: `ls ~/.omp/extensions/arize-tracing.ts`. |
 | Hook not loading | omp does **not** auto-discover an extensions dir. Confirm the shim's absolute path is in the `extensions` array of `~/.omp/agent/settings.json`, then restart omp and check its CLI output for extension errors. |
 | Handler entry point missing | The shim spawns the handler by absolute path; verify the binary exists at `~/.arize/harness/venv/bin/arize-hook-omp` (or `~/.arize/harness/venv/Scripts/arize-hook-omp.exe` on Windows). Rerun `./install.sh omp` to reinstall the venv entry point. |
 | Missing LLM or tool spans | Spans emit on `turn_end` (one LLM span per model call, one TOOL span per tool result). If a turn hasn't completed yet, its spans won't appear until the event fires. Wait for the agent run to finish (`agent_end`). |
@@ -210,7 +218,7 @@ Common issues and fixes for omp:
 | Phoenix unreachable | Verify Phoenix is running: `curl -sf <endpoint>/v1/traces` |
 | Want to test without sending | Set `ARIZE_DRY_RUN=true` env var before launching omp |
 | Want verbose logging | Set `ARIZE_VERBOSE=true` env var before launching omp |
-| Want raw event payloads for inspection | Set `ARIZE_TRACE_DEBUG=true` env var; payloads land under `~/.arize/harness/state/debug/` as `omp_before_agent_start_<ts>.yaml` / `omp_turn_end_<ts>.yaml` / `omp_agent_end_<ts>.yaml` / `omp_session_shutdown_<ts>.yaml` |
-| Wrong project name | Set `harnesses.omp.project_name` in `~/.arize/harness/config.yaml` (default: `"omp"`) |
+| Want raw event payloads for inspection | Set `ARIZE_TRACE_DEBUG=true` env var; payloads land under `~/.arize/harness/state/debug/` as `omp_before_agent_start_<ts>.json` / `omp_turn_end_<ts>.json` / `omp_agent_end_<ts>.json` / `omp_session_shutdown_<ts>.json` |
+| Wrong project name | Set `harnesses.omp.project_name` in `~/.arize/harness/config.json` (default: `"omp"`) |
 | Spans missing user attribution | Set `ARIZE_USER_ID` env var before launching omp |
 | Tracing not toggling | Ensure `ARIZE_TRACE_ENABLED` is exported in your shell, not just set — the omp process and any shim-spawned handler inherit host env vars |


### PR DESCRIPTION
# Add Oh My Pi (omp) tracing harness

## Summary

Adds a new `omp` harness that emits OpenTelemetry / OpenInference spans from the
Oh My Pi terminal coding agent. A dependency-free TypeScript shim runs in-process
inside omp's Bun runtime and forwards lifecycle events to a Python entry point,
which runs a stateful event handler that builds one trace per agent run (Turn root
with child LLM and tool spans) reusing the shared `core` infrastructure.

## Changes

- Register the `omp` harness in `core/constants.py` and wire `arize-hook-omp` /
  `arize-setup-omp` entry points in `pyproject.toml`, with `core/setup/omp.py` as
  the setup shim.
- Add the `tracing/omp/` package: `constants.py`, the session `adapter.py`, the
  stateful `handlers.py` event handler, and `install.py` for plugin install/uninstall.
- Add the TypeScript event-forward shim `tracing/omp/plugin/arize-tracing.ts` (spawns
  the Python entry point detached, no npm dependencies) and stamp the session id from
  the hook context.
- Update `install.sh` / `install.bat` shell installers and the top-level `README.md`
  to cover the new harness.
- Add harness docs (`tracing/omp/README.md`) and the `manage-omp-tracing` skill.
- Add omp test suites and fixtures covering the adapter, hook handlers, install/uninstall,
  entry-point wiring, and the shell router.

## Test plan

- [x] `uv run pytest tests/tracing/omp/ -q` passes (adapter, handlers, install).
- [x] `uv run pytest -q` passes the full suite, including entry-point and shell-router tests.
- [x] Install registers `arize-tracing.ts` in `~/.omp/agent/settings.json` "extensions"
      and drops the shim into `~/.omp/extensions/`; uninstall removes both (only when ours).
- [x] A real omp agent run produces one trace per run: a Turn root with `input.value`
      = prompt and `output.value` = final assistant text, an `LLM: <model>` span per
      `turn_end`, and a child TOOL span per tool result (errors marked `status_code=2`).
- [x] Tool input args and outputs pair correctly by `ToolCall.id` == `ToolResultMessage.toolCallId`.
- [x] `uv run pre-commit run --files <changed>` is clean (black, isort, ruff, ≤120 cols).

🤖 Generated by workbench pr_writer
