### PR TITLE
feat(codex): trace custom Code Mode tool calls

### DIFF
--- a/tests/tracing/codex/test_codex_hook.py
+++ b/tests/tracing/codex/test_codex_hook.py
@@ -250,6 +250,40 @@ class TestExtractTurnFromRollout:
         assert tc["output"] == "file1\nfile2"
         assert tc["end_ts"] > tc["start_ts"]
 
+    def test_custom_tool_call_pairs_with_output_by_call_id(self, tmp_path):
+        path = _write_rollout(
+            tmp_path,
+            "s1",
+            _evt({"type": "task_started", "turn_id": "t1"}),
+            _resp(
+                {
+                    "type": "custom_tool_call",
+                    "status": "completed",
+                    "name": "exec",
+                    "call_id": "custom-1",
+                    "input": 'await tools.exec_command({cmd: "ls"});',
+                },
+                ts="2026-05-20T00:00:01.000Z",
+            ),
+            _resp(
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "custom-1",
+                    "output": "file1\nfile2",
+                },
+                ts="2026-05-20T00:00:02.000Z",
+            ),
+            _evt({"type": "task_complete", "turn_id": "t1"}),
+        )
+        turn = _extract_turn_from_rollout(path, "t1")
+        assert len(turn["tool_calls"]) == 1
+        tc = turn["tool_calls"][0]
+        assert tc["tool"] == "exec"
+        assert tc["call_id"] == "custom-1"
+        assert tc["args"] == 'await tools.exec_command({cmd: "ls"});'
+        assert tc["output"] == "file1\nfile2"
+        assert tc["end_ts"] > tc["start_ts"]
+
     def test_web_search_call_pairs_with_preceding_end(self, tmp_path):
         path = _write_rollout(
             tmp_path,

--- a/tracing/codex/hooks/handlers.py
+++ b/tracing/codex/hooks/handlers.py
@@ -142,6 +142,7 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
 
     tool_calls: list = []
     pending_func: dict = {}  # call_id -> entry being filled
+    pending_custom: dict = {}  # call_id -> Code Mode entry being filled
     pending_search_end: "dict | None" = None  # most recent unmatched web_search_end
 
     try:
@@ -250,6 +251,33 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
                 if outer == "response_item" and ptype == "function_call_output":
                     call_id = payload.get("call_id") or ""
                     pending = pending_func.get(call_id) if call_id else None
+                    if pending is not None:
+                        pending["output"] = payload.get("output") or ""
+                        pending["end_ts"] = ts_ms or pending["end_ts"]
+                    continue
+
+                # Code Mode exposes its outer exec invocation as a custom tool
+                # call rather than a function_call. Pair it with the durable
+                # output record by call_id so it is rendered like other tools.
+                if outer == "response_item" and ptype == "custom_tool_call":
+                    call_id = payload.get("call_id") or ""
+                    entry = {
+                        "tool": payload.get("name") or "custom_tool_call",
+                        "args": payload.get("input") or "",
+                        "output": "",
+                        "call_id": call_id,
+                        "start_ts": ts_ms,
+                        "end_ts": ts_ms,
+                        "decision": None,
+                    }
+                    tool_calls.append(entry)
+                    if call_id:
+                        pending_custom[call_id] = entry
+                    continue
+
+                if outer == "response_item" and ptype == "custom_tool_call_output":
+                    call_id = payload.get("call_id") or ""
+                    pending = pending_custom.get(call_id) if call_id else None
                     if pending is not None:
                         pending["output"] = payload.get("output") or ""
                         pending["end_ts"] = ts_ms or pending["end_ts"]


### PR DESCRIPTION
## Summary

adds tracing support for custom_tool_calls by codex, so code mode tool calls also appear as span attributes (currently missing from ingestion).

## Changes

- Parse `custom_tool_call` and `custom_tool_call_output` rollout records.
- Pair calls and outputs by `call_id`.
- Add regression coverage for Code Mode `exec` calls.

## Validation

- `uv run pytest tests/ -m 'not slow' -q` — 2184 passed, 1 skipped
- Ruff and `git diff --check` pass

Resolves #110
