### PR TITLE
ci: add CodeQL advanced setup so fork PRs get scanned

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+# CodeQL code scanning (advanced setup).
+#
+# Replaces GitHub's "default setup", which does not analyze pull requests from
+# forks. This workflow runs on the `pull_request` event, so it also scans
+# external contributors' PRs (after the standard first-time-contributor
+# workflow approval), in addition to pushes to main and a weekly scheduled run.
+#
+# NOTE: default setup and advanced setup are mutually exclusive. Default setup
+# must be turned OFF in Settings -> Code security -> Code scanning before this
+# workflow will run; otherwise GitHub reports a conflicting-configuration error.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, Monday 07:31 UTC — mirrors the cadence of default setup's runs.
+    - cron: '31 7 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # Languages and build modes must match what was scanned under default
+        # setup: python, JS/TS, and GitHub Actions workflows. None require a
+        # build step, so build-mode is `none` for all three.
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
+        with:
+          # Category keeps this analysis's alerts distinct per language and
+          # matches the categories default setup used, preserving alert history.
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,9 @@ jobs:
             build-mode: none
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Don't leave the job's git token in .git/config after checkout.
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3


### PR DESCRIPTION
## Problem

CodeQL code scanning is currently configured via GitHub's **default setup**, which does not analyze pull requests from forks. As a result, external contributors' PRs are never scanned.

Evidence: every same-repo PR (#55, #59, #70, #79, #82–#85) has CodeQL analyses, while every fork PR (#78, #90, #91, #92, #99, #100) has **zero**. Default-setup runs also report the internal `dynamic` event and there is no `codeql.yml` in the repo, confirming default setup is in use.

## Fix

Replace default setup with an **advanced-setup** workflow (`.github/workflows/codeql.yml`). Because it runs on the `pull_request` event, fork PRs are scanned too (this repo is public, so code scanning results are supported on fork PRs). It also runs on push to `main` and a weekly schedule.

- **Languages / categories** mirror the previous default setup — `python`, `javascript-typescript`, `actions` (`build-mode: none`) — preserving alert history.
- **Actions are SHA-pinned** per repo convention (`codeql-action` → v3.37.3).
- **`persist-credentials: false`** on checkout, matching the hardening convention used in `Arize-ai/phoenix`'s zizmor workflow.

## ⚠️ Required before/at merge

Default setup and advanced setup are **mutually exclusive**. An org admin must **disable default setup** in **Settings → Code security → Code scanning** before this workflow will run; otherwise GitHub reports a conflicting-configuration error.

## Note

First-time / outside-contributor fork PRs will still need a maintainer to click **"Approve and run workflows"** before any Actions (CI and CodeQL alike) run — this is the standard GitHub Actions fork gate, not specific to CodeQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)