### PR TITLE
ci: disable advanced CodeQL workflow (workflow_dispatch only)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,16 +8,27 @@
 # NOTE: default setup and advanced setup are mutually exclusive. Default setup
 # must be turned OFF in Settings -> Code security -> Code scanning before this
 # workflow will run; otherwise GitHub reports a conflicting-configuration error.
+#
+# DISABLED FOR NOW: default setup is enforced at the Arize-ai org level, so a
+# repo-level disable does not stick and every advanced-config run is rejected at
+# SARIF upload ("cannot be processed when the default setup is enabled"). The
+# automatic triggers are therefore removed and this is left as
+# `workflow_dispatch` only, so the config is preserved but never runs (and never
+# conflicts). To re-enable once default setup is turned off at the org level,
+# restore the push / pull_request / schedule triggers below — that is what gives
+# fork PRs coverage:
+#
+#   on:
+#     push:
+#       branches: [main]
+#     pull_request:
+#       branches: [main]
+#     schedule:
+#       - cron: '31 7 * * 1'   # weekly, Monday 07:31 UTC
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  schedule:
-    # Weekly, Monday 07:31 UTC — mirrors the cadence of default setup's runs.
-    - cron: '31 7 * * 1'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Why

The advanced-setup CodeQL workflow added in #102 cannot upload results while CodeQL **default setup** is enabled:

> CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled

Default setup is **enforced at the Arize-ai org level**, so a repo-level disable does not stick — verified from run history (a default-setup `Code Quality: Push on main` run succeeded at 19:17 while the advanced run at 19:28 still failed with the conflict). Every advanced-workflow run therefore fails at the SARIF upload step, on all PRs.

## What (disable, don't delete)

Instead of removing the workflow, its automatic triggers are neutered to **`workflow_dispatch` only**, so it never runs automatically (no conflict) while the config stays in the repo. The original `push` / `pull_request` / `schedule` block is preserved as a comment in the file for easy restoration.

## Restoring later

The original goal — scanning **fork PRs** — still requires advanced setup, which only works once default setup is turned off at the **org level** (Arize-ai → Code security → Configurations → detach this repo). Once that's done, restore the triggers (uncomment the block in the file) and the advanced workflow — including fork coverage — comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)