### PR TITLE
fix(claude_code): open transcript as UTF-8 in prompt-submit and usage…

### DIFF
--- a/tracing/claude_code/hooks/handlers.py
+++ b/tracing/claude_code/hooks/handlers.py
@@ -340,7 +340,7 @@ def _handle_user_prompt_submit(input_json: dict) -> None:
     # Track transcript position
     transcript = input_json.get("transcript_path", "")
     if transcript and Path(transcript).is_file():
-        with open(transcript) as f:
+        with open(transcript, encoding="utf-8") as f:
             line_count = sum(1 for _ in f)
         state.set("trace_start_line", str(line_count))
     else:
@@ -410,7 +410,7 @@ def _scan_transcript_for_usage(
     # authoritative. Records with no identity at all are counted individually.
     last_usage: "dict[object, dict]" = {}
 
-    with open(transcript) as f:
+    with open(transcript, encoding="utf-8") as f:
         for i, line in enumerate(f):
             if i < start_line:
                 continue


### PR DESCRIPTION
… scan

Claude Code transcripts are UTF-8 JSONL, but _handle_user_prompt_submit's line-count read and _scan_transcript_for_usage opened them with the platform default encoding. On Windows locales where that default is not UTF-8 (e.g. cp949), a transcript byte sequence invalid under the locale codec raises UnicodeDecodeError; the hook wrappers catch and log it and exit 0, so the turn's real span is silently never emitted -- only the next turn's empty fail-safe span reaches the backend.

Pass encoding="utf-8" at both call sites, matching the codex and copilot adapters.

Fixes #88.

## Summary

<!-- What does this PR change, and why? -->

resolves #<issue-number>

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [x] Refactor
- [x] Other

## How tested

<!-- Commands you ran, which harness you exercised, backend used, etc. -->

## Checklist

- [x] Tests pass (`uv run pytest tests/ -m "not slow"`)
- [x] Pre-commit clean (`uv run pre-commit run --all-files`)
- [x] Ran the `code-review` skill and addressed findings
- [x] Docs updated if needed
