### PR TITLE
Honor PHOENIX_PROJECT and stop shadowing config.json project_name (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Most settings live in `.arize/harness/config.json`, but a small set of env vars 
 | `ARIZE_VERBOSE` | `false` | Enables `[arize] ...` log lines in `~/.arize/harness/logs/<harness>.log`. Errors are always logged; verbose adds routine activity (hook fires, span emits, state transitions). |
 | `ARIZE_DRY_RUN` | `false` | Build spans but skip the backend send. Useful for confirming hook wiring without writing data. |
 | `ARIZE_USER_ID` | — | Attached to every span as `user.id`. Mirrors the `user_id` field in `config.json`; env wins if both are set. |
-| `ARIZE_PROJECT_NAME` | per-harness | Overrides `harnesses.<name>.project_name` from `config.json` for a single session. |
+| `ARIZE_PROJECT_NAME` | per-harness | Overrides `harnesses.<name>.project_name` from `config.json` for a single session. **Arize backend only** — ignored on the Phoenix backend (use `PHOENIX_PROJECT` there). |
 | `ARIZE_LOG_FILE` | per-harness | Path the harness writes its log to. Adapters default to `~/.arize/harness/logs/<harness>.log`. |
 | `ARIZE_TRACE_DEBUG` | `false` | Dump raw hook payloads as JSON under `~/.arize/harness/state/<harness>/debug/`. Codex hooks use this for span-tree inspection. |
 | `OTEL_RESOURCE_ATTRIBUTES` | — | Standard OTel attribute string (`team=payments,environment=prod`) added to every span. Overrides `config.json` `attributes`/`harnesses.<name>.attributes` on key collision; set per-harness by placing it in that harness's settings env block. |
@@ -84,6 +84,7 @@ Most settings live in `.arize/harness/config.json`, but a small set of env vars 
 |----------|-------------|
 | `ARIZE_API_KEY`, `ARIZE_SPACE_ID`, `ARIZE_OTLP_ENDPOINT` | Arize AX credentials and endpoint. |
 | `PHOENIX_ENDPOINT`, `PHOENIX_API_KEY` | Phoenix endpoint and (optional) API key. |
+| `PHOENIX_PROJECT`, `PHOENIX_PROJECT_NAME` | Project override on the **Phoenix backend** (mirrors `ARIZE_PROJECT_NAME` for Arize). `PHOENIX_PROJECT` wins if both are set; both override `harnesses.<name>.project_name`. |
 
 > Claude Code plugin reads env vars from `~/.claude/settings.json` under the `env` block
 

--- a/core/common.py
+++ b/core/common.py
@@ -67,6 +67,38 @@ class _Env:
     def user_id(self) -> str:
         return self.get_user_id()
 
+    def _resolve_target(self, harness_cfg: dict) -> str:
+        """Resolve the backend target: env-derived wins over the config target.
+
+        ``PHOENIX_ENDPOINT`` → phoenix; ``ARIZE_API_KEY``+``ARIZE_SPACE_ID`` →
+        arize; otherwise ``harness_cfg['target']`` (``""`` if unset). Mirrors the
+        precedence in :func:`resolve_backend` so project-name resolution stays in
+        sync with the backend actually chosen.
+        """
+        if self.phoenix_endpoint:
+            return "phoenix"
+        if self.api_key and self.space_id:
+            return "arize"
+        return harness_cfg.get("target", "") if isinstance(harness_cfg, dict) else ""
+
+    def project_name_for(self, service_name: str = "") -> str:
+        """Resolve a harness's project name from env + config.json, target-aware.
+
+        Determines the backend target (env-derived, else the config entry) and
+        returns the framework-scoped env override (``PHOENIX_PROJECT`` /
+        ``PHOENIX_PROJECT_NAME`` on Phoenix, ``ARIZE_PROJECT_NAME`` on Arize),
+        else the config ``project_name``, else ``""``. Adapters supply their own
+        fallback (service name or cwd basename) when this returns empty.
+        """
+        harness_cfg: dict = {}
+        harnesses = self._top_level_config.get("harnesses")
+        if isinstance(harnesses, dict):
+            entry = harnesses.get(service_name)
+            if isinstance(entry, dict):
+                harness_cfg = entry
+        target = self._resolve_target(harness_cfg)
+        return resolve_project_name(target, harness_cfg)
+
     @property
     def verbose(self) -> bool:
         return os.environ.get("ARIZE_VERBOSE", "").lower() == "true"
@@ -91,6 +123,13 @@ class _Env:
     @property
     def phoenix_endpoint(self) -> str:
         return os.environ.get("PHOENIX_ENDPOINT", "")
+
+    @property
+    def phoenix_project_name(self) -> str:
+        # Phoenix-native project override, consulted only on the Phoenix backend.
+        # PHOENIX_PROJECT is the var users reach for; PHOENIX_PROJECT_NAME mirrors
+        # the Phoenix SDK's own env var. PHOENIX_PROJECT wins if both are set.
+        return os.environ.get("PHOENIX_PROJECT", "") or os.environ.get("PHOENIX_PROJECT_NAME", "")
 
     @property
     def phoenix_api_key(self) -> str:
@@ -386,6 +425,31 @@ def get_target() -> str:
     return "none"
 
 
+def resolve_project_name(target: str, harness_cfg: dict, fallback: str = "") -> str:
+    """Resolve the project name for a resolved backend target.
+
+    The env override is framework-scoped so a value configured for one backend
+    never leaks into another: the Phoenix backend honors ``PHOENIX_PROJECT``
+    then ``PHOENIX_PROJECT_NAME``; the Arize backend honors
+    ``ARIZE_PROJECT_NAME``. When the target is unknown, either generic var is
+    accepted for backward compatibility.
+
+    This is why, on the Phoenix backend, the ``ARIZE_PROJECT_NAME`` the Claude
+    Code installer historically baked into ``settings.json`` is ignored — see
+    GitHub issue #74.
+
+    Precedence: framework env var > ``harness_cfg['project_name']`` > fallback.
+    """
+    if target == "phoenix":
+        env_override = env.phoenix_project_name
+    elif target == "arize":
+        env_override = env.project_name
+    else:
+        env_override = env.project_name or env.phoenix_project_name
+    cfg_val = harness_cfg.get("project_name", "") if isinstance(harness_cfg, dict) else ""
+    return env_override or cfg_val or fallback
+
+
 def resolve_backend(span_dict: dict) -> dict:
     """Resolve backend config for a span payload.
 
@@ -395,10 +459,12 @@ def resolve_backend(span_dict: dict) -> dict:
     purely via the runtime env block in ~/.claude/settings.json.
 
     Env vars consulted:
-      - PHOENIX_ENDPOINT     → target=phoenix (overrides config target)
-      - ARIZE_API_KEY        → target=arize when paired with ARIZE_SPACE_ID
-      - ARIZE_SPACE_ID       → required for arize when env-only
-      - ARIZE_PROJECT_NAME   → project_name override
+      - PHOENIX_ENDPOINT      → target=phoenix (overrides config target)
+      - ARIZE_API_KEY         → target=arize when paired with ARIZE_SPACE_ID
+      - ARIZE_SPACE_ID        → required for arize when env-only
+      - ARIZE_PROJECT_NAME    → project_name override (Arize backend only)
+      - PHOENIX_PROJECT /
+        PHOENIX_PROJECT_NAME  → project_name override (Phoenix backend only)
 
     service_name is pulled from the span's resource attributes
     (resource.attributes[service.name]).
@@ -436,16 +502,13 @@ def resolve_backend(span_dict: dict) -> dict:
 
     harness_cfg = cfg.get("harnesses", {}).get(service_name) or {}
 
-    # Resolve project_name: env > config > service_name
-    project_name = env.project_name or harness_cfg.get("project_name", "") or service_name
+    # Resolve target first: env-derived backend takes precedence over config target
+    target = env._resolve_target(harness_cfg)
 
-    # Resolve target: env-derived backend takes precedence over config target
-    if env.phoenix_endpoint:
-        target = "phoenix"
-    elif env.api_key and env.space_id:
-        target = "arize"
-    else:
-        target = harness_cfg.get("target", "")
+    # Resolve project_name (target-aware): framework env var > config > service_name.
+    # Env override is framework-scoped so ARIZE_PROJECT_NAME can't shadow a Phoenix
+    # project (and vice versa) — see resolve_project_name / issue #74.
+    project_name = resolve_project_name(target, harness_cfg, service_name)
 
     if not target:
         error(

--- a/core/setup/codex.py
+++ b/core/setup/codex.py
@@ -28,8 +28,14 @@ def uninstall() -> None:
     _install_mod.uninstall()
 
 
-def _write_env_file(env_path: Path, target: str, credentials: dict, project_name: str = "codex") -> None:
-    """Write ~/.codex/arize-env.sh with export statements."""
+def _write_env_file(env_path: Path, target: str, credentials: dict) -> None:
+    """Write ~/.codex/arize-env.sh with export statements.
+
+    The project name is intentionally NOT baked here — it lives in config.json
+    (harnesses.codex.project_name) so edits take effect, and a baked
+    ARIZE_PROJECT_NAME would shadow config and leak into the Phoenix backend
+    (which honors PHOENIX_PROJECT instead) — see issue #74.
+    """
     env_path.parent.mkdir(parents=True, exist_ok=True)
 
     lines = ["# Arize Codex tracing environment (auto-generated)"]
@@ -44,8 +50,6 @@ def _write_env_file(env_path: Path, target: str, credentials: dict, project_name
         lines.append(f'export ARIZE_API_KEY="{credentials.get("api_key", "")}"')
         lines.append(f'export ARIZE_SPACE_ID="{credentials.get("space_id", "")}"')
         lines.append(f'export ARIZE_OTLP_ENDPOINT="{credentials.get("endpoint", "otlp.arize.com:443")}"')
-
-    lines.append(f'export ARIZE_PROJECT_NAME="{project_name}"')
 
     env_path.write_text("\n".join(lines) + "\n")
 
@@ -144,7 +148,7 @@ def _run() -> None:
             err(f"Unknown target in config: {target}")
             sys.exit(1)
 
-        _write_env_file(env_file, target, creds, project_name)
+        _write_env_file(env_file, target, creds)
         info(f"Wrote credentials to {env_file}")
     else:
         # No existing config — prompt for backend
@@ -159,7 +163,7 @@ def _run() -> None:
         info("Wrote config to ~/.arize/harness/config.json")
 
         # Write env file
-        _write_env_file(env_file, target, credentials, project_name)
+        _write_env_file(env_file, target, credentials)
         info(f"Wrote credentials to {env_file}")
 
     # Configure OTLP exporter in ~/.codex/config.toml

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -1377,7 +1377,15 @@ class TestResolveBackend:
     @pytest.fixture(autouse=True)
     def _fresh_env(self, monkeypatch):
         # Clear any inherited backend env vars so each test starts clean.
-        for key in ("ARIZE_API_KEY", "ARIZE_SPACE_ID", "PHOENIX_ENDPOINT", "PHOENIX_API_KEY", "ARIZE_PROJECT_NAME"):
+        for key in (
+            "ARIZE_API_KEY",
+            "ARIZE_SPACE_ID",
+            "PHOENIX_ENDPOINT",
+            "PHOENIX_API_KEY",
+            "ARIZE_PROJECT_NAME",
+            "PHOENIX_PROJECT",
+            "PHOENIX_PROJECT_NAME",
+        ):
             monkeypatch.delenv(key, raising=False)
 
     def _make_span(self, service_name=""):
@@ -1518,6 +1526,98 @@ class TestResolveBackend:
 
         result = resolve_backend(self._make_span("claude-code"))
         assert result["project_name"] == "from-env"
+
+    # ── framework-scoped project env vars ──────────────────────────────────
+
+    def test_phoenix_project_env_override(self, monkeypatch):
+        """PHOENIX_PROJECT sets the project on the Phoenix backend."""
+        monkeypatch.setenv("PHOENIX_PROJECT", "from-phoenix-env")
+        cfg = {
+            "harnesses": {
+                "claude-code": {
+                    "project_name": "from-config",
+                    "target": "phoenix",
+                    "endpoint": "http://localhost:6006",
+                },
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["target"] == "phoenix"
+        assert result["project_name"] == "from-phoenix-env"
+
+    def test_phoenix_project_name_env_override(self, monkeypatch):
+        """PHOENIX_PROJECT_NAME is honored on the Phoenix backend."""
+        monkeypatch.setenv("PHOENIX_PROJECT_NAME", "from-phoenix-name")
+        cfg = {
+            "harnesses": {
+                "claude-code": {
+                    "project_name": "from-config",
+                    "target": "phoenix",
+                    "endpoint": "http://localhost:6006",
+                },
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["project_name"] == "from-phoenix-name"
+
+    def test_phoenix_project_beats_phoenix_project_name(self, monkeypatch):
+        """PHOENIX_PROJECT takes precedence over PHOENIX_PROJECT_NAME."""
+        monkeypatch.setenv("PHOENIX_PROJECT", "primary")
+        monkeypatch.setenv("PHOENIX_PROJECT_NAME", "secondary")
+        cfg = {
+            "harnesses": {
+                "claude-code": {"target": "phoenix", "endpoint": "http://localhost:6006"},
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["project_name"] == "primary"
+
+    def test_arize_project_name_ignored_on_phoenix(self, monkeypatch):
+        """ARIZE_PROJECT_NAME does not affect the Phoenix backend (issue #74).
+
+        The Claude Code installer used to bake ARIZE_PROJECT_NAME into
+        settings.json; on the Phoenix backend it must be ignored so the
+        config project_name (or PHOENIX_PROJECT) wins instead.
+        """
+        monkeypatch.setenv("ARIZE_PROJECT_NAME", "claude-code")
+        cfg = {
+            "harnesses": {
+                "claude-code": {
+                    "project_name": "my-phoenix-project",
+                    "target": "phoenix",
+                    "endpoint": "http://localhost:6006",
+                },
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["project_name"] == "my-phoenix-project"
+
+    def test_phoenix_project_ignored_on_arize(self, monkeypatch):
+        """PHOENIX_PROJECT does not affect the Arize backend."""
+        monkeypatch.setenv("PHOENIX_PROJECT", "phoenix-only")
+        cfg = {
+            "harnesses": {
+                "claude-code": {
+                    "project_name": "arize-project",
+                    "target": "arize",
+                    "api_key": "ak",
+                    "space_id": "sp",
+                },
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["target"] == "arize"
+        assert result["project_name"] == "arize-project"
 
     # ── env-overrides-config precedence ────────────────────────────────────
 

--- a/tests/core/test_setup.py
+++ b/tests/core/test_setup.py
@@ -568,7 +568,8 @@ class TestCodexWriteEnvFile:
         assert "export ARIZE_TRACE_ENABLED=true" in content
         assert 'export PHOENIX_ENDPOINT="http://localhost:6006"' in content
         assert "PHOENIX_API_KEY" not in content  # empty api_key should be skipped
-        assert 'export ARIZE_PROJECT_NAME="codex"' in content
+        # project_name lives in config.json only; not baked into the env file (#74).
+        assert "ARIZE_PROJECT_NAME" not in content
 
     def test_phoenix_env_file_with_api_key(self, tmp_path):
         """Env file for Phoenix with API key includes it."""
@@ -600,7 +601,8 @@ class TestCodexWriteEnvFile:
         assert 'export ARIZE_API_KEY="test-key"' in content
         assert 'export ARIZE_SPACE_ID="test-space"' in content
         assert 'export ARIZE_OTLP_ENDPOINT="otlp.arize.com:443"' in content
-        assert 'export ARIZE_PROJECT_NAME="codex"' in content
+        # project_name lives in config.json only; not baked into the env file (#74).
+        assert "ARIZE_PROJECT_NAME" not in content
 
     def test_env_file_creates_parent_dir(self, tmp_path):
         """_write_env_file creates parent directories."""

--- a/tests/core/test_setup.py
+++ b/tests/core/test_setup.py
@@ -520,7 +520,8 @@ class TestClaudeSetup:
         # settings.json should have hooks and env vars
         result = json.loads(settings_file.read_text())
         assert result["env"]["ARIZE_TRACE_ENABLED"] == "true"
-        assert result["env"]["ARIZE_PROJECT_NAME"] == "claude-code"
+        # project_name lives in config.json only; not baked into settings.json (#74).
+        assert "ARIZE_PROJECT_NAME" not in result["env"]
         assert len(result.get("hooks", {})) == 16
 
     def test_run_arize_flow(self, tmp_path, monkeypatch):

--- a/tests/tracing/claude/test_claude_adapter.py
+++ b/tests/tracing/claude/test_claude_adapter.py
@@ -139,6 +139,49 @@ class TestEnsureSessionInitialized:
         adapter.ensure_session_initialized(sm, {"cwd": "/home/user/my-project"})
         assert sm.get("project_name") == "my-project"
 
+    def test_project_name_from_config(self, claude_state_dir, monkeypatch):
+        """config.json project_name is used when no env override is set (issue #74)."""
+        from core.common import env as core_env
+
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        cfg = {"harnesses": {"claude-code": {"project_name": "from-config", "target": "phoenix"}}}
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+        core_env.invalidate_caches()
+
+        sm = self._make_state(claude_state_dir, "proj-config")
+        adapter.ensure_session_initialized(sm, {"cwd": "/home/user/other-project"})
+        assert sm.get("project_name") == "from-config"
+
+    def test_phoenix_project_env_used_on_phoenix_config(self, claude_state_dir, monkeypatch):
+        """On the Phoenix backend, PHOENIX_PROJECT wins over config project_name."""
+        from core.common import env as core_env
+
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        monkeypatch.setenv("PHOENIX_PROJECT", "from-phoenix-env")
+        cfg = {"harnesses": {"claude-code": {"project_name": "from-config", "target": "phoenix"}}}
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+        core_env.invalidate_caches()
+
+        sm = self._make_state(claude_state_dir, "proj-phoenix-env")
+        adapter.ensure_session_initialized(sm, {"cwd": "/home/user/other-project"})
+        assert sm.get("project_name") == "from-phoenix-env"
+
+    def test_arize_project_name_ignored_on_phoenix_config(self, claude_state_dir, monkeypatch):
+        """A baked ARIZE_PROJECT_NAME does not shadow config on the Phoenix backend (issue #74)."""
+        from core.common import env as core_env
+
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.setenv("ARIZE_PROJECT_NAME", "claude-code")  # installer's baked default
+        cfg = {"harnesses": {"claude-code": {"project_name": "my-phoenix-project", "target": "phoenix"}}}
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+        core_env.invalidate_caches()
+
+        sm = self._make_state(claude_state_dir, "proj-arize-ignored")
+        adapter.ensure_session_initialized(sm, {"cwd": "/home/user/other-project"})
+        assert sm.get("project_name") == "my-phoenix-project"
+
     def test_user_id_from_env(self, claude_state_dir, monkeypatch):
         """ARIZE_USER_ID env var takes priority over input."""
         monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")

--- a/tests/tracing/claude/test_install_claude.py
+++ b/tests/tracing/claude/test_install_claude.py
@@ -134,7 +134,9 @@ class TestFreshInstall:
 
         env = settings.get("env", {})
         assert env.get("ARIZE_TRACE_ENABLED") == "true"
-        assert env.get("ARIZE_PROJECT_NAME") == "claude-code"
+        # project_name lives in config.json only; baking ARIZE_PROJECT_NAME here
+        # used to shadow config.json edits and leak into the Phoenix backend (#74).
+        assert "ARIZE_PROJECT_NAME" not in env
 
     def test_install_fresh_writes_flat_harness_entry(self, fake_home, monkeypatch):
         """Fresh install writes all backend fields directly under harnesses.claude-code."""

--- a/tests/tracing/codex/test_codex_hook.py
+++ b/tests/tracing/codex/test_codex_hook.py
@@ -348,6 +348,29 @@ class TestBuildAndSendSpans:
             side_effect=lambda p: (sent.append(p), True)[1],
         )
 
+    def test_project_name_from_config(self, monkeypatch):
+        """project.name comes from config.json when no env override is set (#74)."""
+        from core.common import env as core_env
+
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        cfg = {"harnesses": {"codex": {"project_name": "from-config", "target": "phoenix"}}}
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+        core_env.invalidate_caches()
+
+        turn = {
+            "trace_count": 1,
+            "turn_start_ms": 1000,
+            "turn_end_ms": 2000,
+            "user_prompt": "hi",
+            "assistant_output": "hello",
+        }
+        sent, patcher = self._send_capture()
+        with patcher:
+            _build_and_send_spans("sess-1", "turn-1", turn)
+
+        parent_attrs = _attrs_of_span(sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
+        assert parent_attrs["project.name"]["stringValue"] == "from-config"
+
     def test_multi_span_with_one_tool(self, monkeypatch):
         monkeypatch.setenv("ARIZE_PROJECT_NAME", "codex")
         turn = {

--- a/tests/tracing/copilot/test_copilot_adapter.py
+++ b/tests/tracing/copilot/test_copilot_adapter.py
@@ -163,6 +163,20 @@ class TestEnsureSessionInitialized:
         adapter.ensure_session_initialized(sm, {"cwd": "/home/user/other-project"})
         assert sm.get("project_name") == "my-env-project"
 
+    def test_project_name_from_config(self, copilot_state_dir, monkeypatch):
+        """config.json project_name is honored when no env override is set (#74)."""
+        from core.common import env as core_env
+
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        cfg = {"harnesses": {"copilot": {"project_name": "from-config", "target": "phoenix"}}}
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+        core_env.invalidate_caches()
+
+        sm = self._make_state(copilot_state_dir, "proj-config")
+        adapter.ensure_session_initialized(sm, {"cwd": "/home/user/other-project"})
+        assert sm.get("project_name") == "from-config"
+
     def test_project_name_from_cwd_input(self, copilot_state_dir, disable_env_vars):
         """project_name from input cwd -> basename extracted."""
         sm = self._make_state(copilot_state_dir, "proj-cwd")

--- a/tests/tracing/cursor/test_cursor_hook.py
+++ b/tests/tracing/cursor/test_cursor_hook.py
@@ -2330,3 +2330,68 @@ class TestDeferredLlmSpan:
         assert llm_attrs["session.id"]["stringValue"] == "conv-abc"
         assert llm_attrs["cursor.conversation.id"]["stringValue"] == "conv-abc"
         assert llm_attrs["user.id"]["stringValue"] == "alice@example.com"
+
+
+# ---------------------------------------------------------------------------
+# project.name injection
+# ---------------------------------------------------------------------------
+
+
+class TestProjectNameInjection:
+    """project.name is injected onto every Cursor span, target-aware (issue #74)."""
+
+    def _drive_and_capture(self, monkeypatch, event="beforeSubmitPrompt"):
+        """Run a handler with the inner backend sender mocked so the send_span
+        wrapper (which injects project.name) actually runs, and return the spans."""
+        sent = []
+        with (
+            mock.patch(
+                "tracing.cursor.hooks.handlers._send_span_to_backend",
+                side_effect=lambda s: sent.append(s) or True,
+            ),
+            mock.patch("tracing.cursor.hooks.handlers.get_timestamp_ms", return_value=5000),
+        ):
+            _dispatch(
+                event,
+                {
+                    "hookEventName": event,
+                    "conversation_id": "c1",
+                    "generation_id": "g1",
+                    "prompt": "hi",
+                },
+            )
+        return sent
+
+    def test_project_name_from_config_injected(self, monkeypatch):
+        """config.json project_name lands on the span when no env override is set."""
+        from core.common import env as core_env
+
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        cfg = {"harnesses": {"cursor": {"project_name": "from-config", "target": "phoenix"}}}
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+        core_env.invalidate_caches()
+
+        sent = self._drive_and_capture(monkeypatch)
+
+        assert len(sent) == 1
+        span = sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert attrs["project.name"]["stringValue"] == "from-config"
+
+    def test_phoenix_project_env_injected(self, monkeypatch):
+        """On the Phoenix backend, PHOENIX_PROJECT wins over config project_name."""
+        from core.common import env as core_env
+
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        monkeypatch.setenv("PHOENIX_PROJECT", "from-phoenix-env")
+        cfg = {"harnesses": {"cursor": {"project_name": "from-config", "target": "phoenix"}}}
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+        core_env.invalidate_caches()
+
+        sent = self._drive_and_capture(monkeypatch)
+
+        span = sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert attrs["project.name"]["stringValue"] == "from-phoenix-env"

--- a/tests/tracing/gemini/test_gemini_adapter.py
+++ b/tests/tracing/gemini/test_gemini_adapter.py
@@ -185,6 +185,21 @@ class TestEnsureSessionInitialized:
         adapter.ensure_session_initialized(sm, {"cwd": "/home/user/other-project"})
         assert sm.get("project_name") == "my-env-project"
 
+    def test_project_name_from_config(self, gemini_state_dir, monkeypatch):
+        """config.json project_name is honored when no env override is set (#74)."""
+        from core.common import env as core_env
+
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        monkeypatch.delenv("GEMINI_SESSION_ID", raising=False)
+        cfg = {"harnesses": {"gemini": {"project_name": "from-config", "target": "phoenix"}}}
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+        core_env.invalidate_caches()
+
+        sm = self._make_state(gemini_state_dir, "proj-config")
+        adapter.ensure_session_initialized(sm, {"cwd": "/home/user/other-project"})
+        assert sm.get("project_name") == "from-config"
+
     def test_project_name_from_cwd(self, gemini_state_dir, disable_env_vars):
         """project_name falls back to basename of cwd."""
         sm = self._make_state(gemini_state_dir, "proj-cwd")

--- a/tests/tracing/kiro/test_kiro_adapter.py
+++ b/tests/tracing/kiro/test_kiro_adapter.py
@@ -189,6 +189,21 @@ class TestEnsureSessionInitialized:
         adapter.ensure_session_initialized(sm, {"session_id": "s1", "cwd": "/foo/bar/other"})
         assert sm.get("project_name") == "my-proj"
 
+    def test_project_name_from_config(self, kiro_state_dir, monkeypatch):
+        """config.json project_name is honored when no env override is set (#74)."""
+        from core.common import env as core_env
+
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        monkeypatch.delenv("KIRO_SESSION_ID", raising=False)
+        cfg = {"harnesses": {"kiro": {"project_name": "from-config", "target": "phoenix"}}}
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+        core_env.invalidate_caches()
+
+        sm = self._make_state(kiro_state_dir, "proj-config")
+        adapter.ensure_session_initialized(sm, {"session_id": "s1", "cwd": "/foo/bar/other"})
+        assert sm.get("project_name") == "from-config"
+
     def test_project_name_falls_back_to_cwd_basename(self, kiro_state_dir, disable_env_vars):
         """project_name uses basename of cwd from payload when env var not set."""
         sm = self._make_state(kiro_state_dir, "proj-cwd")

--- a/tests/tracing/omp/test_omp_adapter.py
+++ b/tests/tracing/omp/test_omp_adapter.py
@@ -229,6 +229,20 @@ class TestEnsureSessionInitialized:
         adapter.ensure_session_initialized(sm, {"sessionId": "ses_e"})
         assert sm.get("project_name") == "my-env-project"
 
+    def test_project_name_from_config(self, omp_state_dir, monkeypatch):
+        """config.json project_name is honored when no env override is set (#74)."""
+        from core.common import env as core_env
+
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        cfg = {"harnesses": {"omp": {"project_name": "from-config", "target": "phoenix"}}}
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+        core_env.invalidate_caches()
+
+        sm = self._make_state(omp_state_dir, "proj-config")
+        adapter.ensure_session_initialized(sm, {"sessionId": "ses_cfg"})
+        assert sm.get("project_name") == "from-config"
+
     def test_project_name_fallback_to_cwd_basename(self, omp_state_dir, disable_env_vars):
         """project_name falls back to basename of os.getcwd() when no env value."""
         sm = self._make_state(omp_state_dir, "proj-fallback")

--- a/tests/tracing/opencode/test_opencode_adapter.py
+++ b/tests/tracing/opencode/test_opencode_adapter.py
@@ -212,6 +212,32 @@ class TestEnsureSessionInitialized:
         adapter.ensure_session_initialized(sm, payload)
         assert sm.get("project_name") == "my-env-project"
 
+    def test_project_name_from_config(self, opencode_state_dir, monkeypatch):
+        """config.json project_name is honored when no env override is set (#74)."""
+        from core.common import env as core_env
+
+        monkeypatch.setenv("ARIZE_TRACE_ENABLED", "true")
+        monkeypatch.delenv("ARIZE_PROJECT_NAME", raising=False)
+        cfg = {"harnesses": {"opencode": {"project_name": "from-config", "target": "phoenix"}}}
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+        core_env.invalidate_caches()
+
+        sm = self._make_state(opencode_state_dir, "proj-config")
+        payload = {
+            "sessionID": "ses_cfg",
+            "messages": [
+                {
+                    "info": {
+                        "role": "assistant",
+                        "path": {"cwd": "/home/user/other-project", "root": "/home/user"},
+                    },
+                    "parts": [],
+                }
+            ],
+        }
+        adapter.ensure_session_initialized(sm, payload)
+        assert sm.get("project_name") == "from-config"
+
     def test_project_name_from_snapshot_cwd(self, opencode_state_dir, disable_env_vars):
         """project_name uses basename of the snapshot message path.cwd."""
         sm = self._make_state(opencode_state_dir, "proj-cwd")

--- a/tracing/claude_code/hooks/adapter.py
+++ b/tracing/claude_code/hooks/adapter.py
@@ -119,7 +119,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     Sets the following state keys (matching bash lines 71-82):
     - session_id: from input_json or generate_trace_id()
     - session_start_time: get_timestamp_ms() as string
-    - project_name: from ARIZE_PROJECT_NAME env, or basename of input_json["cwd"], or cwd
+    - project_name: framework-scoped env override or config.json, else basename of input_json["cwd"], or cwd
     - trace_count: "0"
     - tool_count: "0"
     - user_id: from env.get_user_id(SERVICE_NAME), then input_json["user_id"], then ""
@@ -134,8 +134,11 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     if not session_id:
         session_id = generate_trace_id()
 
-    # project_name
-    project_name = env.project_name
+    # project_name: framework-scoped env override > config.json > cwd basename.
+    # Reading config here (rather than only env.project_name) means edits to
+    # harnesses.claude-code.project_name take effect and PHOENIX_PROJECT is
+    # honored on the Phoenix backend — see issue #74.
+    project_name = env.project_name_for(SERVICE_NAME)
     if not project_name:
         cwd = input_json.get("cwd", "")
         project_name = os.path.basename(cwd) if cwd else os.path.basename(os.getcwd())

--- a/tracing/claude_code/install.py
+++ b/tracing/claude_code/install.py
@@ -75,7 +75,7 @@ def install(with_skills: bool = False) -> None:
     else:
         info("Using existing logging settings from config.json")
 
-    _register_claude_hooks(project_name)
+    _register_claude_hooks()
     if with_skills:
         symlink_skills(HARNESS_NAME)
     info(f"Claude Code tracing installed ({SETTINGS_FILE})")
@@ -105,7 +105,7 @@ def _save_settings(settings: dict) -> None:
     SETTINGS_FILE.write_text(json.dumps(settings, indent=2) + "\n")
 
 
-def _register_claude_hooks(project_name: str = HARNESS_NAME) -> None:
+def _register_claude_hooks() -> None:
     """Read SETTINGS_FILE (or init to {}), add plugin reference + hook commands.
 
     Registering the local plugin (path → ~/.arize/harness/tracing/claude_code)
@@ -129,10 +129,12 @@ def _register_claude_hooks(project_name: str = HARNESS_NAME) -> None:
     if not has_plugin:
         plugins.append({"type": "local", "path": plugin_dir})
 
-    # Set env vars (only if absent)
+    # Set env vars (only if absent). We deliberately do NOT bake
+    # ARIZE_PROJECT_NAME here: the project name lives in config.json
+    # (harnesses.claude-code.project_name) so edits there take effect, and a
+    # baked env var would otherwise shadow config and leak into the Phoenix
+    # backend (which honors PHOENIX_PROJECT instead) — see issue #74.
     env_block = settings.setdefault("env", {})
-    if not env_block.get("ARIZE_PROJECT_NAME"):
-        env_block["ARIZE_PROJECT_NAME"] = project_name
     env_block.setdefault("ARIZE_TRACE_ENABLED", "true")
 
     # Register hooks

--- a/tracing/codex/hooks/handlers.py
+++ b/tracing/codex/hooks/handlers.py
@@ -336,7 +336,7 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
 
 def _build_and_send_spans(thread_id: str, turn_id: str, turn: dict) -> None:
     """Assemble the LLM + TOOL spans from an extracted turn and ship them."""
-    project_name = env.project_name or "codex"
+    project_name = env.project_name_for(SERVICE_NAME) or "codex"
     user_id = env.get_user_id(SERVICE_NAME) or ""
 
     trace_id = generate_trace_id()
@@ -494,7 +494,7 @@ def _send_legacy_single_span(thread_id: str, turn_id: str, input_json: dict) -> 
 
     attrs = {
         "session.id": thread_id,
-        "project.name": env.project_name or "codex",
+        "project.name": env.project_name_for(SERVICE_NAME) or "codex",
         "openinference.span.kind": "LLM",
         "input.value": user_prompt,
         "output.value": final_output,

--- a/tracing/copilot/hooks/adapter.py
+++ b/tracing/copilot/hooks/adapter.py
@@ -124,7 +124,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     State keys set:
       session_id          -- input_json["session_id"] (always populated by Copilot)
       session_start_time  -- get_timestamp_ms() as string
-      project_name        -- env.project_name, else basename(input_json["cwd"]),
+      project_name        -- framework-scoped env override or config.json, else basename(input_json["cwd"]),
                              else basename(getcwd())
       trace_count         -- "0"
       tool_count          -- "0"
@@ -135,7 +135,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
 
     session_id = input_json.get("session_id", "") or generate_trace_id()
 
-    project_name = env.project_name
+    project_name = env.project_name_for(SERVICE_NAME)
     if not project_name:
         cwd = input_json.get("cwd", "")
         project_name = os.path.basename(cwd) if cwd else os.path.basename(os.getcwd())

--- a/tracing/cursor/hooks/handlers.py
+++ b/tracing/cursor/hooks/handlers.py
@@ -8,9 +8,11 @@ stdout: MUST print permissive JSON response, even on error.
 stderr: redirected to ARIZE_LOG_FILE before dispatch.
 """
 import json
+import os
 import sys
 
-from core.common import build_span, env, error, get_timestamp_ms, log, redact_content, send_span
+from core.common import build_span, env, error, get_timestamp_ms, log, redact_content
+from core.common import send_span as _send_span_to_backend
 from tracing.cursor.hooks.adapter import (
     SCOPE_NAME,
     SERVICE_NAME,
@@ -24,6 +26,37 @@ from tracing.cursor.hooks.adapter import (
     state_push,
     trace_id_from_generation,
 )
+
+# ---------------------------------------------------------------------------
+# Span send (with project.name injection)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_project_name() -> str:
+    """Project name for Cursor spans: framework env override or config.json,
+    else cwd basename, else the service name.
+
+    Cursor builds many span dicts across 15 handlers and keeps no per-session
+    project state, so it resolves the project centrally at send time — matching
+    the framework-scoped resolution the other harnesses do in their adapters.
+    """
+    return env.project_name_for(SERVICE_NAME) or os.path.basename(os.getcwd()) or SERVICE_NAME
+
+
+def send_span(payload: dict) -> bool:
+    """Inject ``project.name`` onto every span in the payload, then send.
+
+    Wraps ``core.common.send_span`` so all handler send sites get the attribute
+    without threading project name through each attrs dict.
+    """
+    project_name = _resolve_project_name()
+    attr = {"key": "project.name", "value": {"stringValue": project_name}}
+    for rs in payload.get("resourceSpans", []):
+        for ss in rs.get("scopeSpans", []):
+            for span in ss.get("spans", []):
+                span.setdefault("attributes", []).append(attr)
+    return _send_span_to_backend(payload)
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tracing/gemini/hooks/adapter.py
+++ b/tracing/gemini/hooks/adapter.py
@@ -143,7 +143,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     )
 
     # project_name
-    project_name = env.project_name
+    project_name = env.project_name_for(SERVICE_NAME)
     if not project_name:
         cwd = input_json.get("projectDir") or input_json.get("cwd", "")
         project_name = os.path.basename(cwd) if cwd else os.path.basename(os.getcwd())

--- a/tracing/kiro/hooks/adapter.py
+++ b/tracing/kiro/hooks/adapter.py
@@ -78,7 +78,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
     # users find a Kiro session in Arize. NEVER substitute a fresh trace ID.
     session_id = input_json.get("session_id") or os.environ.get("KIRO_SESSION_ID") or ""
 
-    project_name = env.project_name
+    project_name = env.project_name_for(SERVICE_NAME)
     if not project_name:
         cwd = input_json.get("cwd", "") or os.getcwd()
         project_name = os.path.basename(cwd) if cwd else HARNESS_NAME

--- a/tracing/omp/hooks/adapter.py
+++ b/tracing/omp/hooks/adapter.py
@@ -10,7 +10,8 @@ runs cannot collide on a single shared state file.
 
 Unlike opencode there is no snapshot/message payload to mine for the project
 name, so the derivation chain is simply
-``env.project_name`` -> ``os.path.basename(os.getcwd())`` -> ``HARNESS_NAME``.
+``env.project_name_for(SERVICE_NAME)`` (framework env override or config.json)
+-> ``os.path.basename(os.getcwd())`` -> ``HARNESS_NAME``.
 """
 from __future__ import annotations
 
@@ -83,7 +84,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
 
     session_id = _session_key(input_json)
 
-    project_name = env.project_name
+    project_name = env.project_name_for(SERVICE_NAME)
     if not project_name:
         project_name = os.path.basename(os.getcwd()) or HARNESS_NAME
 

--- a/tracing/opencode/hooks/adapter.py
+++ b/tracing/opencode/hooks/adapter.py
@@ -83,7 +83,7 @@ def ensure_session_initialized(state: StateManager, input_json: dict) -> None:
 
     session_id = input_json.get("sessionID") or "unknown"
 
-    project_name = env.project_name
+    project_name = env.project_name_for(SERVICE_NAME)
     if not project_name:
         project_name = _project_name_from_snapshot(input_json) or os.path.basename(os.getcwd())
 


### PR DESCRIPTION
Fixes #74.

## Problem

Two related project-name resolution bugs:

1. **`PHOENIX_PROJECT` was ignored.** Project name was resolved only from `ARIZE_PROJECT_NAME` → config → `service_name`, so on the Phoenix backend traces landed in the default project even when `PHOENIX_PROJECT` was set.
2. **`config.json`'s `project_name` was shadowed.** The Claude Code installer baked `ARIZE_PROJECT_NAME` into `~/.claude/settings.json` (and the legacy Codex wizard baked it into `~/.codex/arize-env.sh`), so that env var always won — masking config edits and any `PHOENIX_PROJECT`.

## Fix (target-scoped resolution, applied across ALL harnesses)

Only the active backend's own env var is consulted, so a value set for one backend never leaks into another:

- **Phoenix** → `PHOENIX_PROJECT`, then `PHOENIX_PROJECT_NAME`
- **Arize** → `ARIZE_PROJECT_NAME`
- else `harnesses.<name>.project_name` from `config.json`, else `service_name` / cwd basename

Precedence per backend: framework env var > `config.json` project_name > fallback. The target is resolved before the project name (env-derived backend > config target).

### Core
- `core/common.py`: new `phoenix_project_name` env property, module-level `resolve_project_name(target, harness_cfg, fallback)`, and `env.project_name_for()` / `env._resolve_target()` helpers; `resolve_backend` resolves target first, then project name. This alone fixes routing for **every** harness (shared code path).

### Per-harness `project.name` span attribute
- Claude Code, Copilot, Gemini, Kiro, omp, OpenCode adapters + Codex handlers now resolve `project.name` via `env.project_name_for(SERVICE_NAME)` (config- and framework-aware) instead of `env.project_name` only.
- Cursor previously emitted no `project.name` attribute (it routed only via `resolve_backend`). A `send_span` wrapper in the Cursor handler now injects `project.name` (target-aware via `env.project_name_for`) onto every span across all 15 handler send sites.

### Installers (stop baking `ARIZE_PROJECT_NAME`)
- `tracing/claude_code/install.py`: no longer bakes `ARIZE_PROJECT_NAME` into `settings.json`.
- `core/setup/codex.py`: legacy `arize-setup-codex` wizard no longer bakes it into `~/.codex/arize-env.sh`.
- (`tracing/codex/install.py` and all other harness installers already write project name to `config.json` only.)
- `ARIZE_PROJECT_NAME` stays in Claude Code's `ARIZE_ENV_KEYS` so uninstall still cleans it from pre-existing installs.

### Docs
- `README.md`: documents `PHOENIX_PROJECT` / `PHOENIX_PROJECT_NAME` and clarifies `ARIZE_PROJECT_NAME` is Arize-only.

## Tests
- Target-scoped resolution coverage in `tests/core/test_common.py` (incl. the exact issue-#74 scenario: baked `ARIZE_PROJECT_NAME` ignored on Phoenix).
- Per-harness `test_project_name_from_config` tests added for claude_code, copilot, gemini, kiro, omp, opencode, and codex handlers (all written failing-first).
- Updated install tests that asserted the old baked env var (Claude settings.json + Codex env file).
- Full suite green (2035 passed); all pre-commit hooks (black/isort/ruff/mypy) pass.


## Behavior note: backend target precedence
Target resolution (shared by routing and project-name resolution) prefers an **env-derived backend** over the `config.json` `target` field: if `PHOENIX_ENDPOINT`, or `ARIZE_API_KEY`+`ARIZE_SPACE_ID`, are set in the environment, they win over `target` in config. Only when none of those env vars are set is `config.json`'s `target` used. This mirrors the long-standing `resolve_backend` precedence, so the backend that decides *which* project env var applies (`PHOENIX_PROJECT` vs `ARIZE_PROJECT_NAME`) is always the backend traces actually route to. Consequence: an unrelated env export of Arize/Phoenix credentials can flip the backend even if `config.json` declares a different `target`. Keeping this as-is for now.
