### PR TITLE
fix(claude_code): dedup per-request token usage in transcript scan

### DIFF
--- a/tests/tracing/claude/test_claude_hook.py
+++ b/tests/tracing/claude/test_claude_hook.py
@@ -733,6 +733,110 @@ class TestScanTranscriptForUsage:
         assert usage.cache_read == 20
         assert usage.cache_write == 30
 
+    def test_duplicate_request_records_counted_once(self, tmp_path):
+        """A streamed response writes one record per content block, each
+        repeating the same usage snapshot — one API call must be billed once,
+        while the text of every content block is still concatenated."""
+        tf = tmp_path / "dup.jsonl"
+        usage_snapshot = {
+            "input_tokens": 10,
+            "cache_read_input_tokens": 20,
+            "cache_creation_input_tokens": 30,
+            "output_tokens": 40,
+        }
+        lines = [
+            json.dumps(
+                {
+                    "requestId": "req_1",
+                    "message": {
+                        "id": "msg_1",
+                        "role": "assistant",
+                        "content": text,
+                        "model": "m",
+                        "usage": usage_snapshot,
+                    },
+                }
+            )
+            for text in ("first block", "second block", "third block")
+        ]
+        tf.write_text("\n".join(lines) + "\n")
+        output, usage, model = _scan_transcript_for_usage(tf, 0)
+        assert output == "first block\nsecond block\nthird block"
+        assert usage.prompt == 60  # 10 + 20 + 30, once — not three times
+        assert usage.completion == 40
+        assert usage.cache_read == 20
+        assert usage.cache_write == 30
+
+    def test_partial_then_final_snapshot_last_record_wins(self, tmp_path):
+        """Some harness versions write partial usage snapshots before the
+        final one; the last record for a request is authoritative."""
+        tf = tmp_path / "partial.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "requestId": "req_1",
+                    "message": {
+                        "id": "msg_1",
+                        "role": "assistant",
+                        "content": "x",
+                        "model": "m",
+                        "usage": {"input_tokens": 10, "output_tokens": 2},
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "requestId": "req_1",
+                    "message": {
+                        "id": "msg_1",
+                        "role": "assistant",
+                        "content": "y",
+                        "model": "m",
+                        "usage": {"input_tokens": 10, "output_tokens": 31979},
+                    },
+                }
+            ),
+        ]
+        tf.write_text("\n".join(lines) + "\n")
+        output, usage, model = _scan_transcript_for_usage(tf, 0)
+        assert usage.completion == 31979
+        assert usage.prompt == 10
+
+    def test_distinct_requests_are_summed(self, tmp_path):
+        """Different API calls (distinct requestIds) still accumulate."""
+        tf = tmp_path / "distinct.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "requestId": f"req_{n}",
+                    "message": {
+                        "id": f"msg_{n}",
+                        "role": "assistant",
+                        "content": "x",
+                        "model": "m",
+                        "usage": {"input_tokens": 10, "output_tokens": n},
+                    },
+                }
+            )
+            for n in (1, 2)
+        ]
+        tf.write_text("\n".join(lines) + "\n")
+        output, usage, model = _scan_transcript_for_usage(tf, 0)
+        assert usage.completion == 3
+        assert usage.prompt == 20
+
+    def test_records_without_identity_counted_individually(self, tmp_path):
+        """Records with neither requestId nor message.id can't be correlated,
+        so each one counts (matches the pre-dedup behavior for such records)."""
+        tf = tmp_path / "noid.jsonl"
+        lines = [
+            json.dumps({"message": {"role": "assistant", "content": "a", "model": "m", "usage": {"output_tokens": 1}}}),
+            json.dumps({"message": {"role": "assistant", "content": "b", "model": "m", "usage": {"output_tokens": 2}}}),
+        ]
+        tf.write_text("\n".join(lines) + "\n")
+        output, usage, model = _scan_transcript_for_usage(tf, 0)
+        assert usage.completion == 3
+
 
 # ---------------------------------------------------------------------------
 # subagent_stop tests

--- a/tracing/claude_code/hooks/handlers.py
+++ b/tracing/claude_code/hooks/handlers.py
@@ -401,6 +401,15 @@ def _scan_transcript_for_usage(
     usage_totals = _TokenUsage()
     model = ""
 
+    # A streamed API response is written to the transcript as one assistant
+    # record per content block, and every record of that response repeats the
+    # same usage snapshot (same requestId / message.id). Summing each record
+    # would bill one API call several times (2-3x on real transcripts), so
+    # usage is collected per request and the last record wins — on older
+    # harness versions the earlier snapshots are partial and the final one is
+    # authoritative. Records with no identity at all are counted individually.
+    last_usage: "dict[object, dict]" = {}
+
     with open(transcript) as f:
         for i, line in enumerate(f):
             if i < start_line:
@@ -430,20 +439,25 @@ def _scan_transcript_for_usage(
 
             model = msg.get("model", "") or model
 
-            # Anthropic reports input_tokens (uncached), cache_read_input_tokens,
-            # and cache_creation_input_tokens as disjoint buckets. The prompt
-            # total is their sum (the OpenInference total), while the two cache
-            # buckets are tracked separately and surfaced as prompt_details so
-            # downstream cost pricing can apply the cheaper cache-read /
-            # cache-write rates instead of the full input rate.
-            usage = msg.get("usage", {})
-            uncached = _usage_int(usage, "input_tokens")
-            cache_read = _usage_int(usage, "cache_read_input_tokens")
-            cache_write = _usage_int(usage, "cache_creation_input_tokens")
-            usage_totals.prompt += uncached + cache_read + cache_write
-            usage_totals.cache_read += cache_read
-            usage_totals.cache_write += cache_write
-            usage_totals.completion += _usage_int(usage, "output_tokens")
+            usage = msg.get("usage")
+            if isinstance(usage, dict) and usage:
+                key = entry.get("requestId") or msg.get("id") or object()
+                last_usage[key] = usage
+
+    for usage in last_usage.values():
+        # Anthropic reports input_tokens (uncached), cache_read_input_tokens,
+        # and cache_creation_input_tokens as disjoint buckets. The prompt
+        # total is their sum (the OpenInference total), while the two cache
+        # buckets are tracked separately and surfaced as prompt_details so
+        # downstream cost pricing can apply the cheaper cache-read /
+        # cache-write rates instead of the full input rate.
+        uncached = _usage_int(usage, "input_tokens")
+        cache_read = _usage_int(usage, "cache_read_input_tokens")
+        cache_write = _usage_int(usage, "cache_creation_input_tokens")
+        usage_totals.prompt += uncached + cache_read + cache_write
+        usage_totals.cache_read += cache_read
+        usage_totals.cache_write += cache_write
+        usage_totals.completion += _usage_int(usage, "output_tokens")
 
     return output, usage_totals, model
 


### PR DESCRIPTION
Fixes #77.

## Problem

`_scan_transcript_for_usage()` sums the `usage` block of **every** assistant record it walks. But Claude Code writes one assistant record **per content block** (thinking / text / tool_use / …), and every record of the same API response repeats the **same** usage snapshot (same `requestId` / `message.id`, identical token counts). Summing them bills one API call several times, inflating `llm.token_count.*` on the Turn span (`_handle_stop`) and subagent span (`_handle_subagent_stop`).

## Verification

Reproduced independently against local transcripts using the issue's methodology:

- **output tokens: 2.79× over-reported**, **prompt tokens: 2.37×** (issue reported 2.79× / 2.38×)
- 74% of requests span multiple assistant records; **all of them carry byte-identical usage snapshots** — confirming duplication, not additive chunking
- Confirmed 4 consecutive records sharing one `requestId`, one per content block

## Fix

Collect usage per request (keyed on `requestId`, falling back to `message.id`) and take **last-record-wins** before totaling — the strategy ccusage converged on, robust if earlier snapshots are ever partial. Records with neither identity keep the old per-record behavior (unique `object()` key). Text concatenation is intentionally untouched: sibling records carry *different* content blocks, only the usage is duplicated. `_handle_subagent_stop` benefits automatically (same scanner).

## Tests

Adds four fixture tests — identical snapshots / partial-then-final / distinct requestIds / no-identity records. Full suite green (107 passed), lint + mypy clean.

## Credit

Cherry-picked from @moongioh's fork (original commit 8b2f904), who diagnosed and patched this. Authorship preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
