### PR TITLE
fix(claude): coalesce split assistant records into one LLM span

### DIFF
--- a/tests/tracing/claude/test_claude_transcript.py
+++ b/tests/tracing/claude/test_claude_transcript.py
@@ -107,6 +107,100 @@ def test_model_usage_and_text_are_kept_per_call():
     assert models[2].status is EventStatus.COMPLETED
 
 
+def test_split_message_id_records_coalesce_into_one_model_call(tmp_path: Path):
+    """Claude Code v2 writes one assistant response (one message.id) across
+    several records — thinking / text / each tool_use. They must fold into a
+    single ModelCallEvent, not one LLM span per record, with un-inflated usage."""
+    transcript = tmp_path / "split-message.jsonl"
+    usage = {"input_tokens": 100, "output_tokens": 20, "cache_read_input_tokens": 10}
+    rows = [
+        {
+            "type": "assistant",
+            "uuid": "rec-1",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "message": {
+                "role": "assistant",
+                "id": "msg-1",
+                "model": "claude-x",
+                "content": [{"type": "thinking", "thinking": "hmm"}],
+                "usage": usage,
+            },
+        },
+        {
+            "type": "assistant",
+            "uuid": "rec-2",
+            "timestamp": "2026-01-01T00:00:01Z",
+            "message": {
+                "role": "assistant",
+                "id": "msg-1",
+                "model": "claude-x",
+                "content": [{"type": "text", "text": "Hello"}],
+                "usage": usage,
+            },
+        },
+        {
+            "type": "assistant",
+            "uuid": "rec-3",
+            "timestamp": "2026-01-01T00:00:02Z",
+            "message": {
+                "role": "assistant",
+                "id": "msg-1",
+                "content": [{"type": "tool_use", "id": "call-1", "name": "Read", "input": {"file_path": "x"}}],
+                "usage": usage,
+            },
+        },
+        {
+            "type": "assistant",
+            "uuid": "rec-4",
+            "timestamp": "2026-01-01T00:00:03Z",
+            "message": {
+                "role": "assistant",
+                "id": "msg-1",
+                "content": [{"type": "tool_use", "id": "call-2", "name": "Bash", "input": {"command": "ls"}}],
+                "usage": usage,
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-01-01T00:00:04Z",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "call-1", "content": "ok1"}],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-01-01T00:00:05Z",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "call-2", "content": "ok2"}],
+            },
+        },
+    ]
+    transcript.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+    graph = parse_claude_transcript(transcript, _turn())
+
+    models = _typed(graph.events, ModelCallEvent)
+    tools = _typed(graph.events, ToolEvent)
+
+    # One real LLM call, not four.
+    assert len(models) == 1
+    assert models[0].event_id == "rec-1"
+    assert models[0].source_id == "msg-1"
+    assert models[0].model == "claude-x"
+    assert "Hello" in (models[0].output or "")
+    # Both tool_use blocks hang off the single coalesced call.
+    assert [tool.tool_call_id for tool in tools] == ["call-1", "call-2"]
+    assert [tool.parent_event_id for tool in tools] == ["rec-1", "rec-1"]
+    # Usage is the message's usage, not summed across the split records.
+    assert models[0].usage.input_tokens == 100
+    assert models[0].usage.output_tokens == 20
+    assert models[0].usage.cache_read_tokens == 10
+    # Span covers the full response window.
+    assert models[0].ended_at_ms > models[0].started_at_ms
+
+
 def test_start_line_excludes_prior_model_and_tool_cycles():
     graph = parse_claude_transcript(FIXTURE_DIR / "main_tool_cycle.jsonl", _turn(), start_line=3)
 

--- a/tracing/claude_code/hooks/transcript.py
+++ b/tracing/claude_code/hooks/transcript.py
@@ -36,6 +36,7 @@ def parse_claude_transcript(
     graph = EventGraph([root_event])
     parser_diagnostics: list[GraphDiagnostic] = []
     tools_by_call_id: dict[str, ToolEvent] = {}
+    models_by_message_id: dict[str, ModelCallEvent] = {}
     agent_id = root_event.agent_id if isinstance(root_event, AgentEvent) else None
     sequence = root_event.sequence + 1
 
@@ -99,24 +100,51 @@ def parse_claude_transcript(
                 )
 
             content = message.get("content")
-            model_event = ModelCallEvent(
-                event_id=event_id,
-                parent_event_id=root_event.event_id,
-                session_id=_string(entry.get("sessionId")) or root_event.session_id,
-                turn_id=root_event.turn_id,
-                sequence=sequence,
-                started_at_ms=timestamp_ms,
-                ended_at_ms=timestamp_ms,
-                status=EventStatus.COMPLETED,
-                input=None,
-                output=_assistant_text(content),
-                agent_id=agent_id,
-                source_id=_string(message.get("id")) or event_id,
-                model=_string(message.get("model")) or None,
-                usage=_usage(message.get("usage")),
-            )
-            graph.events.append(model_event)
-            sequence += 1
+            message_id = _string(message.get("id"))
+            # Claude Code v2 writes one assistant response (one message.id) as
+            # several records -- thinking / text / each tool_use on its own line,
+            # each with a distinct record uuid. Fold those back into a single
+            # ModelCallEvent keyed by message.id so one response is one LLM span,
+            # not one per block. Records with no message.id can't be grouped and
+            # stay one-event-per-record (also preserves assistant-line-* ids).
+            model_event = models_by_message_id.get(message_id) if message_id else None
+            if model_event is None:
+                model_event = ModelCallEvent(
+                    event_id=event_id,
+                    parent_event_id=root_event.event_id,
+                    session_id=_string(entry.get("sessionId")) or root_event.session_id,
+                    turn_id=root_event.turn_id,
+                    sequence=sequence,
+                    started_at_ms=timestamp_ms,
+                    ended_at_ms=timestamp_ms,
+                    status=EventStatus.COMPLETED,
+                    input=None,
+                    output=_assistant_text(content),
+                    agent_id=agent_id,
+                    source_id=message_id or event_id,
+                    model=_string(message.get("model")) or None,
+                    usage=_usage(message.get("usage")),
+                )
+                graph.events.append(model_event)
+                sequence += 1
+                if message_id:
+                    models_by_message_id[message_id] = model_event
+            else:
+                # Merge this continuation record into the existing call: append
+                # any text, extend the time window, keep the fullest usage/model.
+                extra_text = _assistant_text(content)
+                if extra_text:
+                    model_event.output = f"{model_event.output}\n{extra_text}" if model_event.output else extra_text
+                if timestamp_ms is not None:
+                    if model_event.started_at_ms is None:
+                        model_event.started_at_ms = timestamp_ms
+                    model_event.ended_at_ms = timestamp_ms
+                if not model_event.model:
+                    model_event.model = _string(message.get("model")) or None
+                record_usage = _usage(message.get("usage"))
+                existing_total = model_event.usage.total_tokens if model_event.usage else -1
+                if record_usage.total_tokens > existing_total:
+                    model_event.usage = record_usage
 
             for block in _content_blocks(content):
                 if block.get("type") != "tool_use":


### PR DESCRIPTION
## Problem
Claude Code v2 writes a single assistant response (one `message.id`) as **several** transcript records — thinking, text, and each `tool_use` block each land on their own line with a distinct record `uuid`. `parse_claude_transcript` keyed a `ModelCallEvent` per record, so one real LLM call rendered as 3–5 separate "LLM call N" spans, and per-record `usage` was multi-counted — inflating token/cost reporting.

## Fix
Group assistant records by `message.id` into a single `ModelCallEvent`:
- concatenate text blocks into the call's `output`
- parent every `tool_use` block to the one coalesced call (no orphaned tools)
- span the time window from the first to the last record
- keep the **fullest single** `usage` (max by total tokens), not the sum — Claude Code repeats cumulative usage across the split records
- records without a `message.id` stay one-event-per-record, preserving the `assistant-line-*` legacy gate and timestamp diagnostics

## Verification
- New test `test_split_message_id_records_coalesce_into_one_model_call`: 4 split records (thinking / text / 2× tool_use) → 1 model call, both tools parented to it, usage un-inflated, span covers the full window.
- Verified on a real 117-record transcript: model calls now equal the number of distinct `message.id`s, with zero orphaned tools.
- Full transcript suite passes (12 tests).

## Scope
2 files, +140 / −18 — `tracing/claude_code/hooks/transcript.py` and its test. Base branch: `feat/claude-high-fidelity-tracing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)