### PR TITLE
fix(claude): emit root and subagent spans as agent spans

### DIFF
--- a/tests/tracing/claude/test_claude_high_fidelity.py
+++ b/tests/tracing/claude/test_claude_high_fidelity.py
@@ -265,7 +265,7 @@ def test_real_v2_transcript_is_exported_once_as_correlated_tree(tmp_path: Path):
     assert "parentSpanId" not in spans[0]
     assert spans[2]["parentSpanId"] == spans[1]["spanId"]
     assert spans[4]["parentSpanId"] == spans[3]["spanId"]
-    assert _attrs(spans[0])["openinference.span.kind"] == "CHAIN"
+    assert _attrs(spans[0])["openinference.span.kind"] == "AGENT"
     assert "llm.token_count.total" not in _attrs(spans[0])
     assert _attrs(spans[2])["output.value"] == "hook read output"
     assert _attrs(spans[2])["tool.call.id"] == "tool-read-1"
@@ -452,6 +452,8 @@ def test_foreground_subagent_is_buffered_and_exported_inside_main_tree(tmp_path:
     assert spans[5]["parentSpanId"] == spans[4]["spanId"]
     assert spans[6]["parentSpanId"] == spans[3]["spanId"]
     assert spans[7]["parentSpanId"] == spans[0]["spanId"]
+    assert _attrs(spans[0])["openinference.span.kind"] == "AGENT"
+    assert _attrs(spans[2])["openinference.span.kind"] == "AGENT"
     assert _attrs(spans[3])["openinference.span.kind"] == "AGENT"
     assert _attrs(spans[3])["subagent.id"] == "agent-1"
     assert _attrs(spans[3])["subagent.type"] == "synthetic-explorer"

--- a/tests/tracing/claude/test_claude_hook.py
+++ b/tests/tracing/claude/test_claude_hook.py
@@ -970,7 +970,7 @@ class TestSubagentStop:
         assert len(captured_spans) == 1
         span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
         attrs = {a["key"]: a["value"] for a in span["attributes"]}
-        assert attrs["openinference.span.kind"]["stringValue"] == "CHAIN"
+        assert attrs["openinference.span.kind"]["stringValue"] == "AGENT"
         assert attrs["subagent.type"]["stringValue"] == "code-review"
         assert "I found the issue." in attrs["output.value"]["stringValue"]
 

--- a/tests/tracing/claude/test_claude_hook_subagent_start.py
+++ b/tests/tracing/claude/test_claude_hook_subagent_start.py
@@ -145,7 +145,7 @@ class TestSubagentStopWithStoredState:
         assert state.get("subagent_a1_prompt") is None
 
     def test_subagent_stop_uses_stored_prompt_as_input(self, mock_resolve, state, captured_spans):
-        """Stored prompt appears as input.value on the CHAIN span."""
+        """Stored prompt appears as input.value on the AGENT span."""
         state.set("current_trace_id", "t" * 32)
         state.set("current_trace_span_id", "s" * 16)
         state.set("subagent_a1_prompt", "do work")
@@ -154,4 +154,5 @@ class TestSubagentStopWithStoredState:
         assert len(captured_spans) == 1
         span = captured_spans[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
         attrs = {a["key"]: a["value"] for a in span["attributes"]}
+        assert attrs["openinference.span.kind"]["stringValue"] == "AGENT"
         assert attrs["input.value"]["stringValue"] == "do work"

--- a/tests/tracing/claude/test_claude_span_renderer.py
+++ b/tests/tracing/claude/test_claude_span_renderer.py
@@ -58,7 +58,7 @@ def test_renders_turn_model_calls_and_tools_with_exact_parents():
         "LLM call 3: qwen3-coder-next",
     ]
     assert [_attrs(span)["openinference.span.kind"] for span in spans] == [
-        "CHAIN",
+        "AGENT",
         "LLM",
         "TOOL",
         "LLM",
@@ -149,6 +149,27 @@ def test_renders_agent_as_agent_parent_for_its_model_and_tool():
     assert _attrs(spans[0])["subagent.id"] == "agent-1"
     assert spans[1]["parentSpanId"] == spans[0]["spanId"]
     assert spans[2]["parentSpanId"] == spans[1]["spanId"]
+
+
+def test_renders_agent_tool_invocations_as_agent_spans():
+    root = TurnEvent(
+        event_id="turn:1",
+        session_id="session-agent-1",
+        turn_id="1",
+        sequence=0,
+        started_at_ms=1_767_272_400_000,
+        ended_at_ms=1_767_272_404_000,
+        status=EventStatus.COMPLETED,
+    )
+    graph = parse_claude_transcript(FIXTURE_DIR / "subagent_main.jsonl", root)
+    spans = _spans(render_event_graph(graph, trace_id=TRACE_ID, span_id_factory=_factory()))
+
+    agent_span = next(span for span in spans if span["name"] == "Agent")
+    attrs = _attrs(agent_span)
+    assert attrs["openinference.span.kind"] == "AGENT"
+    assert attrs["subagent.id"] == "agent-1"
+    assert attrs["subagent.type"] == "synthetic-explorer"
+    assert attrs["tool.call.id"] == "tool-agent-1"
 
 
 def test_duplicate_event_ids_receive_distinct_span_ids():

--- a/tracing/claude_code/hooks/handlers.py
+++ b/tracing/claude_code/hooks/handlers.py
@@ -990,7 +990,7 @@ def _handle_subagent_start(input_json: dict) -> None:
 
 
 def _handle_subagent_stop(input_json: dict) -> None:
-    """Handle subagent_stop: parse subagent transcript and send CHAIN span."""
+    """Handle subagent_stop: parse subagent transcript and send AGENT span."""
     state = resolve_session(input_json)
     trace_id = state.get("current_trace_id")
     if trace_id is None:
@@ -1049,7 +1049,7 @@ def _handle_subagent_stop(input_json: dict) -> None:
     # Build attributes
     attrs = {
         "session.id": session_id,
-        "openinference.span.kind": "CHAIN",
+        "openinference.span.kind": "AGENT",
         "subagent.id": agent_id,
         "subagent.type": agent_type,
         "llm.model_name": model,
@@ -1065,7 +1065,7 @@ def _handle_subagent_stop(input_json: dict) -> None:
 
     span = build_span(
         f"Subagent: {agent_type}",
-        "CHAIN",
+        "AGENT",
         span_id,
         trace_id,
         parent or "",

--- a/tracing/claude_code/hooks/span_renderer.py
+++ b/tracing/claude_code/hooks/span_renderer.py
@@ -88,10 +88,10 @@ def _span_fields(event: BaseEvent, model_call_number: int) -> tuple[str, str, di
     }
 
     if isinstance(event, TurnEvent):
-        attrs["openinference.span.kind"] = "CHAIN"
+        attrs["openinference.span.kind"] = "AGENT"
         _put_content(attrs, "input.value", event.input, env.log_prompts)
         _put_content(attrs, "output.value", event.output, env.log_prompts)
-        return f"Turn {event.turn_id}", "CHAIN", attrs
+        return f"Turn {event.turn_id}", "AGENT", attrs
 
     if isinstance(event, AgentEvent):
         attrs.update(
@@ -133,6 +133,19 @@ def _span_fields(event: BaseEvent, model_call_number: int) -> tuple[str, str, di
         return f"LLM call {model_call_number}{suffix}", "LLM", attrs
 
     if isinstance(event, ToolEvent):
+        if event.tool_name == "Agent":
+            attrs.update(
+                {
+                    "openinference.span.kind": "AGENT",
+                    "subagent.id": _tool_subagent_id(event),
+                    "subagent.type": _tool_subagent_type(event),
+                    "tool.call.id": event.tool_call_id or "",
+                }
+            )
+            _put_content(attrs, "input.value", event.input, env.log_prompts)
+            _put_content(attrs, "output.value", event.output, env.log_tool_content)
+            _put_content(attrs, "error.message", event.error, env.log_tool_content)
+            return "Agent", "AGENT", attrs
         attrs.update(
             {
                 "openinference.span.kind": "TOOL",
@@ -174,6 +187,30 @@ def _put_tool_details(attrs: dict[str, Any], event: ToolEvent) -> None:
     for key, value in details.items():
         if value is not None:
             attrs[key] = redact_content(env.log_tool_details, _content_string(value))
+
+
+def _tool_subagent_id(event: ToolEvent) -> str:
+    if isinstance(event.output, dict):
+        tool_result = event.output.get("toolUseResult")
+        if isinstance(tool_result, dict):
+            agent_id = tool_result.get("agentId")
+            if isinstance(agent_id, str) and agent_id:
+                return agent_id
+    return event.agent_id or ""
+
+
+def _tool_subagent_type(event: ToolEvent) -> str:
+    if isinstance(event.output, dict):
+        tool_result = event.output.get("toolUseResult")
+        if isinstance(tool_result, dict):
+            agent_type = tool_result.get("agentType")
+            if isinstance(agent_type, str) and agent_type:
+                return agent_type
+    if isinstance(event.input, dict):
+        agent_type = event.input.get("subagent_type")
+        if isinstance(agent_type, str) and agent_type:
+            return agent_type
+    return "unknown"
 
 
 def _put_content(attrs: dict[str, Any], key: str, value: Any, allowed: bool) -> None:


### PR DESCRIPTION
Fixes 98

## Checklist

- [x] Tests pass (`145 passed`)
- [x] `ruff` clean
- [x] `black` formatted
- [x] No new runtime dependencies