### PR TITLE
feat: non-interactive install for all harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Values come from the environment, or from a dotenv file named explicitly with `A
 
 **A named file takes precedence over existing environment variables** — an already-installed harness exports `ARIZE_API_KEY`, `ARIZE_SPACE_ID` and `ARIZE_PROJECT_NAME` into every agent session, and those inherited values should not beat credentials you just wrote to a file. Only the keys below are read out of it, so a file full of unrelated settings is safe to use.
 
+Parsing is [`python-dotenv`](https://pypi.org/project/python-dotenv/)'s `dotenv_values`, so quoting, `export` prefixes, comments and escapes behave as they do for every other dotenv consumer. It is the package's only runtime dependency, imported by the installer alone — the hooks that run inside a traced session still use nothing outside the stdlib. A line it cannot parse is a hard error rather than a skip: a credential quietly falling back to the environment is the outcome this whole section exists to avoid.
+
 There is deliberately **no automatic `./.env` search**. Because a named file outranks the environment, reading the working directory would let a cloned repository's dotenv choose `ARIZE_OTLP_ENDPOINT` or `PHOENIX_ENDPOINT` while your real credentials came from the environment — installing a config that sends spans and a bearer API key to an endpoint the repo picked, for every later session on the machine. Name the file you mean:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -103,10 +103,16 @@ The API key is never echoed — the installer reports only that it found one, an
 [arize] Backend: Arize AX at otlp.arize.com:443 (from default)
 [arize]   space ID: my-space (from /path/to/.env)
 [arize]   API key: found (from /path/to/.env)
-[arize] Project name: codex (from harness default)
+[arize] Project name: codex (from default)
 ```
 
 An API key on its own is rejected as ambiguous, since both backends use one.
+
+### Updating
+
+`install.sh update` pulls the latest code and re-registers every harness already in `config.json`. Re-registering runs each harness's installer, so in a terminal it still asks for each project name, exactly as before.
+
+With no terminal to answer on — CI, a cron job, a script — it takes the stored values instead of failing. Credentials aren't re-read on that path; only the project name is confirmed, and it keeps whatever is in `config.json`.
 
 ### Checking what's installed
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Values are read from `./.env` or `./.env.local` (point somewhere else with `ARIZ
 | `ARIZE_API_KEY` + `ARIZE_SPACE_ID` | — | Arize AX credentials. Both required for the Arize backend. |
 | `PHOENIX_ENDPOINT`, `PHOENIX_API_KEY` | `http://localhost:6006` | Phoenix endpoint and optional API key. |
 | `ARIZE_BACKEND` | inferred | `arize` or `phoenix`. Inferred when unset: a space ID means Arize AX, a Phoenix endpoint means Phoenix. |
-| `ARIZE_PROJECT_NAME` | harness name | Project spans are grouped under. |
+| `ARIZE_PROJECT_NAME` | harness name | Project spans are grouped under. **Read from the dotenv file only** — an environment value is ignored here, since an installed harness exports its own project name into every session and inheriting it would name this harness's project after a different one. |
 | `ARIZE_USER_ID` | — | Optional `user.id` on every span. |
 | `ARIZE_OTLP_ENDPOINT` | `otlp.arize.com:443` | Override for hosted/dedicated Arize instances. |
 | `ARIZE_LOG_PROMPTS` | `true` | Set `false` to omit prompt text. |
@@ -93,9 +93,20 @@ Values are read from `./.env` or `./.env.local` (point somewhere else with `ARIZ
 | `ARIZE_KIRO_AGENT` | `arize-traced` | Kiro only — which agent to install hooks into. |
 | `ARIZE_KIRO_SET_DEFAULT` | `false` | Kiro only — also make that agent Kiro's default. |
 
+In a dotenv file, an unquoted value ends at a whitespace-preceded `#`, so `ARIZE_SPACE_ID=abc # my space` yields `abc`. Quote the value to keep a literal `#`.
+
 Content logging defaults match the interactive wizard: everything on. Set the three `ARIZE_LOG_*` variables explicitly if you need a narrower capture.
 
-The API key is never echoed — the installer reports only that it found one. An API key on its own is rejected as ambiguous, since both backends use one.
+The API key is never echoed — the installer reports only that it found one, and where it came from. Every resolved value is reported with its source (dotenv path, `$VAR`, or default) so a wrong-credentials install is diagnosable:
+
+```
+[arize] Backend: Arize AX at otlp.arize.com:443 (from default)
+[arize]   space ID: my-space (from /path/to/.env)
+[arize]   API key: found (from /path/to/.env)
+[arize] Project name: codex (from harness default)
+```
+
+An API key on its own is rejected as ambiguous, since both backends use one.
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You're only asked these the first time you install a harness — subsequent inst
 
 Pass `--non-interactive` (or `-y`) to skip every prompt above and take each value from the environment instead. Nothing is asked, and a missing required value is an error rather than a prompt — so this is the mode to use from a script, from CI, or when a coding agent is driving the install itself.
 
-Values resolve from the environment first, then from `./.env` or `./.env.local` (point somewhere else with `ARIZE_ENV_FILE`). Only the keys below are read out of a dotenv file, so an app's `.env` full of unrelated settings is safe to use.
+Values are read from `./.env` or `./.env.local` (point somewhere else with `ARIZE_ENV_FILE`), falling back to the environment for anything the file doesn't define. **The file takes precedence over existing environment variables** — an already-installed harness exports `ARIZE_API_KEY`, `ARIZE_SPACE_ID` and `ARIZE_PROJECT_NAME` into every agent session, and those inherited values should not beat credentials you just wrote to a file. Only the keys below are read out of a dotenv file, so an app's `.env` full of unrelated settings is safe to use.
 
 ```bash
 ./install.sh claude --non-interactive

--- a/README.md
+++ b/README.md
@@ -75,13 +75,8 @@ Pass `--non-interactive` (or `-y`) to skip every prompt above and take each valu
 Values resolve from the environment first, then from `./.env` or `./.env.local` (point somewhere else with `ARIZE_ENV_FILE`). Only the keys below are read out of a dotenv file, so an app's `.env` full of unrelated settings is safe to use.
 
 ```bash
-# credentials straight from a dotenv file — nothing exported, no key in argv
-ax api-keys create --env-file .env          # writes ARIZE_API_KEY
-echo 'ARIZE_SPACE_ID=<space-id>' >> .env
 ./install.sh claude --non-interactive
 ```
-
-Reading the key from a file rather than a flag keeps it out of your shell history, out of `ps` output, and out of a coding agent's transcript.
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/README.md
+++ b/README.md
@@ -108,6 +108,29 @@ The API key is never echoed — the installer reports only that it found one, an
 
 An API key on its own is rejected as ambiguous, since both backends use one.
 
+### Checking what's installed
+
+`status` reports which harnesses are configured and whether their hooks are actually wired into the harness's own settings file — the two things that have to both be true for traces to appear.
+
+```bash
+./install.sh status
+./install.sh status --json    # machine-readable
+```
+
+`--json` is the one to use from a script or a coding agent: it exits non-zero when no harness is configured, so you can gate on it without parsing output. The payload contains no secrets — an API key appears only as `"api_key_present": true` — so it is safe to paste into a bug report.
+
+```
+Harnesses:
+  claude-code
+    project:  claude-code
+    backend:  arize → otlp.arize.com:443
+    space:    my-space
+    API key:  present
+    hooks:    registered (/Users/me/.claude/settings.json)
+```
+
+`hooks: NOT registered` means credentials are saved but the harness was never wired up (or something removed the hooks) — re-run the install for that harness.
+
 ### Environment variables
 
 Most settings live in `.arize/harness/config.json`, but a small set of env vars affect runtime behavior on every harness. The installers wire most of these for you; set them yourself when you want to override behavior for a single session or debug locally.

--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ Values are read from `./.env` or `./.env.local` (point somewhere else with `ARIZ
 |----------|---------|-------------|
 | `ARIZE_API_KEY` + `ARIZE_SPACE_ID` | — | Arize AX credentials. Both required for the Arize backend. |
 | `PHOENIX_ENDPOINT`, `PHOENIX_API_KEY` | `http://localhost:6006` | Phoenix endpoint and optional API key. |
-| `ARIZE_BACKEND` | inferred | `arize` or `phoenix`. Inferred when unset: a space ID means Arize AX, a Phoenix endpoint means Phoenix. |
+| `ARIZE_BACKEND` | inferred | `arize` or `phoenix`. Inferred when unset: a space ID means Arize AX, a Phoenix endpoint means Phoenix. When both are present, or an Arize key appears with only a Phoenix endpoint, the install stops and asks you to set this rather than guess — guessing would discard one backend's credentials. |
 | `ARIZE_PROJECT_NAME` | harness name | Project spans are grouped under. **Read from the dotenv file only** — an environment value is ignored here, since an installed harness exports its own project name into every session and inheriting it would name this harness's project after a different one. |
 | `ARIZE_USER_ID` | — | Optional `user.id` on every span. |
 | `ARIZE_OTLP_ENDPOINT` | `otlp.arize.com:443` | Override for hosted/dedicated Arize instances. |
 | `ARIZE_LOG_PROMPTS` | `true` | Set `false` to omit prompt text. |
 | `ARIZE_LOG_TOOL_DETAILS` | `true` | Set `false` to omit tool commands, file paths and URLs. |
 | `ARIZE_LOG_TOOL_CONTENT` | `true` | Set `false` to omit tool output. |
-| `ARIZE_ENV_FILE` | `./.env`, `./.env.local` | Explicit dotenv path to read instead of searching. |
+| `ARIZE_ENV_FILE` | `./.env`, `./.env.local` | Explicit dotenv path to read instead of searching. A path that is not a readable file is an error, not a fall-back to the environment. |
 | `ARIZE_KIRO_AGENT` | `arize-traced` | Kiro only — which agent to install hooks into. |
 | `ARIZE_KIRO_SET_DEFAULT` | `false` | Kiro only — also make that agent Kiro's default. |
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,15 @@ You're only asked these the first time you install a harness — subsequent inst
 
 Pass `--non-interactive` (or `-y`) to skip every prompt above and take each value from the environment instead. Nothing is asked, and a missing required value is an error rather than a prompt — so this is the mode to use from a script, from CI, or when a coding agent is driving the install itself.
 
-Values are read from `./.env` or `./.env.local` (point somewhere else with `ARIZE_ENV_FILE`), falling back to the environment for anything the file doesn't define. **The file takes precedence over existing environment variables** — an already-installed harness exports `ARIZE_API_KEY`, `ARIZE_SPACE_ID` and `ARIZE_PROJECT_NAME` into every agent session, and those inherited values should not beat credentials you just wrote to a file. Only the keys below are read out of a dotenv file, so an app's `.env` full of unrelated settings is safe to use.
+Values come from the environment, or from a dotenv file named explicitly with `ARIZE_ENV_FILE`. Using a file keeps the API key out of the command line and shell history.
+
+**A named file takes precedence over existing environment variables** — an already-installed harness exports `ARIZE_API_KEY`, `ARIZE_SPACE_ID` and `ARIZE_PROJECT_NAME` into every agent session, and those inherited values should not beat credentials you just wrote to a file. Only the keys below are read out of it, so a file full of unrelated settings is safe to use.
+
+There is deliberately **no automatic `./.env` search**. Because a named file outranks the environment, reading the working directory would let a cloned repository's dotenv choose `ARIZE_OTLP_ENDPOINT` or `PHOENIX_ENDPOINT` while your real credentials came from the environment — installing a config that sends spans and a bearer API key to an endpoint the repo picked, for every later session on the machine. Name the file you mean:
+
+```bash
+ARIZE_ENV_FILE=~/.arize/onboarding.env ./install.sh claude --non-interactive
+```
 
 ```bash
 ./install.sh claude --non-interactive
@@ -86,16 +94,16 @@ Values are read from `./.env` or `./.env.local` (point somewhere else with `ARIZ
 | `ARIZE_PROJECT_NAME` | harness name | Project spans are grouped under. **Read from the dotenv file only** — an environment value is ignored here, since an installed harness exports its own project name into every session and inheriting it would name this harness's project after a different one. |
 | `ARIZE_USER_ID` | — | Optional `user.id` on every span. |
 | `ARIZE_OTLP_ENDPOINT` | `otlp.arize.com:443` | Override for hosted/dedicated Arize instances. |
-| `ARIZE_LOG_PROMPTS` | `true` | Set `false` to omit prompt text. |
-| `ARIZE_LOG_TOOL_DETAILS` | `true` | Set `false` to omit tool commands, file paths and URLs. |
-| `ARIZE_LOG_TOOL_CONTENT` | `true` | Set `false` to omit tool output. |
-| `ARIZE_ENV_FILE` | `./.env`, `./.env.local` | Explicit dotenv path to read instead of searching. A path that is not a readable file is an error, not a fall-back to the environment. |
+| `ARIZE_LOG_PROMPTS` | `false` | Set `true` to capture prompt text. |
+| `ARIZE_LOG_TOOL_DETAILS` | `false` | Set `true` to capture tool commands, file paths and URLs. |
+| `ARIZE_LOG_TOOL_CONTENT` | `false` | Set `true` to capture tool output. |
+| `ARIZE_ENV_FILE` | — | Dotenv file to read. No file is read unless this is set. A path that is not a readable file is an error, not a fall-back to the environment. |
 | `ARIZE_KIRO_AGENT` | `arize-traced` | Kiro only — which agent to install hooks into. |
 | `ARIZE_KIRO_SET_DEFAULT` | `false` | Kiro only — also make that agent Kiro's default. |
 
 In a dotenv file, an unquoted value ends at a whitespace-preceded `#`, so `ARIZE_SPACE_ID=abc # my space` yields `abc`. Quote the value to keep a literal `#`.
 
-Content logging defaults match the interactive wizard: everything on. Set the three `ARIZE_LOG_*` variables explicitly if you need a narrower capture.
+Content logging is **off by default here**, unlike the interactive wizard where each question defaults to yes. A `[Y/n]` default is a person declining to change an answer they were shown; the same default unattended would capture prompts, commands and file contents that nobody agreed to — and `update` runs non-interactively whenever there is no terminal. Set the `ARIZE_LOG_*` variables you want to `true`.
 
 The API key is never echoed — the installer reports only that it found one, and where it came from. Every resolved value is reported with its source (dotenv path, `$VAR`, or default) so a wrong-credentials install is diagnosable:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Claude Code tracing reconstructs each turn as a `CHAIN` containing per-response 
 
 ### Setup walkthrough
 
-The installer involves a brief interactive setup. The steps below run in order:
+The installer involves a brief interactive setup. The steps below run in order. To skip all of them, see [Non-interactive install](#non-interactive-install).
 
 #### 1. Backend selection
 
@@ -67,6 +67,40 @@ Three Y/n opt-outs that apply to **all** harnesses:
 - Log what tools returned (file contents, command output)?
 
 You're only asked these the first time you install a harness — subsequent installs reuse the existing `logging:` block. You can edit them later in `~/.arize/harness/config.json`.
+
+### Non-interactive install
+
+Pass `--non-interactive` (or `-y`) to skip every prompt above and take each value from the environment instead. Nothing is asked, and a missing required value is an error rather than a prompt — so this is the mode to use from a script, from CI, or when a coding agent is driving the install itself.
+
+Values resolve from the environment first, then from `./.env` or `./.env.local` (point somewhere else with `ARIZE_ENV_FILE`). Only the keys below are read out of a dotenv file, so an app's `.env` full of unrelated settings is safe to use.
+
+```bash
+# credentials straight from a dotenv file — nothing exported, no key in argv
+ax api-keys create --env-file .env          # writes ARIZE_API_KEY
+echo 'ARIZE_SPACE_ID=<space-id>' >> .env
+./install.sh claude --non-interactive
+```
+
+Reading the key from a file rather than a flag keeps it out of your shell history, out of `ps` output, and out of a coding agent's transcript.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ARIZE_API_KEY` + `ARIZE_SPACE_ID` | — | Arize AX credentials. Both required for the Arize backend. |
+| `PHOENIX_ENDPOINT`, `PHOENIX_API_KEY` | `http://localhost:6006` | Phoenix endpoint and optional API key. |
+| `ARIZE_BACKEND` | inferred | `arize` or `phoenix`. Inferred when unset: a space ID means Arize AX, a Phoenix endpoint means Phoenix. |
+| `ARIZE_PROJECT_NAME` | harness name | Project spans are grouped under. |
+| `ARIZE_USER_ID` | — | Optional `user.id` on every span. |
+| `ARIZE_OTLP_ENDPOINT` | `otlp.arize.com:443` | Override for hosted/dedicated Arize instances. |
+| `ARIZE_LOG_PROMPTS` | `true` | Set `false` to omit prompt text. |
+| `ARIZE_LOG_TOOL_DETAILS` | `true` | Set `false` to omit tool commands, file paths and URLs. |
+| `ARIZE_LOG_TOOL_CONTENT` | `true` | Set `false` to omit tool output. |
+| `ARIZE_ENV_FILE` | `./.env`, `./.env.local` | Explicit dotenv path to read instead of searching. |
+| `ARIZE_KIRO_AGENT` | `arize-traced` | Kiro only — which agent to install hooks into. |
+| `ARIZE_KIRO_SET_DEFAULT` | `false` | Kiro only — also make that agent Kiro's default. |
+
+Content logging defaults match the interactive wizard: everything on. Set the three `ARIZE_LOG_*` variables explicitly if you need a narrower capture.
+
+The API key is never echoed — the installer reports only that it found one. An API key on its own is rejected as ambiguous, since both backends use one.
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,15 @@ With no terminal to answer on — CI, a cron job, a script — it takes the stor
 ./install.sh status --json    # machine-readable
 ```
 
-`--json` is the one to use from a script or a coding agent: it exits non-zero when no harness is configured, so you can gate on it without parsing output. The payload contains no secrets — an API key appears only as `"api_key_present": true` — so it is safe to paste into a bug report.
+`--json` is the one to use from a script or a coding agent — you can gate on the exit code without parsing output:
+
+| Exit | Meaning |
+|------|---------|
+| `0` | every configured harness is wired up |
+| `1` | nothing configured |
+| `2` | configured, but at least one harness's hooks are missing |
+
+The JSON payload carries the same verdict as `"healthy"`, plus `"unregistered"` listing any harness whose hooks are missing. It contains no secrets — an API key appears only as `"api_key_present": true` — so it is safe to paste into a bug report.
 
 ```
 Harnesses:

--- a/core/setup/__init__.py
+++ b/core/setup/__init__.py
@@ -251,7 +251,7 @@ def _backend_from_env() -> tuple[str, dict]:
         else:
             err(
                 "No credentials found. Set ARIZE_API_KEY and ARIZE_SPACE_ID for Arize AX "
-                "(in the environment or a .env file), or PHOENIX_ENDPOINT for Phoenix."
+                "(in the environment or the file named by ARIZE_ENV_FILE), or PHOENIX_ENDPOINT for Phoenix."
             )
             sys.exit(1)
 
@@ -659,10 +659,7 @@ def _env(name: str) -> str:
     values silently beat the credentials the caller had just written, and could
     pair a fresh key from the file with a space ID from the environment.
     """
-    value = _dotenv_values().get(name, "").strip()
-    if value:
-        return value
-    return os.environ.get(name, "").strip()
+    return _dotenv_only(name) or os.environ.get(name, "").strip()
 
 
 def env_value(name: str) -> str:
@@ -692,7 +689,10 @@ def _require_env(name: str, what: str) -> str:
     """Resolve a required value, or exit with an actionable message."""
     value = _env(name)
     if not value:
-        err(f"{what} is required for a non-interactive install — set {name} or put it in a .env file.")
+        err(
+            f"{what} is required for a non-interactive install — set {name}, or add it to the file\n"
+            f"        named by ARIZE_ENV_FILE."
+        )
         sys.exit(1)
     return value
 

--- a/core/setup/__init__.py
+++ b/core/setup/__init__.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import sys
 from getpass import getpass
 from pathlib import Path
 from typing import Optional
+
+from dotenv import dotenv_values
 
 from core.config import delete_value, load_config, save_config, set_value
 
@@ -555,59 +558,40 @@ def _parse_dotenv(path: Path) -> dict:
     Handles ``export KEY=value``, surrounding quotes, comments and blank lines.
     Values are not shell-expanded — a literal ``$FOO`` stays literal.
 
-    An unquoted value ends at a whitespace-preceded ``#``, matching dotenv
-    convention: ``KEY=value # note`` yields ``value``. Quote the value to keep
-    a literal ``#``. Without this, a commented credential line silently
-    produced a malformed value rather than an error.
+    Parsing is ``python-dotenv``'s ``dotenv_values``, so quoting, ``export``
+    prefixes, inline comments and escapes follow the same rules as every other
+    dotenv consumer instead of a local approximation. It returns a dict and
+    touches no process state, which is what this needs — values here are
+    resolved per key by ``_env``, never exported.
 
-    An unbalanced quote is fatal. ``KEY="abc`` used to yield ``"abc`` — a
-    credential with a stray quote welded on, which reads as "found" and then
-    fails authentication with nothing pointing at the typo. Checked against
-    ``python-dotenv``'s ``dotenv_values``, which rejects the same lines; the two
-    agree on every other case exercised in the tests, except that it expands
-    ``\\n`` inside double quotes. None of the keys read here want a newline, so
-    that expansion is deliberately not copied.
+    Only ``_DOTENV_KEYS`` are kept, so a file holding unrelated application
+    settings is safe to point at.
+
+    A line ``dotenv_values`` cannot parse is dropped with a warning, which for a
+    credential is the wrong outcome: ``ARIZE_API_KEY="abc`` would silently fall
+    through to whatever was in the environment, and the install would report a
+    key it did not read from the file you named. So a key that is clearly
+    present in the text but absent from the parse is fatal.
     """
-    values: dict = {}
     try:
-        lines = path.read_text().splitlines()
+        text = path.read_text()
     except OSError:
-        return values
+        return {}
 
-    for line in lines:
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        if line.startswith("export "):
-            line = line[len("export ") :]
-        key, _, raw = line.partition("=")
-        if key.strip() not in _DOTENV_KEYS:
-            continue
+    parsed = dotenv_values(path)
+    values = {key: (parsed.get(key) or "").strip() for key in _DOTENV_KEYS if parsed.get(key) is not None}
 
-        value = raw.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-            value = value[1:-1]
-        elif value[:1] in ("'", '"'):
-            err(f"{path}: {key.strip()} has an unbalanced {value[:1]} quote.")
-            err("Fix the line or remove the quotes — a value cannot be read from it safely.")
-            sys.exit(1)
-        else:
-            value = _strip_inline_comment(value)
-
-        values[key.strip()] = value.strip()
+    unparsed = [
+        key
+        for key in _DOTENV_KEYS
+        if key not in values and re.search(rf"^[ \t]*(?:export[ \t]+)?{key}[ \t]*=", text, re.MULTILINE)
+    ]
+    if unparsed:
+        err(f"{path}: could not parse {', '.join(sorted(unparsed))} — check for an unbalanced quote.")
+        err("Fix the line rather than leaving it: the value would otherwise be taken from the environment.")
+        sys.exit(1)
 
     return values
-
-
-def _strip_inline_comment(value: str) -> str:
-    """Drop a trailing ``# comment`` from an unquoted dotenv value."""
-    if value.startswith("#"):
-        return ""
-    for sep in (" #", "\t#"):
-        idx = value.find(sep)
-        if idx != -1:
-            value = value[:idx]
-    return value
 
 
 def _dotenv_values() -> dict:

--- a/core/setup/__init__.py
+++ b/core/setup/__init__.py
@@ -559,6 +559,14 @@ def _parse_dotenv(path: Path) -> dict:
     convention: ``KEY=value # note`` yields ``value``. Quote the value to keep
     a literal ``#``. Without this, a commented credential line silently
     produced a malformed value rather than an error.
+
+    An unbalanced quote is fatal. ``KEY="abc`` used to yield ``"abc`` — a
+    credential with a stray quote welded on, which reads as "found" and then
+    fails authentication with nothing pointing at the typo. Checked against
+    ``python-dotenv``'s ``dotenv_values``, which rejects the same lines; the two
+    agree on every other case exercised in the tests, except that it expands
+    ``\\n`` inside double quotes. None of the keys read here want a newline, so
+    that expansion is deliberately not copied.
     """
     values: dict = {}
     try:
@@ -579,6 +587,10 @@ def _parse_dotenv(path: Path) -> dict:
         value = raw.strip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
             value = value[1:-1]
+        elif value[:1] in ("'", '"'):
+            err(f"{path}: {key.strip()} has an unbalanced {value[:1]} quote.")
+            err("Fix the line or remove the quotes — a value cannot be read from it safely.")
+            sys.exit(1)
         else:
             value = _strip_inline_comment(value)
 

--- a/core/setup/__init__.py
+++ b/core/setup/__init__.py
@@ -109,7 +109,7 @@ def ensure_harness_installed(
     if checks:
         info(f"  (not found: {', '.join(checks)})")
 
-    if not sys.stdout.isatty():
+    if non_interactive() or not sys.stdout.isatty():
         info("  non-interactive — proceeding anyway")
         return True
 
@@ -139,6 +139,9 @@ def prompt_backend(
       phoenix: {"endpoint", "api_key"}
       arize:   {"endpoint", "api_key", "space_id"}
     """
+    if non_interactive():
+        return _backend_from_env()
+
     print("Which backend do you want to use?")
     print("")
     print("  1) Phoenix (self-hosted)")
@@ -194,6 +197,55 @@ def prompt_backend(
             "space_id": space_id,
         },
     )
+
+
+def _backend_from_env() -> tuple[str, dict]:
+    """Resolve backend + credentials from the environment, for non-interactive installs.
+
+    Backend selection is explicit via ``ARIZE_BACKEND``, otherwise inferred: a
+    space ID means Arize AX, a Phoenix endpoint means Phoenix. Nothing is
+    inferred from the API key alone — both backends use one.
+
+    Exits with an actionable message when a required value is missing; this
+    path must never fall back to a prompt, because there is nobody to answer it.
+    """
+    target = _env("ARIZE_BACKEND").lower()
+    if target in ("ax", "arize"):
+        target = "arize"
+    elif target and target != "phoenix":
+        err(f"Unknown ARIZE_BACKEND '{target}' — use 'arize' or 'phoenix'.")
+        sys.exit(1)
+
+    if not target:
+        if _env("ARIZE_SPACE_ID"):
+            target = "arize"
+        elif _env("PHOENIX_ENDPOINT"):
+            target = "phoenix"
+        elif _env("ARIZE_API_KEY"):
+            # Both backends take an API key, so a key on its own is ambiguous.
+            err(
+                "Found an API key but cannot tell which backend it is for. Add "
+                "ARIZE_SPACE_ID for Arize AX, or PHOENIX_ENDPOINT for Phoenix."
+            )
+            sys.exit(1)
+        else:
+            err(
+                "No credentials found. Set ARIZE_API_KEY and ARIZE_SPACE_ID for Arize AX "
+                "(in the environment or a .env file), or PHOENIX_ENDPOINT for Phoenix."
+            )
+            sys.exit(1)
+
+    if target == "phoenix":
+        endpoint = _env("PHOENIX_ENDPOINT") or "http://localhost:6006"
+        info(f"Backend: Phoenix at {endpoint}")
+        return ("phoenix", {"endpoint": endpoint, "api_key": _env("PHOENIX_API_KEY")})
+
+    # Arize AX. Read the key but never echo it — only report that it was found.
+    api_key = _require_env("ARIZE_API_KEY", "An Arize API key")
+    space_id = _require_env("ARIZE_SPACE_ID", "An Arize space ID")
+    endpoint = _env("ARIZE_OTLP_ENDPOINT") or "otlp.arize.com:443"
+    info(f"Backend: Arize AX at {endpoint} (space {space_id}, API key from ARIZE_API_KEY)")
+    return ("arize", {"endpoint": endpoint, "api_key": api_key, "space_id": space_id})
 
 
 def _try_copy_from(target: str, existing_harnesses: dict | None) -> dict | None:
@@ -265,6 +317,11 @@ def _try_copy_from(target: str, existing_harnesses: dict | None) -> dict | None:
 
 def prompt_project_name(default: str) -> str:
     """Prompt for project name. Returns default if blank."""
+    if non_interactive():
+        name = _env("ARIZE_PROJECT_NAME") or default
+        info(f"Project name: {name}")
+        return name
+
     print("")
     name = input(f"Project name [{default}]: ").strip()
     return name if name else default
@@ -276,6 +333,16 @@ def prompt_content_logging() -> dict:
     All three default to True to match the kit's existing capture-everything
     behavior. Users opt out per category.
     """
+    if non_interactive():
+        block = {
+            "prompts": env_flag("ARIZE_LOG_PROMPTS"),
+            "tool_details": env_flag("ARIZE_LOG_TOOL_DETAILS"),
+            "tool_content": env_flag("ARIZE_LOG_TOOL_CONTENT"),
+        }
+        enabled = ", ".join(f"{k}={'on' if v else 'off'}" for k, v in block.items())
+        info(f"Content logging: {enabled}")
+        return block
+
     print("")
     if sys.stdout.isatty() and os.name != "nt":
         print("\033[1;33mSecurity:\033[0m Traces can contain sensitive data — credentials, PII, file contents.")
@@ -309,6 +376,9 @@ def write_logging_config(logging_block: dict, config_path: str | None = None) ->
 
 def prompt_user_id() -> str:
     """Optional user ID prompt. Returns "" if skipped."""
+    if non_interactive():
+        return _env("ARIZE_USER_ID")
+
     print("")
     if sys.stdout.isatty() and os.name != "nt":
         print("\033[0;34mOptional:\033[0m Set a user ID to identify your spans (useful for teams).")
@@ -371,6 +441,146 @@ def write_config(
 def dry_run() -> bool:
     """True when ARIZE_DRY_RUN env var is set to a truthy value ('1','true','yes')."""
     return os.environ.get("ARIZE_DRY_RUN", "").lower() in ("1", "true", "yes")
+
+
+def non_interactive() -> bool:
+    """True when ARIZE_NONINTERACTIVE is set to a truthy value ('1','true','yes').
+
+    In this mode the setup wizards never call ``input()``/``getpass()``: every
+    value is resolved from the environment (or a dotenv file, see
+    ``_dotenv_values``) and a missing required value is a hard error instead of
+    a prompt. Deliberately opt-in — without it, an exported ``ARIZE_API_KEY``
+    would silently stop the interactive wizard from asking its questions.
+    """
+    return os.environ.get("ARIZE_NONINTERACTIVE", "").lower() in ("1", "true", "yes")
+
+
+# Keys we will read out of a dotenv file. Everything else in the file is
+# ignored, so pointing at an app's .env can't inject unrelated settings.
+_DOTENV_KEYS = (
+    "ARIZE_API_KEY",
+    "ARIZE_SPACE_ID",
+    "ARIZE_BACKEND",
+    "ARIZE_OTLP_ENDPOINT",
+    "ARIZE_PROJECT_NAME",
+    "ARIZE_USER_ID",
+    "ARIZE_LOG_PROMPTS",
+    "ARIZE_LOG_TOOL_DETAILS",
+    "ARIZE_LOG_TOOL_CONTENT",
+    "PHOENIX_ENDPOINT",
+    "PHOENIX_API_KEY",
+)
+
+_dotenv_cache: Optional[dict] = None
+
+
+def _dotenv_candidates() -> list:
+    """Dotenv files to consider, in order. ARIZE_ENV_FILE overrides the search."""
+    explicit = os.environ.get("ARIZE_ENV_FILE", "").strip()
+    if explicit:
+        return [Path(explicit).expanduser()]
+    cwd = Path.cwd()
+    return [cwd / ".env", cwd / ".env.local"]
+
+
+def _parse_dotenv(path: Path) -> dict:
+    """Extract _DOTENV_KEYS from a dotenv file. Unreadable file → {}.
+
+    Handles ``export KEY=value``, surrounding quotes, comments and blank lines.
+    Values are not shell-expanded — a literal ``$FOO`` stays literal.
+    """
+    values: dict = {}
+    try:
+        lines = path.read_text().splitlines()
+    except OSError:
+        return values
+
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :]
+        key, _, raw = line.partition("=")
+        if key.strip() not in _DOTENV_KEYS:
+            continue
+        value = raw.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        values[key.strip()] = value.strip()
+
+    return values
+
+
+def _dotenv_values() -> dict:
+    """Load Arize/Phoenix values from a dotenv file, once per process.
+
+    Lets ``ax api-keys create --env-file .env`` feed the installer directly:
+    the key goes CLI → file → installer, never through argv, shell history, or
+    a coding agent's transcript. Only consulted when the real environment
+    doesn't already supply the value, so exported vars still win.
+    """
+    global _dotenv_cache
+    if _dotenv_cache is not None:
+        return _dotenv_cache
+
+    _dotenv_cache = {}
+    for path in _dotenv_candidates():
+        if not path.is_file():
+            continue
+        found = _parse_dotenv(path)
+        if found:
+            info(f"Reading configuration from {path} ({len(found)} value(s))")
+            _dotenv_cache = found
+            break
+
+    return _dotenv_cache
+
+
+def _reset_dotenv_cache() -> None:
+    """Clear the dotenv cache. For tests, which vary cwd and file contents."""
+    global _dotenv_cache
+    _dotenv_cache = None
+
+
+def _env(name: str) -> str:
+    """Resolve a config value: real environment first, then the dotenv file."""
+    value = os.environ.get(name, "").strip()
+    if value:
+        return value
+    return _dotenv_values().get(name, "").strip()
+
+
+def env_value(name: str) -> str:
+    """Resolve a config value from the environment or dotenv file.
+
+    Public entry point for harness installers that have a prompt of their own
+    to resolve (currently only Kiro's agent name).
+    """
+    return _env(name)
+
+
+def env_flag(name: str, default: bool = True) -> bool:
+    """Read a boolean setting from the environment or dotenv file.
+
+    Only explicit falsey words turn a default-on setting off, and only explicit
+    truthy words turn a default-off setting on.
+    """
+    raw = _env(name).lower()
+    if not raw:
+        return default
+    if default:
+        return raw not in ("0", "false", "no", "n", "off")
+    return raw in ("1", "true", "yes", "y", "on")
+
+
+def _require_env(name: str, what: str) -> str:
+    """Resolve a required value, or exit with an actionable message."""
+    value = _env(name)
+    if not value:
+        err(f"{what} is required for a non-interactive install — set {name} or put it in a .env file.")
+        sys.exit(1)
+    return value
 
 
 def ensure_shared_runtime() -> None:

--- a/core/setup/__init__.py
+++ b/core/setup/__init__.py
@@ -217,8 +217,25 @@ def _backend_from_env() -> tuple[str, dict]:
         sys.exit(1)
 
     if not target:
+        if _env("ARIZE_SPACE_ID") and _env("PHOENIX_ENDPOINT"):
+            # Both backends signalled. Picking one would silently discard the
+            # other's credentials — a dev running Phoenix locally for their app
+            # has PHOENIX_ENDPOINT in its .env while wanting Arize AX here.
+            err(
+                "Both an Arize space ID and a Phoenix endpoint are configured, so the "
+                "backend is ambiguous. Set ARIZE_BACKEND to 'arize' or 'phoenix'."
+            )
+            sys.exit(1)
         if _env("ARIZE_SPACE_ID"):
             target = "arize"
+        elif _env("ARIZE_API_KEY") and _env("PHOENIX_ENDPOINT"):
+            # An Arize key with only a Phoenix endpoint: inferring Phoenix would
+            # throw the key away, which is never what the caller meant.
+            err(
+                "Found an Arize API key but only a Phoenix endpoint. Add ARIZE_SPACE_ID "
+                "for Arize AX, or set ARIZE_BACKEND=phoenix to use Phoenix deliberately."
+            )
+            sys.exit(1)
         elif _env("PHOENIX_ENDPOINT"):
             target = "phoenix"
         elif _env("ARIZE_API_KEY"):
@@ -490,10 +507,20 @@ _dotenv_path: Optional[Path] = None
 
 
 def _dotenv_candidates() -> list:
-    """Dotenv files to consider, in order. ARIZE_ENV_FILE overrides the search."""
+    """Dotenv files to consider, in order. ARIZE_ENV_FILE overrides the search.
+
+    An explicit path that cannot be read is a hard error rather than a silent
+    fall-back to the environment: naming a file states where the credentials are
+    meant to come from, and a typo would otherwise quietly install with whatever
+    happened to be in the environment instead.
+    """
     explicit = os.environ.get("ARIZE_ENV_FILE", "").strip()
     if explicit:
-        return [Path(explicit).expanduser()]
+        path = Path(explicit).expanduser()
+        if not path.is_file():
+            err(f"ARIZE_ENV_FILE points at {path}, which is not a readable file.")
+            sys.exit(1)
+        return [path]
     cwd = Path.cwd()
     return [cwd / ".env", cwd / ".env.local"]
 

--- a/core/setup/__init__.py
+++ b/core/setup/__init__.py
@@ -517,8 +517,8 @@ def _dotenv_values() -> dict:
 
     Lets ``ax api-keys create --env-file .env`` feed the installer directly:
     the key goes CLI → file → installer, never through argv, shell history, or
-    a coding agent's transcript. Only consulted when the real environment
-    doesn't already supply the value, so exported vars still win.
+    a coding agent's transcript. Values found here take precedence over the
+    real environment (see ``_env``).
     """
     global _dotenv_cache
     if _dotenv_cache is not None:
@@ -544,15 +544,24 @@ def _reset_dotenv_cache() -> None:
 
 
 def _env(name: str) -> str:
-    """Resolve a config value: real environment first, then the dotenv file."""
-    value = os.environ.get(name, "").strip()
+    """Resolve a config value: dotenv file first, then the real environment.
+
+    The file deliberately wins. A dotenv file is an explicit, inspectable
+    statement of intent; ``ARIZE_*`` variables are frequently *inherited* rather
+    than chosen — an installed harness exports ``ARIZE_API_KEY``,
+    ``ARIZE_SPACE_ID`` and ``ARIZE_PROJECT_NAME`` into every agent session via
+    the harness settings file. Reading the environment first let those stale
+    values silently beat the credentials the caller had just written, and could
+    pair a fresh key from the file with a space ID from the environment.
+    """
+    value = _dotenv_values().get(name, "").strip()
     if value:
         return value
-    return _dotenv_values().get(name, "").strip()
+    return os.environ.get(name, "").strip()
 
 
 def env_value(name: str) -> str:
-    """Resolve a config value from the environment or dotenv file.
+    """Resolve a config value from the dotenv file or environment.
 
     Public entry point for harness installers that have a prompt of their own
     to resolve (currently only Kiro's agent name).
@@ -561,7 +570,7 @@ def env_value(name: str) -> str:
 
 
 def env_flag(name: str, default: bool = True) -> bool:
-    """Read a boolean setting from the environment or dotenv file.
+    """Read a boolean setting from the dotenv file or environment.
 
     Only explicit falsey words turn a default-on setting off, and only explicit
     truthy words turn a default-off setting on.

--- a/core/setup/__init__.py
+++ b/core/setup/__init__.py
@@ -329,7 +329,10 @@ def prompt_project_name(default: str) -> str:
         # different one and collide their spans. Only an explicit dotenv entry
         # or the harness default may set it.
         name = _dotenv_only("ARIZE_PROJECT_NAME") or default
-        source = _source_of("ARIZE_PROJECT_NAME", fallback="harness default", include_env=False)
+        # "default" rather than "harness default": on a re-install the caller
+        # passes the stored project name as the default, so naming the harness
+        # would be wrong.
+        source = _source_of("ARIZE_PROJECT_NAME", fallback="default", include_env=False)
         info(f"Project name: {name} (from {source})")
         return name
 

--- a/core/setup/__init__.py
+++ b/core/setup/__init__.py
@@ -237,14 +237,19 @@ def _backend_from_env() -> tuple[str, dict]:
 
     if target == "phoenix":
         endpoint = _env("PHOENIX_ENDPOINT") or "http://localhost:6006"
-        info(f"Backend: Phoenix at {endpoint}")
-        return ("phoenix", {"endpoint": endpoint, "api_key": _env("PHOENIX_API_KEY")})
+        api_key = _env("PHOENIX_API_KEY")
+        info(f"Backend: Phoenix at {endpoint} (from {_source_of('PHOENIX_ENDPOINT', fallback='default')})")
+        info(f"  API key: {'found' if api_key else 'none'} (from {_source_of('PHOENIX_API_KEY', fallback='unset')})")
+        return ("phoenix", {"endpoint": endpoint, "api_key": api_key})
 
-    # Arize AX. Read the key but never echo it — only report that it was found.
+    # Arize AX. Read the key but never echo it — only report that it was found
+    # and where from, so a wrong-credentials install is diagnosable.
     api_key = _require_env("ARIZE_API_KEY", "An Arize API key")
     space_id = _require_env("ARIZE_SPACE_ID", "An Arize space ID")
     endpoint = _env("ARIZE_OTLP_ENDPOINT") or "otlp.arize.com:443"
-    info(f"Backend: Arize AX at {endpoint} (space {space_id}, API key from ARIZE_API_KEY)")
+    info(f"Backend: Arize AX at {endpoint} (from {_source_of('ARIZE_OTLP_ENDPOINT', fallback='default')})")
+    info(f"  space ID: {space_id} (from {_source_of('ARIZE_SPACE_ID')})")
+    info(f"  API key: found (from {_source_of('ARIZE_API_KEY')})")
     return ("arize", {"endpoint": endpoint, "api_key": api_key, "space_id": space_id})
 
 
@@ -318,8 +323,14 @@ def _try_copy_from(target: str, existing_harnesses: dict | None) -> dict | None:
 def prompt_project_name(default: str) -> str:
     """Prompt for project name. Returns default if blank."""
     if non_interactive():
-        name = _env("ARIZE_PROJECT_NAME") or default
-        info(f"Project name: {name}")
+        # Deliberately not _env(): the ambient ARIZE_PROJECT_NAME belongs to
+        # whichever harness is already installed and exports it into this
+        # session. Inheriting it would name *this* harness's project after a
+        # different one and collide their spans. Only an explicit dotenv entry
+        # or the harness default may set it.
+        name = _dotenv_only("ARIZE_PROJECT_NAME") or default
+        source = _source_of("ARIZE_PROJECT_NAME", fallback="harness default", include_env=False)
+        info(f"Project name: {name} (from {source})")
         return name
 
     print("")
@@ -472,6 +483,7 @@ _DOTENV_KEYS = (
 )
 
 _dotenv_cache: Optional[dict] = None
+_dotenv_path: Optional[Path] = None
 
 
 def _dotenv_candidates() -> list:
@@ -488,6 +500,11 @@ def _parse_dotenv(path: Path) -> dict:
 
     Handles ``export KEY=value``, surrounding quotes, comments and blank lines.
     Values are not shell-expanded — a literal ``$FOO`` stays literal.
+
+    An unquoted value ends at a whitespace-preceded ``#``, matching dotenv
+    convention: ``KEY=value # note`` yields ``value``. Quote the value to keep
+    a literal ``#``. Without this, a commented credential line silently
+    produced a malformed value rather than an error.
     """
     values: dict = {}
     try:
@@ -504,12 +521,27 @@ def _parse_dotenv(path: Path) -> dict:
         key, _, raw = line.partition("=")
         if key.strip() not in _DOTENV_KEYS:
             continue
+
         value = raw.strip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
             value = value[1:-1]
+        else:
+            value = _strip_inline_comment(value)
+
         values[key.strip()] = value.strip()
 
     return values
+
+
+def _strip_inline_comment(value: str) -> str:
+    """Drop a trailing ``# comment`` from an unquoted dotenv value."""
+    if value.startswith("#"):
+        return ""
+    for sep in (" #", "\t#"):
+        idx = value.find(sep)
+        if idx != -1:
+            value = value[:idx]
+    return value
 
 
 def _dotenv_values() -> dict:
@@ -520,7 +552,7 @@ def _dotenv_values() -> dict:
     a coding agent's transcript. Values found here take precedence over the
     real environment (see ``_env``).
     """
-    global _dotenv_cache
+    global _dotenv_cache, _dotenv_path
     if _dotenv_cache is not None:
         return _dotenv_cache
 
@@ -532,6 +564,7 @@ def _dotenv_values() -> dict:
         if found:
             info(f"Reading configuration from {path} ({len(found)} value(s))")
             _dotenv_cache = found
+            _dotenv_path = path
             break
 
     return _dotenv_cache
@@ -539,8 +572,30 @@ def _dotenv_values() -> dict:
 
 def _reset_dotenv_cache() -> None:
     """Clear the dotenv cache. For tests, which vary cwd and file contents."""
-    global _dotenv_cache
+    global _dotenv_cache, _dotenv_path
     _dotenv_cache = None
+    _dotenv_path = None
+
+
+def _dotenv_only(name: str) -> str:
+    """Resolve a value from the dotenv file alone, ignoring the environment."""
+    return _dotenv_values().get(name, "").strip()
+
+
+def _source_of(name: str, fallback: str = "unset", include_env: bool = True) -> str:
+    """Name where a value was resolved from, for reporting back to the user.
+
+    Answers the question the old output could not: whether a value came from the
+    file the caller wrote or from an inherited variable.
+
+    ``include_env=False`` for values that ignore the environment by design, so
+    the label never credits a source that was not consulted.
+    """
+    if _dotenv_only(name):
+        return str(_dotenv_path) if _dotenv_path else "dotenv file"
+    if include_env and os.environ.get(name, "").strip():
+        return f"${name}"
+    return fallback
 
 
 def _env(name: str) -> str:

--- a/core/setup/__init__.py
+++ b/core/setup/__init__.py
@@ -361,17 +361,30 @@ def prompt_project_name(default: str) -> str:
 def prompt_content_logging() -> dict:
     """Prompt for content logging settings. Returns the dict to write under `logging:`.
 
-    All three default to True to match the kit's existing capture-everything
-    behavior. Users opt out per category.
+    Interactively, all three default to True — the questions below are ``[Y/n]``
+    and users opt out per category, matching the kit's capture-everything
+    behaviour.
+
+    Non-interactively they default to **False**. That asymmetry is the point: a
+    ``[Y/n]`` default is a human declining to change an answer they were shown,
+    which is consent; the same default with nobody watching is capture of
+    prompts, commands and file contents that no one agreed to. Reaching it
+    needs no malice — ``update`` forces non-interactive mode whenever there is no
+    terminal, so a cron job or CI run against a config with no ``logging`` block
+    would have switched capture on silently. Each category now requires its
+    ``ARIZE_LOG_*`` setting to say so explicitly.
     """
     if non_interactive():
         block = {
-            "prompts": env_flag("ARIZE_LOG_PROMPTS"),
-            "tool_details": env_flag("ARIZE_LOG_TOOL_DETAILS"),
-            "tool_content": env_flag("ARIZE_LOG_TOOL_CONTENT"),
+            "prompts": env_flag("ARIZE_LOG_PROMPTS", default=False),
+            "tool_details": env_flag("ARIZE_LOG_TOOL_DETAILS", default=False),
+            "tool_content": env_flag("ARIZE_LOG_TOOL_CONTENT", default=False),
         }
         enabled = ", ".join(f"{k}={'on' if v else 'off'}" for k, v in block.items())
         info(f"Content logging: {enabled}")
+        if not any(block.values()):
+            info("No ARIZE_LOG_* settings given, so no content is captured — span structure only.")
+            info("Set ARIZE_LOG_PROMPTS, ARIZE_LOG_TOOL_DETAILS or ARIZE_LOG_TOOL_CONTENT to true to capture it.")
         return block
 
     print("")
@@ -507,7 +520,19 @@ _dotenv_path: Optional[Path] = None
 
 
 def _dotenv_candidates() -> list:
-    """Dotenv files to consider, in order. ARIZE_ENV_FILE overrides the search.
+    """The dotenv file to read, from ARIZE_ENV_FILE only. Empty list when unset.
+
+    Deliberately does **not** fall back to ``./.env`` or ``./.env.local``.
+    Values from a dotenv file outrank the process environment (see ``_env``), and
+    the working directory is whatever repository the user happens to be sitting
+    in. An implicit search therefore let a cloned repo's dotenv supply the
+    *routing* — ``ARIZE_OTLP_ENDPOINT`` or ``PHOENIX_ENDPOINT`` — while the
+    user's real credentials came from the ambient environment, writing a config
+    that ships spans and a bearer API key to an endpoint the repo chose. Every
+    later session on that machine would keep doing it.
+
+    Requiring an explicit path keeps the precedence rule where it is useful
+    without handing the decision to untrusted content.
 
     An explicit path that cannot be read is a hard error rather than a silent
     fall-back to the environment: naming a file states where the credentials are
@@ -515,14 +540,13 @@ def _dotenv_candidates() -> list:
     happened to be in the environment instead.
     """
     explicit = os.environ.get("ARIZE_ENV_FILE", "").strip()
-    if explicit:
-        path = Path(explicit).expanduser()
-        if not path.is_file():
-            err(f"ARIZE_ENV_FILE points at {path}, which is not a readable file.")
-            sys.exit(1)
-        return [path]
-    cwd = Path.cwd()
-    return [cwd / ".env", cwd / ".env.local"]
+    if not explicit:
+        return []
+    path = Path(explicit).expanduser()
+    if not path.is_file():
+        err(f"ARIZE_ENV_FILE points at {path}, which is not a readable file.")
+        sys.exit(1)
+    return [path]
 
 
 def _parse_dotenv(path: Path) -> dict:

--- a/core/setup/status.py
+++ b/core/setup/status.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Report installed-tracing state, for humans or as JSON.
+
+Exists so a caller — CI, a script, or a coding agent that just ran a
+non-interactive install — can *verify* the result instead of parsing prose out
+of the installer's output.
+
+Secrets are never included. An API key is reported only as ``api_key_present``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+from core.config import load_config
+from core.setup import CONFIG_FILE, INSTALL_DIR, VENV_DIR
+
+# Where each harness registers itself, as (module, constant names). Checked in
+# order; the first path that exists decides. Kept declarative so a new harness
+# is one line rather than a bespoke check.
+_REGISTRATION = {
+    "claude-code": ("tracing.claude_code.constants", ("SETTINGS_FILE",)),
+    "codex": ("tracing.codex.constants", ("CODEX_CONFIG_FILE",)),
+    "copilot": ("tracing.copilot.constants", ("HOOKS_FILE",)),
+    "cursor": ("tracing.cursor.constants", ("HOOKS_FILE",)),
+    "gemini": ("tracing.gemini.constants", ("SETTINGS_FILE",)),
+    "kiro": ("tracing.kiro.constants", ("KIRO_AGENTS_DIR",)),
+    "opencode": ("tracing.opencode.constants", ("PLUGIN_FILE",)),
+    "omp": ("tracing.omp.constants", ("SETTINGS_FILE", "PLUGIN_FILE")),
+}
+
+
+def _registration_paths(harness: str) -> list:
+    """Resolve the candidate registration paths for a harness.
+
+    Returns [] when the harness is unknown or its constants can't be imported —
+    reported as an unknown registration rather than a crash.
+    """
+    entry = _REGISTRATION.get(harness)
+    if not entry:
+        return []
+
+    module_name, names = entry
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError:
+        return []
+
+    paths = []
+    for name in names:
+        value = getattr(module, name, None)
+        if isinstance(value, Path):
+            paths.append(value)
+    return paths
+
+
+def _references_install(path: Path) -> bool:
+    """True when `path` points at, or mentions, our install directory.
+
+    Every harness wires itself up by writing an absolute path into its own
+    settings/config file, or by linking a plugin out of the install dir — so a
+    mention of INSTALL_DIR is the common signal across all of them.
+    """
+    marker = str(INSTALL_DIR)
+
+    if path.is_symlink():
+        try:
+            if str(path.resolve()).startswith(marker):
+                return True
+        except OSError:
+            return False
+
+    if path.is_dir():
+        for child in sorted(path.iterdir()):
+            if child.is_file() and _references_install(child):
+                return True
+        return False
+
+    try:
+        return marker in path.read_text(errors="ignore")
+    except OSError:
+        return False
+
+
+def _registration_state(harness: str) -> tuple:
+    """Return (registered, path) for a harness.
+
+    ``registered`` is None when we have no way to tell — an unknown harness, or
+    one whose constants failed to import. Never guess True.
+    """
+    paths = _registration_paths(harness)
+    if not paths:
+        return (None, None)
+
+    for path in paths:
+        if path.exists():
+            return (_references_install(path), str(path))
+
+    # Nothing on disk: not registered, but report where we looked.
+    return (False, str(paths[0]))
+
+
+def collect_status() -> dict:
+    """Build the full status payload. Contains no secrets."""
+    config = load_config(str(CONFIG_FILE)) or {}
+    harnesses = config.get("harnesses")
+    if not isinstance(harnesses, dict):
+        harnesses = {}
+
+    entries = []
+    for name in sorted(harnesses):
+        entry = harnesses[name]
+        if not isinstance(entry, dict):
+            continue
+
+        registered, path = _registration_state(name)
+        item = {
+            "name": name,
+            "project_name": entry.get("project_name") or name,
+            "target": entry.get("target"),
+            "endpoint": entry.get("endpoint"),
+            "api_key_present": bool(entry.get("api_key")),
+            "registered": registered,
+            "registration_path": path,
+        }
+        if entry.get("target") == "arize":
+            item["space_id"] = entry.get("space_id")
+        entries.append(item)
+
+    return {
+        "install_dir": str(INSTALL_DIR),
+        "installed": VENV_DIR.exists(),
+        "config_file": str(CONFIG_FILE),
+        "config_exists": CONFIG_FILE.exists(),
+        "user_id": config.get("user_id") or "",
+        "logging": config.get("logging"),
+        "harnesses": entries,
+    }
+
+
+def _format_human(status: dict) -> str:
+    """Render the payload as indented text."""
+    lines = [
+        f"Install dir:  {status['install_dir']}",
+        f"Installed:    {'yes' if status['installed'] else 'no'}",
+        f"Config:       {status['config_file']}" f"{'' if status['config_exists'] else ' (missing)'}",
+    ]
+
+    if status["user_id"]:
+        lines.append(f"User ID:      {status['user_id']}")
+
+    logging_block = status["logging"]
+    if isinstance(logging_block, dict):
+        flags = ", ".join(f"{k}={'on' if v else 'off'}" for k, v in sorted(logging_block.items()))
+        lines.append(f"Logging:      {flags}")
+
+    if not status["harnesses"]:
+        lines.append("")
+        lines.append("No harnesses configured.")
+        return "\n".join(lines)
+
+    lines.append("")
+    lines.append("Harnesses:")
+    for item in status["harnesses"]:
+        if item["registered"] is None:
+            reg = "registration unknown"
+        elif item["registered"]:
+            reg = "registered"
+        else:
+            reg = "NOT registered"
+
+        lines.append(f"  {item['name']}")
+        lines.append(f"    project:  {item['project_name']}")
+        lines.append(f"    backend:  {item['target']} → {item['endpoint']}")
+        if "space_id" in item:
+            lines.append(f"    space:    {item['space_id']}")
+        lines.append(f"    API key:  {'present' if item['api_key_present'] else 'MISSING'}")
+        lines.append(f"    hooks:    {reg}" + (f" ({item['registration_path']})" if item["registration_path"] else ""))
+
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="install.sh status",
+        description="Report configured harnesses and whether their hooks are wired up.",
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    status = collect_status()
+
+    if args.json:
+        print(json.dumps(status, indent=2, sort_keys=True))
+    else:
+        print(_format_human(status))
+
+    # Non-zero when nothing is set up, so a caller can gate on it.
+    return 0 if status["harnesses"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/setup/status.py
+++ b/core/setup/status.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import importlib
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Optional
@@ -65,8 +66,13 @@ def _references_install(path: Path) -> bool:
     Every harness wires itself up by writing an absolute path into its own
     settings/config file, or by linking a plugin out of the install dir — so a
     mention of INSTALL_DIR is the common signal across all of them.
+
+    The marker carries a trailing separator so a sibling directory cannot match
+    on prefix: ``~/.arize/harness-old`` is not ``~/.arize/harness``, and
+    reporting a stale install as wired up would be a false positive in the one
+    command whose job is to tell you the truth about that.
     """
-    marker = str(INSTALL_DIR)
+    marker = str(INSTALL_DIR).rstrip(os.sep) + os.sep
 
     if path.is_symlink():
         try:

--- a/core/setup/status.py
+++ b/core/setup/status.py
@@ -20,9 +20,9 @@ from typing import Optional
 from core.config import load_config
 from core.setup import CONFIG_FILE, INSTALL_DIR, VENV_DIR
 
-# Where each harness registers itself, as (module, constant names). Checked in
-# order; the first path that exists decides. Kept declarative so a new harness
-# is one line rather than a bespoke check.
+# Where each harness registers itself, as (module, constant names). Every
+# candidate is checked — a harness may register through any one of them. Kept
+# declarative so a new harness is one line rather than a bespoke check.
 _REGISTRATION = {
     "claude-code": ("tracing.claude_code.constants", ("SETTINGS_FILE",)),
     "codex": ("tracing.codex.constants", ("CODEX_CONFIG_FILE",)),
@@ -90,6 +90,10 @@ def _references_install(path: Path) -> bool:
 def _registration_state(harness: str) -> tuple:
     """Return (registered, path) for a harness.
 
+    Every existing candidate is checked, not just the first: a harness can
+    register through any one of them, so stopping at the first existing path
+    would report a false negative when a later path is the one that matched.
+
     ``registered`` is None when we have no way to tell — an unknown harness, or
     one whose constants failed to import. Never guess True.
     """
@@ -97,12 +101,14 @@ def _registration_state(harness: str) -> tuple:
     if not paths:
         return (None, None)
 
-    for path in paths:
-        if path.exists():
-            return (_references_install(path), str(path))
+    existing = [path for path in paths if path.exists()]
+    for path in existing:
+        if _references_install(path):
+            return (True, str(path))
 
-    # Nothing on disk: not registered, but report where we looked.
-    return (False, str(paths[0]))
+    # Nothing references us. Point at what we actually inspected when something
+    # was there, otherwise at where we looked first.
+    return (False, str(existing[0]) if existing else str(paths[0]))
 
 
 def collect_status() -> dict:
@@ -132,6 +138,10 @@ def collect_status() -> dict:
             item["space_id"] = entry.get("space_id")
         entries.append(item)
 
+    # A harness we cannot check is not counted as broken — that would be
+    # guessing in the other direction. Only an explicit False counts.
+    unregistered = [item["name"] for item in entries if item["registered"] is False]
+
     return {
         "install_dir": str(INSTALL_DIR),
         "installed": VENV_DIR.exists(),
@@ -140,6 +150,8 @@ def collect_status() -> dict:
         "user_id": config.get("user_id") or "",
         "logging": config.get("logging"),
         "harnesses": entries,
+        "unregistered": unregistered,
+        "healthy": bool(entries) and not unregistered,
     }
 
 
@@ -164,6 +176,12 @@ def _format_human(status: dict) -> str:
         lines.append("No harnesses configured.")
         return "\n".join(lines)
 
+    if status["unregistered"]:
+        lines.append("")
+        lines.append(
+            "Hooks are missing for: " + ", ".join(status["unregistered"]) + " — re-run the install for those harnesses."
+        )
+
     lines.append("")
     lines.append("Harnesses:")
     for item in status["harnesses"]:
@@ -186,6 +204,17 @@ def _format_human(status: dict) -> str:
 
 
 def main(argv: Optional[list] = None) -> int:
+    """Print the report and return an exit code a caller can gate on.
+
+    0  every configured harness is wired up
+    1  nothing configured
+    2  configured, but at least one harness's hooks are missing
+
+    2 exists because 0 previously covered it: a harness whose hooks had been
+    removed reported ``"registered": false`` in the payload while the process
+    still exited successfully, so anything gating on the exit code alone
+    concluded the install was fine.
+    """
     parser = argparse.ArgumentParser(
         prog="install.sh status",
         description="Report configured harnesses and whether their hooks are wired up.",
@@ -200,8 +229,9 @@ def main(argv: Optional[list] = None) -> int:
     else:
         print(_format_human(status))
 
-    # Non-zero when nothing is set up, so a caller can gate on it.
-    return 0 if status["harnesses"] else 1
+    if not status["harnesses"]:
+        return 1
+    return 2 if status["unregistered"] else 0
 
 
 if __name__ == "__main__":

--- a/install.bat
+++ b/install.bat
@@ -259,11 +259,12 @@ echo     --json          With status: emit machine-readable JSON
 echo     --non-interactive, -y  Ask nothing; read values from the environment
 echo                     or a .env file. Missing required values are an error.
 echo.
-echo   Non-interactive install reads (environment first, then .env/.env.local,
-echo   or ARIZE_ENV_FILE): ARIZE_API_KEY and ARIZE_SPACE_ID for Arize AX,
+echo   Non-interactive install reads the environment, plus a dotenv file named
+echo   with ARIZE_ENV_FILE (no automatic .env search): ARIZE_API_KEY and ARIZE_SPACE_ID for Arize AX,
 echo   PHOENIX_ENDPOINT and PHOENIX_API_KEY for Phoenix, plus optional
 echo   ARIZE_BACKEND, ARIZE_PROJECT_NAME, ARIZE_USER_ID, ARIZE_OTLP_ENDPOINT,
-echo   ARIZE_LOG_PROMPTS, ARIZE_LOG_TOOL_DETAILS, ARIZE_LOG_TOOL_CONTENT.
+echo   ARIZE_LOG_PROMPTS, ARIZE_LOG_TOOL_DETAILS, ARIZE_LOG_TOOL_CONTENT (all
+echo   off unless set to true).
 echo.
 echo   Examples:
 echo     install.bat claude

--- a/install.bat
+++ b/install.bat
@@ -257,7 +257,8 @@ echo     --with-skills   Symlink harness skills into .agents\skills\
 echo     --branch NAME   Install from a specific git branch (default: main)
 echo     --json          With status: emit machine-readable JSON
 echo     --non-interactive, -y  Ask nothing; read values from the environment
-echo                     or a .env file. Missing required values are an error.
+echo                     or the file named by ARIZE_ENV_FILE. Missing required
+echo                     values are an error.
 echo.
 echo   Non-interactive install reads the environment, plus a dotenv file named
 echo   with ARIZE_ENV_FILE (no automatic .env search): ARIZE_API_KEY and ARIZE_SPACE_ID for Arize AX,

--- a/install.bat
+++ b/install.bat
@@ -27,6 +27,8 @@ if /i "%~1"=="-h"        goto :usage
 if /i "%~1"=="--help"    goto :usage
 if /i "%~1"=="help"      goto :usage
 if /i "%~1"=="--with-skills" ( set "WITH_SKILLS=--with-skills" & shift & goto :parse_args )
+if /i "%~1"=="--non-interactive" ( set "ARIZE_NONINTERACTIVE=1" & shift & goto :parse_args )
+if /i "%~1"=="-y" ( set "ARIZE_NONINTERACTIVE=1" & shift & goto :parse_args )
 if /i "%~1"=="--branch" ( set "INSTALL_BRANCH=%~2" & set "TARBALL_URL=https://github.com/Arize-ai/coding-harness-tracing/archive/refs/heads/%~2.tar.gz" & shift & shift & goto :parse_args )
 for %%C in (claude codex copilot cursor gemini kiro opencode omp) do if /i "%~1"=="%%C" ( set "COMMAND=%%C" & shift & goto :parse_args )
 if /i "%~1"=="update" ( set "COMMAND=update" & shift & goto :parse_args )
@@ -237,6 +239,14 @@ echo.
 echo   Flags:
 echo     --with-skills   Symlink harness skills into .agents\skills\
 echo     --branch NAME   Install from a specific git branch (default: main)
+echo     --non-interactive, -y  Ask nothing; read values from the environment
+echo                     or a .env file. Missing required values are an error.
+echo.
+echo   Non-interactive install reads (environment first, then .env/.env.local,
+echo   or ARIZE_ENV_FILE): ARIZE_API_KEY and ARIZE_SPACE_ID for Arize AX,
+echo   PHOENIX_ENDPOINT and PHOENIX_API_KEY for Phoenix, plus optional
+echo   ARIZE_BACKEND, ARIZE_PROJECT_NAME, ARIZE_USER_ID, ARIZE_OTLP_ENDPOINT,
+echo   ARIZE_LOG_PROMPTS, ARIZE_LOG_TOOL_DETAILS, ARIZE_LOG_TOOL_CONTENT.
 echo.
 echo   Examples:
 echo     install.bat claude

--- a/install.bat
+++ b/install.bat
@@ -21,6 +21,7 @@ REM --- Parse arguments ---
 set "COMMAND="
 set "UNINSTALL_HARNESS="
 set "WITH_SKILLS="
+set "STATUS_ARGS="
 :parse_args
 if "%~1"=="" goto :done_args
 if /i "%~1"=="-h"        goto :usage
@@ -29,9 +30,11 @@ if /i "%~1"=="help"      goto :usage
 if /i "%~1"=="--with-skills" ( set "WITH_SKILLS=--with-skills" & shift & goto :parse_args )
 if /i "%~1"=="--non-interactive" ( set "ARIZE_NONINTERACTIVE=1" & shift & goto :parse_args )
 if /i "%~1"=="-y" ( set "ARIZE_NONINTERACTIVE=1" & shift & goto :parse_args )
+if /i "%~1"=="--json" ( set "STATUS_ARGS=--json" & shift & goto :parse_args )
 if /i "%~1"=="--branch" ( set "INSTALL_BRANCH=%~2" & set "TARBALL_URL=https://github.com/Arize-ai/coding-harness-tracing/archive/refs/heads/%~2.tar.gz" & shift & shift & goto :parse_args )
 for %%C in (claude codex copilot cursor gemini kiro opencode omp) do if /i "%~1"=="%%C" ( set "COMMAND=%%C" & shift & goto :parse_args )
 if /i "%~1"=="update" ( set "COMMAND=update" & shift & goto :parse_args )
+if /i "%~1"=="status" ( set "COMMAND=status" & shift & goto :parse_args )
 if /i "%~1"=="uninstall" (
     set "COMMAND=uninstall" & shift
     for %%C in (claude codex copilot cursor gemini kiro opencode omp) do if /i "%~1"=="%%C" ( set "UNINSTALL_HARNESS=%%C" & shift )
@@ -46,6 +49,7 @@ REM --- Harness name -> directory mapping ---
 REM claude->tracing\claude_code  codex->tracing\codex  copilot->tracing\copilot  cursor->tracing\cursor  gemini->tracing\gemini  kiro->tracing\kiro  opencode->tracing\opencode  omp->tracing\omp
 
 REM --- Dispatch ---
+if "%COMMAND%"=="status"    goto :cmd_status
 if "%COMMAND%"=="update"    goto :cmd_update
 if "%COMMAND%"=="uninstall" goto :cmd_uninstall
 
@@ -64,6 +68,12 @@ set "_PY=%INSTALL_DIR%\%HARNESS_DIR%\install.py"
 if not exist "%_PY%" ( echo [arize] install.py not found at %_PY% >&2 & exit /b 1 )
 echo [arize] Running %COMMAND% install...
 "%VENV_PYTHON%" "%_PY%" install %WITH_SKILLS%
+exit /b %ERRORLEVEL%
+
+REM --- cmd_status ---
+:cmd_status
+if not exist "%VENV_PYTHON%" ( echo [arize] Venv not found - nothing installed >&2 & exit /b 1 )
+"%VENV_PYTHON%" -m core.setup.status %STATUS_ARGS%
 exit /b %ERRORLEVEL%
 
 REM --- cmd_update ---
@@ -233,12 +243,14 @@ echo     gemini              Install tracing for Gemini CLI
 echo     kiro                Install tracing for Kiro CLI
 echo     opencode            Install tracing for opencode
 echo     omp                 Install tracing for Oh My Pi (omp)
+echo     status              Report configured harnesses and hook wiring
 echo     update              Update to latest and reinstall all harnesses
 echo     uninstall [harness] Remove one harness or full wipe
 echo.
 echo   Flags:
 echo     --with-skills   Symlink harness skills into .agents\skills\
 echo     --branch NAME   Install from a specific git branch (default: main)
+echo     --json          With status: emit machine-readable JSON
 echo     --non-interactive, -y  Ask nothing; read values from the environment
 echo                     or a .env file. Missing required values are an error.
 echo.

--- a/install.bat
+++ b/install.bat
@@ -81,6 +81,11 @@ REM --- cmd_update ---
 if not exist "%INSTALL_DIR%" ( echo [arize] Not installed at %INSTALL_DIR% >&2 & exit /b 1 )
 call :find_python
 if "%FOUND_PYTHON%"=="" ( echo [arize] Error: Python 3.9+ is required >&2 & exit /b 1 )
+REM Re-registering runs each harness's installer, which prompts for the project
+REM name. With no console to answer on that dies with an EOFError, so fall back
+REM to stored values there — and only there, so an interactive update keeps
+REM every prompt it has today. cmd has no -t test; ask Python instead.
+%FOUND_PYTHON% -c "import sys; sys.exit(0 if sys.stdin.isatty() else 1)" >nul 2>&1 || set "ARIZE_NONINTERACTIVE=1"
 set "_UPDATE_NEED_VENV=0"
 if exist "%INSTALL_DIR%\.git" (
     echo [arize] Pulling latest changes...

--- a/install.sh
+++ b/install.sh
@@ -250,7 +250,7 @@ harness_dir() {
 
 install_harness() {
     local cmd="$1" skills="$2"
-    local dir; dir=$(harness_dir "$cmd") || { err "Unknown harness: ${cmd}"; usage; exit 1; }
+    harness_dir "$cmd" >/dev/null || { err "Unknown harness: ${cmd}"; usage; exit 1; }
     header "Installing ${cmd} tracing"
     local python_cmd; python_cmd=$(find_python) || { err "No Python 3.9+ found"; exit 1; }
     info "Found Python: ${python_cmd} ($("$python_cmd" --version 2>&1))"
@@ -428,7 +428,10 @@ main() {
             if [[ -n "$harnesses" ]]; then
                 while IFS= read -r key; do
                     harness_dir "$key" >/dev/null || { warn "Unknown harness: ${key} (skipping)"; continue; }
-                    info "Re-registering ${key}..."; run_harness_py "$key" "$vp" install
+                    # Keep going, as the uninstall loop does: one harness whose
+                    # registration fails should not abandon the rest half-updated.
+                    info "Re-registering ${key}..."
+                    run_harness_py "$key" "$vp" install || warn "${key} re-registration failed (continuing)"
                 done <<< "$harnesses"
             else info "No installed harnesses found to re-register"; fi
             info "Update complete."

--- a/install.sh
+++ b/install.sh
@@ -254,8 +254,8 @@ Commands:
 Flags:
   --with-skills         Symlink harness skills into .agents/skills/
   --branch NAME         Install from a specific git branch (default: main)
-  --json                With `status`: emit machine-readable JSON. Exits non-zero
-                        when no harness is configured, so callers can gate on it.
+  --json                With `status`: emit machine-readable JSON. Exit code is
+                        0 all wired up, 1 nothing configured, 2 hooks missing.
   --non-interactive, -y Ask nothing; read every value from the environment or a
                         .env file. Missing required values are an error.
 

--- a/install.sh
+++ b/install.sh
@@ -344,6 +344,11 @@ main() {
             ;;
         update)
             header "Updating coding-harness-tracing"
+            # Re-registering runs each harness's installer, which prompts for the
+            # project name. With no terminal to answer on that used to die with an
+            # EOFError, so fall back to stored values there — and only there, so an
+            # interactive update keeps every prompt it has today.
+            [[ -n "$_tty_in" ]] || export ARIZE_NONINTERACTIVE=1
             if [[ -d "${INSTALL_DIR}/.git" ]]; then
                 info "Pulling latest changes..."
                 git -C "$INSTALL_DIR" pull --ff-only 2>/dev/null || {

--- a/install.sh
+++ b/install.sh
@@ -37,12 +37,6 @@ _tty_in=""
 if [[ -t 0 ]]; then _tty_in="/dev/stdin"
 elif (exec 3< /dev/tty) 2>/dev/null; then exec 3<&-; _tty_in="/dev/tty"; fi
 
-tty_input() {
-    local prompt="$1" reply=""
-    [[ -n "$_tty_in" ]] && read -rp "$prompt" reply < "$_tty_in"
-    echo "$reply"
-}
-
 # Run a command with stdin wired to the user's TTY when possible.
 # Under `curl | bash`, our own stdin is the pipe — not a terminal — so any
 # subprocess that calls input() (e.g. tracing/<harness>/install.py) would hit
@@ -54,25 +48,6 @@ run_with_tty() {
     else
         "$@"
     fi
-}
-
-tty_read_masked_line() {
-    REPLY=""
-    [[ -n "${_tty_in:-}" ]] || return 1
-    local prompt="$1" char
-    printf '%s' "$prompt" >&2
-    while IFS= read -rs -n 1 char < "$_tty_in"; do
-        if [[ -z "$char" || "$char" == $'\n' || "$char" == $'\r' ]]; then
-            printf '\n' >&2; return 0
-        fi
-        if [[ "$char" == $'\177' || "$char" == $'\b' ]]; then
-            [[ -n "$REPLY" ]] && { REPLY="${REPLY%?}"; printf '\b \b' >&2; }
-            continue
-        fi
-        [[ "$char" =~ [[:cntrl:]] ]] && continue
-        REPLY+="$char"; printf '*' >&2
-    done
-    printf '\n' >&2
 }
 
 # -- Python discovery --------------------------------------------------------
@@ -207,6 +182,22 @@ PYEOF
     info "SSL certificates configured via certifi"
 }
 
+# Install the package into the venv. Extra args go to pip (`-U` for update).
+# Shared so install and update cannot drift: they were the same wheel/repo branch
+# twice, differing only by -U, and a flag added to one would have missed the other.
+pip_install_harness() {
+    local pip="$1"; shift
+    if [[ -n "$WHEEL_DIR" ]]; then
+        # --no-index so a missing wheel fails loudly instead of quietly reaching
+        # PyPI, which would defeat the point of installing offline.
+        "$pip" install --quiet "$@" --no-index --find-links "$WHEEL_DIR" coding-harness-tracing \
+            || { err "Failed to install coding-harness-tracing from ${WHEEL_DIR}"; return 1; }
+    else
+        "$pip" install --quiet "$@" "$INSTALL_DIR" 2>/dev/null \
+            || { err "Failed to install coding-harness-tracing package"; return 1; }
+    fi
+}
+
 setup_venv() {
     local python_cmd="$1"
     if ! venv_python &>/dev/null; then
@@ -219,14 +210,7 @@ setup_venv() {
     fi
     local pip; pip=$(venv_pip) || { err "pip not found in venv"; return 1; }
     info "Installing coding-harness-tracing into venv..."
-    if [[ -n "$WHEEL_DIR" ]]; then
-        # --no-index so a missing wheel fails loudly instead of quietly reaching
-        # PyPI, which would defeat the point of installing offline.
-        "$pip" install --quiet --no-index --find-links "$WHEEL_DIR" coding-harness-tracing \
-            || { err "Failed to install coding-harness-tracing from ${WHEEL_DIR}"; return 1; }
-    else
-        "$pip" install --quiet "$INSTALL_DIR" 2>/dev/null || { err "Failed to install coding-harness-tracing package"; return 1; }
-    fi
+    pip_install_harness "$pip" || return 1
 
     [[ "$(uname)" == "Darwin" ]] && _fix_macos_ssl_certs "$pip"
 
@@ -306,7 +290,8 @@ Flags:
   --json                With `status`: emit machine-readable JSON. Exit code is
                         0 all wired up, 1 nothing configured, 2 hooks missing.
   --non-interactive, -y Ask nothing; read every value from the environment or a
-                        .env file. Missing required values are an error.
+                        file named by ARIZE_ENV_FILE. Missing required
+                        values are an error.
 
 Non-interactive install:
   Values come from the environment, or from a dotenv file named with
@@ -424,12 +409,7 @@ main() {
             else install_repo_tarball; fi
             local pip; pip=$(venv_pip) || { err "Venv not found — run install first"; exit 1; }
             info "Reinstalling coding-harness-tracing..."
-            if [[ -n "$WHEEL_DIR" ]]; then
-                "$pip" install --quiet -U --no-index --find-links "$WHEEL_DIR" coding-harness-tracing \
-                    || { err "Failed to reinstall from ${WHEEL_DIR}"; exit 1; }
-            else
-                "$pip" install --quiet -U "$INSTALL_DIR" 2>/dev/null || { err "Failed to reinstall package"; exit 1; }
-            fi
+            pip_install_harness "$pip" -U || exit 1
             local vp; vp=$(venv_python) || { err "venv python not found"; exit 1; }
             info "Migrating legacy config.yaml to config.json (if present)..."
             "$vp" -m core.config migrate || true

--- a/install.sh
+++ b/install.sh
@@ -253,6 +253,30 @@ Commands:
 Flags:
   --with-skills         Symlink harness skills into .agents/skills/
   --branch NAME         Install from a specific git branch (default: main)
+  --non-interactive, -y Ask nothing; read every value from the environment or a
+                        .env file. Missing required values are an error.
+
+Non-interactive install:
+  Values are read from the environment first, then from ./.env or ./.env.local
+  (override the path with ARIZE_ENV_FILE). Because credentials can come from a
+  file, the API key never has to appear in a command line or shell history.
+
+  ARIZE_API_KEY, ARIZE_SPACE_ID     Arize AX credentials (both required)
+  PHOENIX_ENDPOINT, PHOENIX_API_KEY Phoenix credentials
+  ARIZE_BACKEND                     arize|phoenix (default: inferred — a space
+                                    ID means Arize AX, a Phoenix endpoint
+                                    means Phoenix)
+  ARIZE_PROJECT_NAME                Project name (default: the harness name)
+  ARIZE_USER_ID                     Optional user ID stamped on spans
+  ARIZE_OTLP_ENDPOINT               Override otlp.arize.com:443
+  ARIZE_LOG_PROMPTS                 Set false to omit prompt text
+  ARIZE_LOG_TOOL_DETAILS            Set false to omit tool commands and paths
+  ARIZE_LOG_TOOL_CONTENT            Set false to omit tool output
+
+  Example — credentials straight from a dotenv file, nothing exported:
+    ax api-keys create --env-file .env   # writes ARIZE_API_KEY
+    echo 'ARIZE_SPACE_ID=<space-id>' >> .env
+    ./install.sh claude --non-interactive
 
 EOF
 }
@@ -265,6 +289,7 @@ main() {
     while [[ $i -lt ${#args[@]} ]]; do
         case "${args[$i]}" in
             --with-skills) with_skills=true ;;
+            --non-interactive|-y) export ARIZE_NONINTERACTIVE=1 ;;
             --branch)
                 i=$((i + 1))
                 INSTALL_BRANCH="${args[$i]:-main}"

--- a/install.sh
+++ b/install.sh
@@ -234,9 +234,17 @@ setup_venv() {
 }
 
 # -- Harness name mapping ----------------------------------------------------
+#
+# Accepts both the CLI name and the config key. They are the same for every
+# harness except Claude Code, which writes HARNESS_NAME "claude-code" while its
+# CLI name is "claude". `update` and full `uninstall` discover harnesses via
+# list_installed_harnesses(), which yields *config keys*, so without the alias
+# both skipped Claude Code entirely — a full uninstall wiped the venv and left
+# its hooks in ~/.claude/settings.json pointing at the deleted path.
+# install.bat has accepted both spellings all along.
 harness_dir() {
     case "$1" in
-        claude)  echo "tracing/claude_code" ;;
+        claude|claude-code)  echo "tracing/claude_code" ;;
         codex)   echo "tracing/codex" ;;
         copilot) echo "tracing/copilot" ;;
         cursor)  echo "tracing/cursor" ;;

--- a/install.sh
+++ b/install.sh
@@ -309,9 +309,11 @@ Flags:
                         .env file. Missing required values are an error.
 
 Non-interactive install:
-  Values are read from the environment first, then from ./.env or ./.env.local
-  (override the path with ARIZE_ENV_FILE). Because credentials can come from a
-  file, the API key never has to appear in a command line or shell history.
+  Values come from the environment, or from a dotenv file named with
+  ARIZE_ENV_FILE — which keeps the API key out of the command line and shell
+  history. A named file outranks the environment, so there is no automatic
+  ./.env search: a cloned repo's dotenv must not get to choose the endpoint
+  your credentials are sent to.
 
   ARIZE_API_KEY, ARIZE_SPACE_ID     Arize AX credentials (both required)
   PHOENIX_ENDPOINT, PHOENIX_API_KEY Phoenix credentials
@@ -321,14 +323,14 @@ Non-interactive install:
   ARIZE_PROJECT_NAME                Project name (default: the harness name)
   ARIZE_USER_ID                     Optional user ID stamped on spans
   ARIZE_OTLP_ENDPOINT               Override otlp.arize.com:443
-  ARIZE_LOG_PROMPTS                 Set false to omit prompt text
-  ARIZE_LOG_TOOL_DETAILS            Set false to omit tool commands and paths
-  ARIZE_LOG_TOOL_CONTENT            Set false to omit tool output
+  ARIZE_LOG_PROMPTS                 Set true to capture prompt text (off here)
+  ARIZE_LOG_TOOL_DETAILS            Set true to capture tool commands and paths
+  ARIZE_LOG_TOOL_CONTENT            Set true to capture tool output
 
   Example — credentials straight from a dotenv file, nothing exported:
-    ax api-keys create --env-file .env   # writes ARIZE_API_KEY
-    echo 'ARIZE_SPACE_ID=<space-id>' >> .env
-    ./install.sh claude --non-interactive
+    ax api-keys create --env-file ~/.arize/onboarding.env
+    echo 'ARIZE_SPACE_ID=<space-id>' >> ~/.arize/onboarding.env
+    ARIZE_ENV_FILE=~/.arize/onboarding.env ./install.sh claude --non-interactive
 
 EOF
 }

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,10 @@ INSTALL_BRANCH="${ARIZE_INSTALL_BRANCH:-main}"
 TARBALL_URL="https://github.com/Arize-ai/coding-harness-tracing/archive/refs/heads/${INSTALL_BRANCH}.tar.gz"
 INSTALL_DIR="${HOME}/.arize/harness"
 VENV_DIR="${INSTALL_DIR}/venv"
+# When set, install from local wheels in this directory instead of fetching the
+# repo. Lets a caller that already ships the wheels install with no network at
+# all — and with no remote code execution for a permission layer to object to.
+WHEEL_DIR="${ARIZE_WHEEL_DIR:-}"
 
 # -- Terminal helpers --------------------------------------------------------
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
@@ -129,8 +133,33 @@ install_repo_tarball() {
 }
 
 install_repo() {
+    # Wheel mode fetches nothing. The wheel carries every module the harness
+    # needs, so there is no source tree to place — but install.sh itself has to
+    # land in INSTALL_DIR, because `status`, `update` and `uninstall` are all
+    # documented as running from there and repo mode gets it via the extract.
+    if [[ -n "$WHEEL_DIR" ]]; then
+        mkdir -p "$INSTALL_DIR"
+        if [[ -f "${BASH_SOURCE[0]}" ]] && ! cmp -s "${BASH_SOURCE[0]}" "${INSTALL_DIR}/install.sh"; then
+            cp "${BASH_SOURCE[0]}" "${INSTALL_DIR}/install.sh" && chmod +x "${INSTALL_DIR}/install.sh"
+        fi
+        return 0
+    fi
     git_sync_harness_repo "$INSTALL_BRANCH" && return 0
     install_repo_tarball
+}
+
+# Invoke a harness's install.py. Repo mode runs the file from the source tree;
+# wheel mode has no source tree, so it runs the same code as a module. Both
+# resolve `core.*` from site-packages either way — the package is pip-installed,
+# never on sys.path by accident — so these are equivalent, not a fallback.
+run_harness_py() {
+    local key="$1" vp="$2"; shift 2
+    local dir; dir=$(harness_dir "$key") || return 1
+    if [[ -f "${INSTALL_DIR}/${dir}/install.py" ]]; then
+        run_with_tty "$vp" "${INSTALL_DIR}/${dir}/install.py" "$@"
+    else
+        run_with_tty "$vp" -m "${dir//\//.}.install" "$@"
+    fi
 }
 
 # -- Venv setup --------------------------------------------------------------
@@ -148,8 +177,11 @@ _fix_macos_ssl_certs() {
     local vp
     vp=$(venv_python 2>/dev/null) || return 0
 
-    if ! "$pip" install --quiet certifi 2>/dev/null; then
+    local offline=()
+    [[ -n "$WHEEL_DIR" ]] && offline=(--no-index --find-links "$WHEEL_DIR")
+    if ! "$pip" install --quiet "${offline[@]+"${offline[@]}"}" certifi 2>/dev/null; then
         warn "Could not install certifi — SSL verification may fail on macOS"
+        [[ -n "$WHEEL_DIR" ]] && warn "Bundle a certifi wheel in ${WHEEL_DIR} to fix this offline."
         return 0
     fi
 
@@ -187,7 +219,14 @@ setup_venv() {
     fi
     local pip; pip=$(venv_pip) || { err "pip not found in venv"; return 1; }
     info "Installing coding-harness-tracing into venv..."
-    "$pip" install --quiet "$INSTALL_DIR" 2>/dev/null || { err "Failed to install coding-harness-tracing package"; return 1; }
+    if [[ -n "$WHEEL_DIR" ]]; then
+        # --no-index so a missing wheel fails loudly instead of quietly reaching
+        # PyPI, which would defeat the point of installing offline.
+        "$pip" install --quiet --no-index --find-links "$WHEEL_DIR" coding-harness-tracing \
+            || { err "Failed to install coding-harness-tracing from ${WHEEL_DIR}"; return 1; }
+    else
+        "$pip" install --quiet "$INSTALL_DIR" 2>/dev/null || { err "Failed to install coding-harness-tracing package"; return 1; }
+    fi
 
     [[ "$(uname)" == "Darwin" ]] && _fix_macos_ssl_certs "$pip"
 
@@ -220,12 +259,10 @@ install_harness() {
     local vp; vp=$(venv_python) || { err "Venv python not found after setup"; exit 1; }
     info "Migrating legacy config.yaml to config.json (if present)..."
     "$vp" -m core.config migrate || true
-    local install_py="${INSTALL_DIR}/${dir}/install.py"
-    [[ -f "$install_py" ]] || { err "Harness install script not found: ${install_py}"; exit 1; }
     if [[ "$skills" == true ]]; then
-        run_with_tty "$vp" "$install_py" install --with-skills
+        run_harness_py "$cmd" "$vp" install --with-skills
     else
-        run_with_tty "$vp" "$install_py" install
+        run_harness_py "$cmd" "$vp" install
     fi
     info "Setup complete!"
 }
@@ -254,6 +291,10 @@ Commands:
 Flags:
   --with-skills         Symlink harness skills into .agents/skills/
   --branch NAME         Install from a specific git branch (default: main)
+  --wheel-dir DIR       Install from local wheels in DIR instead of downloading
+                        the repo. No network and no remote code execution; also
+                        settable as ARIZE_WHEEL_DIR. Bundle a certifi wheel
+                        alongside it to keep macOS SSL working offline.
   --json                With `status`: emit machine-readable JSON. Exit code is
                         0 all wired up, 1 nothing configured, 2 hooks missing.
   --non-interactive, -y Ask nothing; read every value from the environment or a
@@ -299,6 +340,14 @@ main() {
                 INSTALL_BRANCH="${args[$i]:-main}"
                 TARBALL_URL="https://github.com/Arize-ai/coding-harness-tracing/archive/refs/heads/${INSTALL_BRANCH}.tar.gz"
                 ;;
+            --wheel-dir)
+                i=$((i + 1))
+                WHEEL_DIR="${args[$i]:-}"
+                [[ -d "$WHEEL_DIR" ]] || { err "--wheel-dir needs a directory; got '${WHEEL_DIR}'"; exit 1; }
+                WHEEL_DIR="$(cd "$WHEEL_DIR" && pwd)"
+                compgen -G "${WHEEL_DIR}/coding_harness_tracing-*.whl" >/dev/null \
+                    || { err "No coding_harness_tracing-*.whl in ${WHEEL_DIR}"; exit 1; }
+                ;;
             *) [[ -z "$subcmd" ]] && subcmd="${args[$i]}" ;;
         esac
         i=$((i + 1))
@@ -310,10 +359,10 @@ main() {
             ;;
         uninstall)
             if [[ -n "$subcmd" ]]; then
-                local dir; dir=$(harness_dir "$subcmd") || { err "Unknown harness: ${subcmd}"; usage; exit 1; }
+                harness_dir "$subcmd" >/dev/null || { err "Unknown harness: ${subcmd}"; usage; exit 1; }
                 local vp; vp=$(venv_python) || { err "Venv not found — nothing to uninstall"; exit 1; }
                 header "Uninstalling ${subcmd} tracing"
-                run_with_tty "$vp" "${INSTALL_DIR}/${dir}/install.py" uninstall
+                run_harness_py "$subcmd" "$vp" uninstall
             else
                 local vp; vp=$(venv_python) || {
                     warn "Venv not found — removing install directory"; rm -rf "$INSTALL_DIR"
@@ -328,11 +377,9 @@ main() {
                 harnesses=$("$vp" -c 'from core.setup import list_installed_harnesses as L; print("\n".join(L()))' 2>/dev/null) || true
                 if [[ -n "$harnesses" ]]; then
                     while IFS= read -r key; do
-                        local dir; dir=$(harness_dir "$key") || { warn "Unknown harness: ${key} (skipping)"; continue; }
-                        if [[ -f "${INSTALL_DIR}/${dir}/install.py" ]]; then
-                            info "Uninstalling ${key} tracing..."
-                            run_with_tty "$vp" "${INSTALL_DIR}/${dir}/install.py" uninstall || warn "${key} uninstall failed (continuing)"
-                        fi
+                        harness_dir "$key" >/dev/null || { warn "Unknown harness: ${key} (skipping)"; continue; }
+                        info "Uninstalling ${key} tracing..."
+                        run_harness_py "$key" "$vp" uninstall || warn "${key} uninstall failed (continuing)"
                     done <<< "$harnesses"
                 fi
                 "$vp" -m core.setup.wipe
@@ -349,14 +396,30 @@ main() {
             # EOFError, so fall back to stored values there — and only there, so an
             # interactive update keeps every prompt it has today.
             [[ -n "$_tty_in" ]] || export ARIZE_NONINTERACTIVE=1
-            if [[ -d "${INSTALL_DIR}/.git" ]]; then
+            # A wheel install has no repo to pull and no newer wheel to hand us.
+            # Silently converting it to a network install would change how it was
+            # installed behind the user's back, so refuse and say who can update.
+            if [[ -z "$WHEEL_DIR" && ! -d "${INSTALL_DIR}/.git" && ! -f "${INSTALL_DIR}/pyproject.toml" ]]; then
+                err "This looks like an offline install with no source tree to update."
+                err "Re-run the installer that created it (for npx evals, update that), or"
+                err "pass --wheel-dir <dir> with a newer wheel."
+                exit 1
+            fi
+            if [[ -n "$WHEEL_DIR" ]]; then
+                info "Updating from local wheels in ${WHEEL_DIR}..."
+            elif [[ -d "${INSTALL_DIR}/.git" ]]; then
                 info "Pulling latest changes..."
                 git -C "$INSTALL_DIR" pull --ff-only 2>/dev/null || {
                     warn "git pull failed — falling back to tarball re-extract"; install_repo_tarball; }
             else install_repo_tarball; fi
             local pip; pip=$(venv_pip) || { err "Venv not found — run install first"; exit 1; }
             info "Reinstalling coding-harness-tracing..."
-            "$pip" install --quiet -U "$INSTALL_DIR" 2>/dev/null || { err "Failed to reinstall package"; exit 1; }
+            if [[ -n "$WHEEL_DIR" ]]; then
+                "$pip" install --quiet -U --no-index --find-links "$WHEEL_DIR" coding-harness-tracing \
+                    || { err "Failed to reinstall from ${WHEEL_DIR}"; exit 1; }
+            else
+                "$pip" install --quiet -U "$INSTALL_DIR" 2>/dev/null || { err "Failed to reinstall package"; exit 1; }
+            fi
             local vp; vp=$(venv_python) || { err "venv python not found"; exit 1; }
             info "Migrating legacy config.yaml to config.json (if present)..."
             "$vp" -m core.config migrate || true
@@ -364,10 +427,8 @@ main() {
             harnesses=$("$vp" -c 'from core.setup import list_installed_harnesses as L; print("\n".join(L()))' 2>/dev/null) || true
             if [[ -n "$harnesses" ]]; then
                 while IFS= read -r key; do
-                    local dir; dir=$(harness_dir "$key") || { warn "Unknown harness: ${key} (skipping)"; continue; }
-                    if [[ -f "${INSTALL_DIR}/${dir}/install.py" ]]; then
-                        info "Re-registering ${key}..."; run_with_tty "$vp" "${INSTALL_DIR}/${dir}/install.py" install
-                    else warn "Harness directory not found: ${dir}"; fi
+                    harness_dir "$key" >/dev/null || { warn "Unknown harness: ${key} (skipping)"; continue; }
+                    info "Re-registering ${key}..."; run_harness_py "$key" "$vp" install
                 done <<< "$harnesses"
             else info "No installed harnesses found to re-register"; fi
             info "Update complete."

--- a/install.sh
+++ b/install.sh
@@ -246,6 +246,7 @@ Commands:
   kiro        Install and configure tracing for Kiro CLI
   opencode    Install and configure tracing for opencode
   omp         Install and configure tracing for Oh My Pi (omp)
+  status      Report configured harnesses and whether their hooks are wired up
   update      Update the installed coding-harness-tracing and re-register all harnesses
   uninstall <harness>   Tear down one harness
   uninstall             Full wipe: venv + repo + shared config
@@ -253,6 +254,8 @@ Commands:
 Flags:
   --with-skills         Symlink harness skills into .agents/skills/
   --branch NAME         Install from a specific git branch (default: main)
+  --json                With `status`: emit machine-readable JSON. Exits non-zero
+                        when no harness is configured, so callers can gate on it.
   --non-interactive, -y Ask nothing; read every value from the environment or a
                         .env file. Missing required values are an error.
 
@@ -284,12 +287,13 @@ EOF
 # -- Main dispatch -----------------------------------------------------------
 main() {
     local cmd="${1:-}"; shift || true
-    local subcmd="" with_skills=false
+    local subcmd="" with_skills=false status_args=""
     local args=("$@") i=0
     while [[ $i -lt ${#args[@]} ]]; do
         case "${args[$i]}" in
             --with-skills) with_skills=true ;;
             --non-interactive|-y) export ARIZE_NONINTERACTIVE=1 ;;
+            --json) status_args="--json" ;;
             --branch)
                 i=$((i + 1))
                 INSTALL_BRANCH="${args[$i]:-main}"
@@ -333,6 +337,10 @@ main() {
                 fi
                 "$vp" -m core.setup.wipe
             fi
+            ;;
+        status)
+            local vp; vp=$(venv_python) || { err "Venv not found — nothing installed"; exit 1; }
+            "$vp" -m core.setup.status $status_args
             ;;
         update)
             header "Updating coding-harness-tracing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,12 @@
 name = "coding-harness-tracing"
 version = "0.1.0"
 requires-python = ">=3.9"
-dependencies = []
+# python-dotenv parses the credential file for non-interactive installs. It is
+# the only runtime dependency; keep it that way. Imported by core/setup alone,
+# never by the hooks, so a traced session still runs on the stdlib.
+# `>=1.0` resolves to 1.2.1 on Python 3.9 and 1.2.2 above it — both verified to
+# agree on every case in TestDotenvResolution.
+dependencies = ["python-dotenv>=1.0"]
 
 [project.optional-dependencies]
 dev = [

--- a/tests/core/test_macos_ssl_fix.py
+++ b/tests/core/test_macos_ssl_fix.py
@@ -52,7 +52,15 @@ class TestFixMacOSSslCertsDefined:
         assert "venv_python" in self.text
 
     def test_installs_certifi(self):
-        assert "install --quiet certifi" in self.text
+        # The offline array expands to nothing in repo mode, and to
+        # --no-index --find-links "$WHEEL_DIR" when installing from local wheels,
+        # so certifi resolves without network in an offline install too.
+        assert 'install --quiet "${offline[@]+"${offline[@]}"}" certifi' in self.text
+
+    def test_certifi_resolves_offline_when_wheels_are_local(self):
+        """Otherwise an offline macOS install completes and then fails at runtime
+        with CERTIFICATE_VERIFY_FAILED on the first span export."""
+        assert 'offline=(--no-index --find-links "$WHEEL_DIR")' in self.text
 
     def test_warns_on_certifi_failure(self):
         assert "Could not install certifi" in self.text

--- a/tests/core/test_setup.py
+++ b/tests/core/test_setup.py
@@ -379,13 +379,31 @@ class TestNonInteractive:
         with self._no_prompts():
             assert prompt_project_name("claude-code") == "claude-code"
 
-    def test_project_name_from_env(self, monkeypatch):
+    def test_project_name_ignores_ambient_env(self, monkeypatch):
+        """ARIZE_PROJECT_NAME in the environment belongs to another harness.
+
+        An installed harness exports it into every session; inheriting it would
+        name this harness's project after a different one and collide spans.
+        """
         from core.setup import prompt_project_name
 
-        monkeypatch.setenv("ARIZE_PROJECT_NAME", "my-project")
+        monkeypatch.setenv("ARIZE_PROJECT_NAME", "claude-code")
 
         with self._no_prompts():
-            assert prompt_project_name("claude-code") == "my-project"
+            assert prompt_project_name("codex") == "codex"
+
+    def test_project_name_source_label_does_not_credit_env(self, monkeypatch, capsys):
+        """The label must not name a source that was never consulted."""
+        from core.setup import prompt_project_name
+
+        monkeypatch.setenv("ARIZE_PROJECT_NAME", "claude-code")
+
+        with self._no_prompts():
+            prompt_project_name("codex")
+
+        out = capsys.readouterr().out
+        assert "harness default" in out
+        assert "ARIZE_PROJECT_NAME" not in out
 
     def test_user_id_blank_by_default(self):
         from core.setup import prompt_user_id
@@ -631,6 +649,74 @@ class TestDotenvResolution:
 
         assert _dotenv_values() == {}
         assert "Reading configuration" not in capsys.readouterr().out
+
+    def test_project_name_read_from_file(self, tmp_path):
+        """The file may set the project name; only the environment is ignored."""
+        from core.setup import prompt_project_name
+
+        (tmp_path / ".env").write_text("ARIZE_PROJECT_NAME=from-file\n")
+
+        with patch("builtins.input", side_effect=AssertionError("prompted")):
+            assert prompt_project_name("codex") == "from-file"
+
+    def test_inline_comment_stripped(self, tmp_path):
+        """`KEY=value # note` must not yield a value with the comment attached."""
+        from core.setup import prompt_backend
+
+        (tmp_path / ".env").write_text(
+            "ARIZE_API_KEY=k # the key\nARIZE_SPACE_ID=space-abc # my main space\n",
+        )
+
+        with patch("builtins.input", side_effect=AssertionError("prompted")):
+            _, creds = prompt_backend()
+
+        assert creds["space_id"] == "space-abc"
+        assert creds["api_key"] == "k"
+
+    def test_tab_before_comment_stripped(self, tmp_path):
+        from core.setup import _dotenv_values
+
+        (tmp_path / ".env").write_text("ARIZE_SPACE_ID=space-abc\t# tabbed note\n")
+
+        assert _dotenv_values()["ARIZE_SPACE_ID"] == "space-abc"
+
+    def test_hash_in_quoted_value_preserved(self, tmp_path):
+        """Quoting is the documented way to keep a literal '#'."""
+        from core.setup import _dotenv_values
+
+        (tmp_path / ".env").write_text('ARIZE_PROJECT_NAME="has # hash"\n')
+
+        assert _dotenv_values()["ARIZE_PROJECT_NAME"] == "has # hash"
+
+    def test_hash_without_leading_space_is_kept(self, tmp_path):
+        """A '#' with no preceding whitespace is part of the value, per dotenv."""
+        from core.setup import _dotenv_values
+
+        (tmp_path / ".env").write_text("ARIZE_SPACE_ID=space#abc\n")
+
+        assert _dotenv_values()["ARIZE_SPACE_ID"] == "space#abc"
+
+    def test_comment_only_value_is_empty(self, tmp_path):
+        from core.setup import _dotenv_values
+
+        (tmp_path / ".env").write_text("ARIZE_SPACE_ID=#nothing here\nARIZE_API_KEY=k\n")
+
+        assert _dotenv_values()["ARIZE_SPACE_ID"] == ""
+
+    def test_reports_source_per_value(self, tmp_path, monkeypatch, capsys):
+        """Mixed sources must be visible: which value came from where."""
+        from core.setup import prompt_backend
+
+        (tmp_path / ".env").write_text("ARIZE_API_KEY=fresh-key\n")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "space-from-env")
+
+        with patch("builtins.input", side_effect=AssertionError("prompted")):
+            prompt_backend()
+
+        out = capsys.readouterr().out
+        assert "$ARIZE_SPACE_ID" in out
+        assert str(tmp_path / ".env") in out
+        assert "fresh-key" not in out
 
 
 class TestWriteConfig:

--- a/tests/core/test_setup.py
+++ b/tests/core/test_setup.py
@@ -533,10 +533,48 @@ class TestDotenvResolution:
 
         assert creds["api_key"] == "right"
 
-    def test_real_env_beats_file(self, tmp_path, monkeypatch):
+    def test_file_beats_real_env(self, tmp_path, monkeypatch):
+        """The file wins: it is chosen, whereas ARIZE_* vars are often inherited."""
         from core.setup import prompt_backend
 
         (tmp_path / ".env").write_text("ARIZE_API_KEY=file-key\nARIZE_SPACE_ID=file-space\n")
+        monkeypatch.setenv("ARIZE_API_KEY", "env-key")
+
+        with patch("builtins.input", side_effect=AssertionError("prompted")):
+            _, creds = prompt_backend()
+
+        assert creds["api_key"] == "file-key"
+        assert creds["space_id"] == "file-space"
+
+    def test_ambient_harness_env_does_not_leak_in(self, tmp_path, monkeypatch):
+        """Regression: an installed harness exports ARIZE_* into every session.
+
+        Those inherited values used to beat the .env the caller had just
+        written, pairing a fresh key with a stale space ID and overriding the
+        project name.
+        """
+        from core.setup import prompt_backend, prompt_project_name
+
+        (tmp_path / ".env").write_text(
+            "ARIZE_API_KEY=fresh-key\nARIZE_SPACE_ID=intended-space\nARIZE_PROJECT_NAME=intended-project\n"
+        )
+        monkeypatch.setenv("ARIZE_API_KEY", "stale-key")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "stale-space")
+        monkeypatch.setenv("ARIZE_PROJECT_NAME", "claude-code")
+
+        with patch("builtins.input", side_effect=AssertionError("prompted")):
+            _, creds = prompt_backend()
+            project = prompt_project_name("fallback")
+
+        assert creds["api_key"] == "fresh-key"
+        assert creds["space_id"] == "intended-space"
+        assert project == "intended-project"
+
+    def test_env_still_used_when_file_lacks_the_key(self, tmp_path, monkeypatch):
+        """The file overrides only what it actually defines."""
+        from core.setup import prompt_backend
+
+        (tmp_path / ".env").write_text("ARIZE_SPACE_ID=file-space\n")
         monkeypatch.setenv("ARIZE_API_KEY", "env-key")
 
         with patch("builtins.input", side_effect=AssertionError("prompted")):

--- a/tests/core/test_setup.py
+++ b/tests/core/test_setup.py
@@ -402,7 +402,7 @@ class TestNonInteractive:
             prompt_project_name("codex")
 
         out = capsys.readouterr().out
-        assert "harness default" in out
+        assert "(from default)" in out
         assert "ARIZE_PROJECT_NAME" not in out
 
     def test_user_id_blank_by_default(self):

--- a/tests/core/test_setup.py
+++ b/tests/core/test_setup.py
@@ -17,6 +17,38 @@ def _isolate_cwd(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
 
+# Every variable the non-interactive resolver reads. Two fixtures used to keep
+# their own subsets, and the shorter one let PHOENIX_ENDPOINT, ARIZE_BACKEND and
+# the ARIZE_LOG_* vars leak in from the developer's shell — the same
+# non-hermetic failure mode that already bites this suite elsewhere.
+_RESOLVED_ENV_KEYS = (
+    "ARIZE_API_KEY",
+    "ARIZE_SPACE_ID",
+    "ARIZE_BACKEND",
+    "ARIZE_OTLP_ENDPOINT",
+    "ARIZE_PROJECT_NAME",
+    "ARIZE_USER_ID",
+    "ARIZE_LOG_PROMPTS",
+    "ARIZE_LOG_TOOL_DETAILS",
+    "ARIZE_LOG_TOOL_CONTENT",
+    "ARIZE_ENV_FILE",
+    "ARIZE_KIRO_AGENT",
+    "ARIZE_KIRO_SET_DEFAULT",
+    "PHOENIX_ENDPOINT",
+    "PHOENIX_API_KEY",
+)
+
+
+def _isolate_resolver_env(monkeypatch):
+    """Turn on non-interactive mode and clear every value the resolver reads."""
+    from core.setup import _reset_dotenv_cache
+
+    monkeypatch.setenv("ARIZE_NONINTERACTIVE", "1")
+    for key in _RESOLVED_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    _reset_dotenv_cache()
+
+
 def _patched_path_class(tmp_path):
     """Create a Path subclass that redirects home() and relative .claude/ to tmp_path."""
     _real_path = Path
@@ -198,26 +230,9 @@ class TestNonInteractive:
 
     @pytest.fixture(autouse=True)
     def _non_interactive_env(self, monkeypatch):
-        """Enable the flag and clear every value the resolver reads."""
         from core.setup import _reset_dotenv_cache
 
-        monkeypatch.setenv("ARIZE_NONINTERACTIVE", "1")
-        for key in (
-            "ARIZE_API_KEY",
-            "ARIZE_SPACE_ID",
-            "ARIZE_BACKEND",
-            "ARIZE_OTLP_ENDPOINT",
-            "ARIZE_PROJECT_NAME",
-            "ARIZE_USER_ID",
-            "ARIZE_LOG_PROMPTS",
-            "ARIZE_LOG_TOOL_DETAILS",
-            "ARIZE_LOG_TOOL_CONTENT",
-            "ARIZE_ENV_FILE",
-            "PHOENIX_ENDPOINT",
-            "PHOENIX_API_KEY",
-        ):
-            monkeypatch.delenv(key, raising=False)
-        _reset_dotenv_cache()
+        _isolate_resolver_env(monkeypatch)
         yield
         _reset_dotenv_cache()
 
@@ -599,10 +614,7 @@ class TestDotenvResolution:
     def _clean_env(self, monkeypatch):
         from core.setup import _reset_dotenv_cache
 
-        monkeypatch.setenv("ARIZE_NONINTERACTIVE", "1")
-        for key in ("ARIZE_API_KEY", "ARIZE_SPACE_ID", "ARIZE_PROJECT_NAME", "ARIZE_ENV_FILE"):
-            monkeypatch.delenv(key, raising=False)
-        _reset_dotenv_cache()
+        _isolate_resolver_env(monkeypatch)
         yield
         _reset_dotenv_cache()
 

--- a/tests/core/test_setup.py
+++ b/tests/core/test_setup.py
@@ -824,6 +824,75 @@ class TestDotenvResolution:
 
         assert _dotenv_values()["ARIZE_SPACE_ID"] == ""
 
+    @pytest.mark.parametrize(
+        "body,expected",
+        [
+            ("ARIZE_API_KEY=abc123", "abc123"),
+            ("export ARIZE_API_KEY=abc123", "abc123"),
+            ('ARIZE_API_KEY="abc123"', "abc123"),
+            ("ARIZE_API_KEY='abc123'", "abc123"),
+            ("ARIZE_API_KEY=abc123 # my key", "abc123"),
+            ("ARIZE_API_KEY=abc\t# my key", "abc"),
+            ('ARIZE_API_KEY="abc#123"', "abc#123"),
+            ("ARIZE_API_KEY=abc#123", "abc#123"),
+            ("ARIZE_API_KEY=a=b=c", "a=b=c"),
+            ("   ARIZE_API_KEY=abc123   ", "abc123"),
+            ("ARIZE_API_KEY = abc123", "abc123"),
+            ("ARIZE_API_KEY=abc123\r", "abc123"),
+            ("ARIZE_API_KEY=first\nARIZE_API_KEY=second", "second"),
+            ("ARIZE_API_KEY=$HOME", "$HOME"),
+            ('ARIZE_API_KEY=ab"cd', 'ab"cd'),
+            ("ARIZE_API_KEY=", ""),
+        ],
+    )
+    def test_matches_reference_dotenv_semantics(self, tmp_path, body, expected):
+        """Each case was checked against python-dotenv's dotenv_values.
+
+        The parser is hand-rolled because the package ships with zero runtime
+        dependencies, and adding one would also have to be bundled for the
+        offline install. So the behaviour is pinned here instead. The one
+        deliberate divergence is that python-dotenv expands ``\\n`` inside
+        double quotes; none of the keys read here want a newline.
+        """
+        from core.setup import _parse_dotenv
+
+        path = tmp_path / "ref.env"
+        path.write_text(body + "\n")
+
+        assert _parse_dotenv(path).get("ARIZE_API_KEY") == expected
+
+    @pytest.mark.parametrize(
+        "body",
+        ['ARIZE_API_KEY="abc123', "ARIZE_API_KEY='abc123", "ARIZE_API_KEY=\"abc123'"],
+    )
+    def test_unbalanced_quote_is_fatal(self, tmp_path, body, capsys):
+        """It used to yield the value with the stray quote still attached.
+
+        `ARIZE_API_KEY="abc` became `"abc` — a credential that reports as found
+        and then fails authentication with nothing pointing at the typo.
+        python-dotenv rejects these lines; we stop, because the file was named
+        explicitly and a corrupted credential is worse than a missing one.
+        """
+        from core.setup import _parse_dotenv
+
+        path = tmp_path / "bad.env"
+        path.write_text(body + "\n")
+
+        with pytest.raises(SystemExit) as exc:
+            _parse_dotenv(path)
+
+        assert exc.value.code == 1
+        assert "unbalanced" in capsys.readouterr().err
+
+    def test_backslash_n_stays_literal(self, tmp_path):
+        """Deliberate divergence from python-dotenv, which would expand it."""
+        from core.setup import _parse_dotenv
+
+        path = tmp_path / "nl.env"
+        path.write_text('ARIZE_API_KEY="a\\nb"\n')
+
+        assert _parse_dotenv(path)["ARIZE_API_KEY"] == "a\\nb"
+
     def test_reports_source_per_value(self, tmp_path, monkeypatch, capsys):
         """Mixed sources must be visible: which value came from where."""
         from core.setup import prompt_backend

--- a/tests/core/test_setup.py
+++ b/tests/core/test_setup.py
@@ -362,6 +362,62 @@ class TestNonInteractive:
 
         assert excinfo.value.code == 1
 
+    def test_arize_key_with_only_phoenix_endpoint_exits(self, monkeypatch, capsys):
+        """Inferring Phoenix here would throw away the Arize key.
+
+        Real setup: a dev runs Phoenix locally for their app, so its .env has
+        PHOENIX_ENDPOINT, while they want Arize AX for the coding agent.
+        """
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("ARIZE_API_KEY", "my-ax-key")
+        monkeypatch.setenv("PHOENIX_ENDPOINT", "http://localhost:6006")
+
+        with self._no_prompts():
+            with pytest.raises(SystemExit):
+                prompt_backend()
+
+        assert "ARIZE_SPACE_ID" in capsys.readouterr().err
+
+    def test_both_backends_configured_exits(self, monkeypatch, capsys):
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("ARIZE_API_KEY", "k")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "s")
+        monkeypatch.setenv("PHOENIX_ENDPOINT", "http://localhost:6006")
+
+        with self._no_prompts():
+            with pytest.raises(SystemExit):
+                prompt_backend()
+
+        assert "ambiguous" in capsys.readouterr().err
+
+    def test_explicit_backend_resolves_the_ambiguity(self, monkeypatch):
+        """ARIZE_BACKEND is the documented way out of both errors above."""
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("ARIZE_BACKEND", "phoenix")
+        monkeypatch.setenv("ARIZE_API_KEY", "k")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "s")
+        monkeypatch.setenv("PHOENIX_ENDPOINT", "http://localhost:6006")
+
+        with self._no_prompts():
+            target, creds = prompt_backend()
+
+        assert target == "phoenix"
+        assert creds["endpoint"] == "http://localhost:6006"
+
+    def test_phoenix_alone_still_infers_phoenix(self, monkeypatch):
+        """No Arize credentials at all — inference is unambiguous."""
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("PHOENIX_ENDPOINT", "http://localhost:6006")
+
+        with self._no_prompts():
+            target, _ = prompt_backend()
+
+        assert target == "phoenix"
+
     def test_unknown_backend_exits(self, monkeypatch, capsys):
         from core.setup import prompt_backend
 
@@ -645,10 +701,35 @@ class TestDotenvResolution:
         assert creds["space_id"] == "typed-space"
 
     def test_missing_file_is_not_an_error(self, capsys):
+        """No .env in the cwd is normal — only an *explicit* path must exist."""
         from core.setup import _dotenv_values
 
         assert _dotenv_values() == {}
         assert "Reading configuration" not in capsys.readouterr().out
+
+    def test_unreadable_explicit_path_is_fatal(self, tmp_path, monkeypatch, capsys):
+        """A typo in ARIZE_ENV_FILE must not fall through to the environment.
+
+        Naming a file states where the credentials come from; ignoring it
+        silently installed with whatever happened to be in the environment.
+        """
+        from core.setup import _dotenv_values
+
+        monkeypatch.setenv("ARIZE_ENV_FILE", str(tmp_path / "typo.env"))
+
+        with pytest.raises(SystemExit) as excinfo:
+            _dotenv_values()
+
+        assert excinfo.value.code == 1
+        assert "ARIZE_ENV_FILE" in capsys.readouterr().err
+
+    def test_explicit_path_that_is_a_directory_is_fatal(self, tmp_path, monkeypatch):
+        from core.setup import _dotenv_values
+
+        monkeypatch.setenv("ARIZE_ENV_FILE", str(tmp_path))
+
+        with pytest.raises(SystemExit):
+            _dotenv_values()
 
     def test_project_name_read_from_file(self, tmp_path):
         """The file may set the project name; only the environment is ignored."""

--- a/tests/core/test_setup.py
+++ b/tests/core/test_setup.py
@@ -189,6 +189,412 @@ class TestPromptUserId:
         assert result == ""
 
 
+class TestNonInteractive:
+    """Tests for non-interactive resolution of the four setup prompts.
+
+    Every test patches builtins.input to explode: reaching a prompt in this
+    mode is the bug being guarded against, since there is nobody to answer it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _non_interactive_env(self, monkeypatch):
+        """Enable the flag and clear every value the resolver reads."""
+        from core.setup import _reset_dotenv_cache
+
+        monkeypatch.setenv("ARIZE_NONINTERACTIVE", "1")
+        for key in (
+            "ARIZE_API_KEY",
+            "ARIZE_SPACE_ID",
+            "ARIZE_BACKEND",
+            "ARIZE_OTLP_ENDPOINT",
+            "ARIZE_PROJECT_NAME",
+            "ARIZE_USER_ID",
+            "ARIZE_LOG_PROMPTS",
+            "ARIZE_LOG_TOOL_DETAILS",
+            "ARIZE_LOG_TOOL_CONTENT",
+            "ARIZE_ENV_FILE",
+            "PHOENIX_ENDPOINT",
+            "PHOENIX_API_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        _reset_dotenv_cache()
+        yield
+        _reset_dotenv_cache()
+
+    @staticmethod
+    def _no_prompts():
+        """Patch input/getpass to fail loudly if the code tries to prompt."""
+        return patch("builtins.input", side_effect=AssertionError("prompted in non-interactive mode"))
+
+    def test_flag_detected(self):
+        from core.setup import non_interactive
+
+        assert non_interactive() is True
+
+    def test_flag_off_by_default(self, monkeypatch):
+        from core.setup import non_interactive
+
+        monkeypatch.delenv("ARIZE_NONINTERACTIVE", raising=False)
+        assert non_interactive() is False
+
+    def test_arize_from_env(self, monkeypatch):
+        """Space ID implies Arize AX; no backend flag needed."""
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("ARIZE_API_KEY", "key-123")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "space-456")
+
+        with self._no_prompts():
+            target, creds = prompt_backend()
+
+        assert target == "arize"
+        assert creds == {
+            "endpoint": "otlp.arize.com:443",
+            "api_key": "key-123",
+            "space_id": "space-456",
+        }
+
+    def test_api_key_never_printed(self, monkeypatch, capsys):
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("ARIZE_API_KEY", "super-secret-key")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "space-456")
+
+        with self._no_prompts():
+            prompt_backend()
+
+        captured = capsys.readouterr()
+        assert "super-secret-key" not in captured.out
+        assert "super-secret-key" not in captured.err
+
+    def test_phoenix_inferred_from_endpoint(self, monkeypatch):
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("PHOENIX_ENDPOINT", "http://phoenix:6006")
+        monkeypatch.setenv("PHOENIX_API_KEY", "phx-key")
+
+        with self._no_prompts():
+            target, creds = prompt_backend()
+
+        assert target == "phoenix"
+        assert creds == {"endpoint": "http://phoenix:6006", "api_key": "phx-key"}
+
+    def test_explicit_backend_overrides_inference(self, monkeypatch):
+        """ARIZE_BACKEND=phoenix wins even when a space ID is present."""
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("ARIZE_BACKEND", "phoenix")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "space-456")
+
+        with self._no_prompts():
+            target, creds = prompt_backend()
+
+        assert target == "phoenix"
+        assert creds["endpoint"] == "http://localhost:6006"
+
+    def test_backend_alias_ax(self, monkeypatch):
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("ARIZE_BACKEND", "ax")
+        monkeypatch.setenv("ARIZE_API_KEY", "key-123")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "space-456")
+
+        with self._no_prompts():
+            target, _ = prompt_backend()
+
+        assert target == "arize"
+
+    def test_custom_otlp_endpoint(self, monkeypatch):
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("ARIZE_API_KEY", "key-123")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "space-456")
+        monkeypatch.setenv("ARIZE_OTLP_ENDPOINT", "custom.arize.com:443")
+
+        with self._no_prompts():
+            _, creds = prompt_backend()
+
+        assert creds["endpoint"] == "custom.arize.com:443"
+
+    def test_missing_api_key_exits(self, monkeypatch, capsys):
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("ARIZE_SPACE_ID", "space-456")
+
+        with self._no_prompts():
+            with pytest.raises(SystemExit):
+                prompt_backend()
+
+        assert "ARIZE_API_KEY" in capsys.readouterr().err
+
+    def test_missing_space_id_exits(self, monkeypatch, capsys):
+        """An API key alone is ambiguous — both backends use one."""
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("ARIZE_API_KEY", "key-123")
+
+        with self._no_prompts():
+            with pytest.raises(SystemExit):
+                prompt_backend()
+
+        err = capsys.readouterr().err
+        assert "cannot tell which backend" in err
+        assert "ARIZE_SPACE_ID" in err
+
+    def test_no_credentials_at_all_exits(self, capsys):
+        from core.setup import prompt_backend
+
+        with self._no_prompts():
+            with pytest.raises(SystemExit):
+                prompt_backend()
+
+        err = capsys.readouterr().err
+        assert "No credentials found" in err
+        assert "ARIZE_SPACE_ID" in err and "PHOENIX_ENDPOINT" in err
+
+    def test_exit_code_is_nonzero(self, capsys):
+        """The installer must fail loudly enough for a caller to detect."""
+        from core.setup import prompt_backend
+
+        with self._no_prompts():
+            with pytest.raises(SystemExit) as excinfo:
+                prompt_backend()
+
+        assert excinfo.value.code == 1
+
+    def test_unknown_backend_exits(self, monkeypatch, capsys):
+        from core.setup import prompt_backend
+
+        monkeypatch.setenv("ARIZE_BACKEND", "datadog")
+
+        with self._no_prompts():
+            with pytest.raises(SystemExit):
+                prompt_backend()
+
+        assert "datadog" in capsys.readouterr().err
+
+    def test_project_name_defaults(self):
+        from core.setup import prompt_project_name
+
+        with self._no_prompts():
+            assert prompt_project_name("claude-code") == "claude-code"
+
+    def test_project_name_from_env(self, monkeypatch):
+        from core.setup import prompt_project_name
+
+        monkeypatch.setenv("ARIZE_PROJECT_NAME", "my-project")
+
+        with self._no_prompts():
+            assert prompt_project_name("claude-code") == "my-project"
+
+    def test_user_id_blank_by_default(self):
+        from core.setup import prompt_user_id
+
+        with self._no_prompts():
+            assert prompt_user_id() == ""
+
+    def test_user_id_from_env(self, monkeypatch):
+        from core.setup import prompt_user_id
+
+        monkeypatch.setenv("ARIZE_USER_ID", "alice")
+
+        with self._no_prompts():
+            assert prompt_user_id() == "alice"
+
+    def test_logging_defaults_to_capture_everything(self):
+        """Parity with the interactive wizard, whose three prompts default to yes."""
+        from core.setup import prompt_content_logging
+
+        with self._no_prompts():
+            block = prompt_content_logging()
+
+        assert block == {"prompts": True, "tool_details": True, "tool_content": True}
+
+    def test_logging_opt_out(self, monkeypatch):
+        from core.setup import prompt_content_logging
+
+        monkeypatch.setenv("ARIZE_LOG_PROMPTS", "false")
+        monkeypatch.setenv("ARIZE_LOG_TOOL_CONTENT", "0")
+
+        with self._no_prompts():
+            block = prompt_content_logging()
+
+        assert block == {"prompts": False, "tool_details": True, "tool_content": False}
+
+    def test_env_flag_default_off_needs_explicit_optin(self, monkeypatch):
+        """A default-off setting must not be turned on by any old value."""
+        from core.setup import env_flag
+
+        assert env_flag("ARIZE_LOG_PROMPTS", default=False) is False
+        monkeypatch.setenv("ARIZE_LOG_PROMPTS", "1")
+        assert env_flag("ARIZE_LOG_PROMPTS", default=False) is True
+        monkeypatch.setenv("ARIZE_LOG_PROMPTS", "no")
+        assert env_flag("ARIZE_LOG_PROMPTS", default=False) is False
+
+    def test_kiro_agent_name_defaults(self):
+        """Kiro's own prompt resolves too — it is the one harness with extras."""
+        from tracing.kiro.install import _prompt_agent_name
+
+        with self._no_prompts():
+            assert _prompt_agent_name() == "arize-traced"
+
+    def test_kiro_agent_name_from_env(self, monkeypatch):
+        from tracing.kiro.install import _prompt_agent_name
+
+        monkeypatch.setenv("ARIZE_KIRO_AGENT", "my-agent")
+
+        with self._no_prompts():
+            assert _prompt_agent_name() == "my-agent"
+
+    def test_kiro_set_default_is_opt_in(self, monkeypatch):
+        """Never silently repoint the user's default Kiro agent."""
+        from tracing.kiro import install as kiro_install
+
+        called = []
+        monkeypatch.setattr(kiro_install.shutil, "which", lambda _: called.append("which") or None)
+
+        with self._no_prompts():
+            kiro_install._maybe_set_default("my-agent")
+
+        assert called == []
+
+    def test_kiro_set_default_opt_in_honored(self, monkeypatch, capsys):
+        from tracing.kiro import install as kiro_install
+
+        monkeypatch.setenv("ARIZE_KIRO_SET_DEFAULT", "1")
+        monkeypatch.setenv("ARIZE_DRY_RUN", "1")
+
+        with self._no_prompts():
+            kiro_install._maybe_set_default("my-agent")
+
+        assert "set-default my-agent" in capsys.readouterr().out
+
+    def test_harness_check_skipped(self, monkeypatch):
+        """The y/N 'not installed' prompt must not fire under the flag, even on a TTY."""
+        from core.setup import ensure_harness_installed
+
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+
+        with self._no_prompts():
+            assert ensure_harness_installed("Nope", home_subdir=".no-such-harness-dir") is True
+
+
+class TestDotenvResolution:
+    """Non-interactive installs can read credentials from a dotenv file.
+
+    This is the path that keeps an API key out of argv and shell history:
+    `ax api-keys create --env-file .env` writes it, the installer reads it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        from core.setup import _reset_dotenv_cache
+
+        monkeypatch.setenv("ARIZE_NONINTERACTIVE", "1")
+        for key in ("ARIZE_API_KEY", "ARIZE_SPACE_ID", "ARIZE_PROJECT_NAME", "ARIZE_ENV_FILE"):
+            monkeypatch.delenv(key, raising=False)
+        _reset_dotenv_cache()
+        yield
+        _reset_dotenv_cache()
+
+    def test_reads_dotenv_from_cwd(self, tmp_path):
+        """tmp_path is cwd via the module-level _isolate_cwd fixture."""
+        from core.setup import prompt_backend
+
+        (tmp_path / ".env").write_text("ARIZE_API_KEY=file-key\nARIZE_SPACE_ID=file-space\n")
+
+        with patch("builtins.input", side_effect=AssertionError("prompted")):
+            target, creds = prompt_backend()
+
+        assert target == "arize"
+        assert creds["api_key"] == "file-key"
+        assert creds["space_id"] == "file-space"
+
+    def test_env_local_fallback(self, tmp_path):
+        from core.setup import prompt_backend
+
+        (tmp_path / ".env.local").write_text("ARIZE_API_KEY=local-key\nARIZE_SPACE_ID=local-space\n")
+
+        with patch("builtins.input", side_effect=AssertionError("prompted")):
+            _, creds = prompt_backend()
+
+        assert creds["api_key"] == "local-key"
+
+    def test_explicit_path_wins(self, tmp_path, monkeypatch):
+        from core.setup import prompt_backend
+
+        (tmp_path / ".env").write_text("ARIZE_API_KEY=wrong\nARIZE_SPACE_ID=wrong\n")
+        custom = tmp_path / "creds.env"
+        custom.write_text("ARIZE_API_KEY=right\nARIZE_SPACE_ID=right-space\n")
+        monkeypatch.setenv("ARIZE_ENV_FILE", str(custom))
+
+        with patch("builtins.input", side_effect=AssertionError("prompted")):
+            _, creds = prompt_backend()
+
+        assert creds["api_key"] == "right"
+
+    def test_real_env_beats_file(self, tmp_path, monkeypatch):
+        from core.setup import prompt_backend
+
+        (tmp_path / ".env").write_text("ARIZE_API_KEY=file-key\nARIZE_SPACE_ID=file-space\n")
+        monkeypatch.setenv("ARIZE_API_KEY", "env-key")
+
+        with patch("builtins.input", side_effect=AssertionError("prompted")):
+            _, creds = prompt_backend()
+
+        assert creds["api_key"] == "env-key"
+        assert creds["space_id"] == "file-space"
+
+    def test_parses_export_quotes_and_comments(self, tmp_path):
+        from core.setup import prompt_backend, prompt_project_name
+
+        (tmp_path / ".env").write_text(
+            "# Arize credentials\n"
+            "\n"
+            'export ARIZE_API_KEY="quoted-key"\n'
+            "ARIZE_SPACE_ID='single-quoted'\n"
+            "ARIZE_PROJECT_NAME = spaced-out \n"
+            "MALFORMED_LINE\n"
+        )
+
+        with patch("builtins.input", side_effect=AssertionError("prompted")):
+            _, creds = prompt_backend()
+            project = prompt_project_name("fallback")
+
+        assert creds["api_key"] == "quoted-key"
+        assert creds["space_id"] == "single-quoted"
+        assert project == "spaced-out"
+
+    def test_unrelated_keys_ignored(self, tmp_path):
+        """An app's .env holds all sorts of things; only our keys are read."""
+        from core.setup import _dotenv_values
+
+        (tmp_path / ".env").write_text("OPENAI_API_KEY=sk-nope\nDATABASE_URL=postgres://x\nARIZE_SPACE_ID=space\n")
+
+        assert _dotenv_values() == {"ARIZE_SPACE_ID": "space"}
+
+    def test_dotenv_ignored_when_interactive(self, tmp_path, monkeypatch):
+        """Without the flag the wizard still asks, even with a .env sitting there."""
+        from core.setup import prompt_backend
+
+        monkeypatch.delenv("ARIZE_NONINTERACTIVE", raising=False)
+        (tmp_path / ".env").write_text("ARIZE_API_KEY=file-key\nARIZE_SPACE_ID=file-space\n")
+
+        with patch("builtins.input", side_effect=["2", "typed-space", ""]):
+            with patch("core.setup.getpass", return_value="typed-key"):
+                with patch.object(sys.stdout, "isatty", return_value=False):
+                    _, creds = prompt_backend()
+
+        assert creds["api_key"] == "typed-key"
+        assert creds["space_id"] == "typed-space"
+
+    def test_missing_file_is_not_an_error(self, capsys):
+        from core.setup import _dotenv_values
+
+        assert _dotenv_values() == {}
+        assert "Reading configuration" not in capsys.readouterr().out
+
+
 class TestWriteConfig:
     """Tests for write_config()."""
 

--- a/tests/core/test_setup.py
+++ b/tests/core/test_setup.py
@@ -817,12 +817,20 @@ class TestDotenvResolution:
 
         assert _dotenv_values()["ARIZE_SPACE_ID"] == "space#abc"
 
-    def test_comment_only_value_is_empty(self, tmp_path, monkeypatch):
+    def test_unspaced_hash_is_part_of_the_value(self, tmp_path, monkeypatch):
+        """`#` only starts a comment when whitespace precedes it.
+
+        So `KEY=#nothing` is the literal value `#nothing`, consistent with
+        `KEY=abc#123` yielding `abc#123`. This is python-dotenv's rule and a
+        change from the hand-rolled parser, which returned "" here — worth
+        knowing, because `ARIZE_SPACE_ID=# TODO` now installs that string
+        instead of reporting a missing value.
+        """
         from core.setup import _dotenv_values
 
         _named_env(tmp_path, monkeypatch, "ARIZE_SPACE_ID=#nothing here\nARIZE_API_KEY=k\n")
 
-        assert _dotenv_values()["ARIZE_SPACE_ID"] == ""
+        assert _dotenv_values()["ARIZE_SPACE_ID"] == "#nothing here"
 
     @pytest.mark.parametrize(
         "body,expected",
@@ -884,14 +892,21 @@ class TestDotenvResolution:
         assert exc.value.code == 1
         assert "unbalanced" in capsys.readouterr().err
 
-    def test_backslash_n_stays_literal(self, tmp_path):
-        """Deliberate divergence from python-dotenv, which would expand it."""
+    def test_backslash_n_expands_in_double_quotes(self, tmp_path):
+        """python-dotenv expands escapes inside double quotes; single quotes don't.
+
+        None of the nine keys read here want a newline, so this is not useful —
+        it is simply what a standard parser does, inherited rather than chosen.
+        """
         from core.setup import _parse_dotenv
 
-        path = tmp_path / "nl.env"
-        path.write_text('ARIZE_API_KEY="a\\nb"\n')
+        dq = tmp_path / "dq.env"
+        dq.write_text('ARIZE_API_KEY="a\\nb"\n')
+        assert _parse_dotenv(dq)["ARIZE_API_KEY"] == "a\nb"
 
-        assert _parse_dotenv(path)["ARIZE_API_KEY"] == "a\\nb"
+        sq = tmp_path / "sq.env"
+        sq.write_text("ARIZE_API_KEY='a\\nb'\n")
+        assert _parse_dotenv(sq)["ARIZE_API_KEY"] == "a\\nb"
 
     def test_reports_source_per_value(self, tmp_path, monkeypatch, capsys):
         """Mixed sources must be visible: which value came from where."""

--- a/tests/core/test_setup.py
+++ b/tests/core/test_setup.py
@@ -475,19 +475,38 @@ class TestNonInteractive:
         with self._no_prompts():
             assert prompt_user_id() == "alice"
 
-    def test_logging_defaults_to_capture_everything(self):
-        """Parity with the interactive wizard, whose three prompts default to yes."""
+    def test_logging_defaults_to_capturing_nothing(self):
+        """Unattended, every category must be opted into explicitly.
+
+        The interactive wizard's three questions still default to yes — a person
+        declining to change an answer they were shown is consent. The same
+        default with nobody watching is not: `update` runs non-interactively
+        whenever there is no terminal, so a cron job against a config with no
+        logging block would have switched prompt and file-content capture on.
+        """
         from core.setup import prompt_content_logging
 
         with self._no_prompts():
             block = prompt_content_logging()
 
-        assert block == {"prompts": True, "tool_details": True, "tool_content": True}
+        assert block == {"prompts": False, "tool_details": False, "tool_content": False}
+
+    def test_logging_opt_in_per_category(self, monkeypatch):
+        from core.setup import prompt_content_logging
+
+        monkeypatch.setenv("ARIZE_LOG_PROMPTS", "true")
+        monkeypatch.setenv("ARIZE_LOG_TOOL_CONTENT", "1")
+
+        with self._no_prompts():
+            block = prompt_content_logging()
+
+        assert block == {"prompts": True, "tool_details": False, "tool_content": True}
 
     def test_logging_opt_out(self, monkeypatch):
         from core.setup import prompt_content_logging
 
         monkeypatch.setenv("ARIZE_LOG_PROMPTS", "false")
+        monkeypatch.setenv("ARIZE_LOG_TOOL_DETAILS", "true")
         monkeypatch.setenv("ARIZE_LOG_TOOL_CONTENT", "0")
 
         with self._no_prompts():
@@ -553,6 +572,22 @@ class TestNonInteractive:
             assert ensure_harness_installed("Nope", home_subdir=".no-such-harness-dir") is True
 
 
+def _named_env(tmp_path, monkeypatch, content, name="creds.env"):
+    """Write a dotenv and point ARIZE_ENV_FILE at it.
+
+    There is no automatic ./.env search: a named file outranks the process
+    environment, so an implicit one would let a cloned repo's dotenv choose where
+    credentials get sent. Tests therefore name the file, like real callers do.
+    """
+    from core.setup import _reset_dotenv_cache
+
+    path = tmp_path / name
+    path.write_text(content)
+    monkeypatch.setenv("ARIZE_ENV_FILE", str(path))
+    _reset_dotenv_cache()
+    return path
+
+
 class TestDotenvResolution:
     """Non-interactive installs can read credentials from a dotenv file.
 
@@ -571,11 +606,10 @@ class TestDotenvResolution:
         yield
         _reset_dotenv_cache()
 
-    def test_reads_dotenv_from_cwd(self, tmp_path):
-        """tmp_path is cwd via the module-level _isolate_cwd fixture."""
+    def test_named_file_is_read(self, tmp_path, monkeypatch):
         from core.setup import prompt_backend
 
-        (tmp_path / ".env").write_text("ARIZE_API_KEY=file-key\nARIZE_SPACE_ID=file-space\n")
+        _named_env(tmp_path, monkeypatch, "ARIZE_API_KEY=file-key\nARIZE_SPACE_ID=file-space\n")
 
         with patch("builtins.input", side_effect=AssertionError("prompted")):
             target, creds = prompt_backend()
@@ -584,34 +618,34 @@ class TestDotenvResolution:
         assert creds["api_key"] == "file-key"
         assert creds["space_id"] == "file-space"
 
-    def test_env_local_fallback(self, tmp_path):
-        from core.setup import prompt_backend
+    def test_cwd_dotenv_is_ignored(self, tmp_path, monkeypatch):
+        """A dotenv in the working directory must never be read.
 
-        (tmp_path / ".env.local").write_text("ARIZE_API_KEY=local-key\nARIZE_SPACE_ID=local-space\n")
+        Security boundary: a file's values outrank the process environment, and
+        cwd is whatever repo the user is sitting in. Reading it let a cloned
+        repo's .env choose ARIZE_OTLP_ENDPOINT while the user's real key came
+        from the environment, so every later session shipped spans and a bearer
+        token to an endpoint the repo picked.
+        """
+        from core.setup import _reset_dotenv_cache, prompt_backend
+
+        (tmp_path / ".env").write_text("ARIZE_OTLP_ENDPOINT=otlp.attacker.example:443\n")
+        (tmp_path / ".env.local").write_text("ARIZE_OTLP_ENDPOINT=otlp.attacker.example:443\n")
+        monkeypatch.setenv("ARIZE_API_KEY", "real-key")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "real-space")
+        _reset_dotenv_cache()
 
         with patch("builtins.input", side_effect=AssertionError("prompted")):
             _, creds = prompt_backend()
 
-        assert creds["api_key"] == "local-key"
-
-    def test_explicit_path_wins(self, tmp_path, monkeypatch):
-        from core.setup import prompt_backend
-
-        (tmp_path / ".env").write_text("ARIZE_API_KEY=wrong\nARIZE_SPACE_ID=wrong\n")
-        custom = tmp_path / "creds.env"
-        custom.write_text("ARIZE_API_KEY=right\nARIZE_SPACE_ID=right-space\n")
-        monkeypatch.setenv("ARIZE_ENV_FILE", str(custom))
-
-        with patch("builtins.input", side_effect=AssertionError("prompted")):
-            _, creds = prompt_backend()
-
-        assert creds["api_key"] == "right"
+        assert "attacker" not in creds["endpoint"], "cwd dotenv must not choose the endpoint"
+        assert creds["endpoint"] == "otlp.arize.com:443"
 
     def test_file_beats_real_env(self, tmp_path, monkeypatch):
         """The file wins: it is chosen, whereas ARIZE_* vars are often inherited."""
         from core.setup import prompt_backend
 
-        (tmp_path / ".env").write_text("ARIZE_API_KEY=file-key\nARIZE_SPACE_ID=file-space\n")
+        _named_env(tmp_path, monkeypatch, "ARIZE_API_KEY=file-key\nARIZE_SPACE_ID=file-space\n")
         monkeypatch.setenv("ARIZE_API_KEY", "env-key")
 
         with patch("builtins.input", side_effect=AssertionError("prompted")):
@@ -629,8 +663,10 @@ class TestDotenvResolution:
         """
         from core.setup import prompt_backend, prompt_project_name
 
-        (tmp_path / ".env").write_text(
-            "ARIZE_API_KEY=fresh-key\nARIZE_SPACE_ID=intended-space\nARIZE_PROJECT_NAME=intended-project\n"
+        _named_env(
+            tmp_path,
+            monkeypatch,
+            "ARIZE_API_KEY=fresh-key\nARIZE_SPACE_ID=intended-space\nARIZE_PROJECT_NAME=intended-project\n",
         )
         monkeypatch.setenv("ARIZE_API_KEY", "stale-key")
         monkeypatch.setenv("ARIZE_SPACE_ID", "stale-space")
@@ -648,7 +684,7 @@ class TestDotenvResolution:
         """The file overrides only what it actually defines."""
         from core.setup import prompt_backend
 
-        (tmp_path / ".env").write_text("ARIZE_SPACE_ID=file-space\n")
+        _named_env(tmp_path, monkeypatch, "ARIZE_SPACE_ID=file-space\n")
         monkeypatch.setenv("ARIZE_API_KEY", "env-key")
 
         with patch("builtins.input", side_effect=AssertionError("prompted")):
@@ -657,16 +693,18 @@ class TestDotenvResolution:
         assert creds["api_key"] == "env-key"
         assert creds["space_id"] == "file-space"
 
-    def test_parses_export_quotes_and_comments(self, tmp_path):
+    def test_parses_export_quotes_and_comments(self, tmp_path, monkeypatch):
         from core.setup import prompt_backend, prompt_project_name
 
-        (tmp_path / ".env").write_text(
+        _named_env(
+            tmp_path,
+            monkeypatch,
             "# Arize credentials\n"
             "\n"
             'export ARIZE_API_KEY="quoted-key"\n'
             "ARIZE_SPACE_ID='single-quoted'\n"
             "ARIZE_PROJECT_NAME = spaced-out \n"
-            "MALFORMED_LINE\n"
+            "MALFORMED_LINE\n",
         )
 
         with patch("builtins.input", side_effect=AssertionError("prompted")):
@@ -677,11 +715,11 @@ class TestDotenvResolution:
         assert creds["space_id"] == "single-quoted"
         assert project == "spaced-out"
 
-    def test_unrelated_keys_ignored(self, tmp_path):
+    def test_unrelated_keys_ignored(self, tmp_path, monkeypatch):
         """An app's .env holds all sorts of things; only our keys are read."""
         from core.setup import _dotenv_values
 
-        (tmp_path / ".env").write_text("OPENAI_API_KEY=sk-nope\nDATABASE_URL=postgres://x\nARIZE_SPACE_ID=space\n")
+        _named_env(tmp_path, monkeypatch, "OPENAI_API_KEY=sk-nope\nDATABASE_URL=postgres://x\nARIZE_SPACE_ID=space\n")
 
         assert _dotenv_values() == {"ARIZE_SPACE_ID": "space"}
 
@@ -690,7 +728,7 @@ class TestDotenvResolution:
         from core.setup import prompt_backend
 
         monkeypatch.delenv("ARIZE_NONINTERACTIVE", raising=False)
-        (tmp_path / ".env").write_text("ARIZE_API_KEY=file-key\nARIZE_SPACE_ID=file-space\n")
+        _named_env(tmp_path, monkeypatch, "ARIZE_API_KEY=file-key\nARIZE_SPACE_ID=file-space\n")
 
         with patch("builtins.input", side_effect=["2", "typed-space", ""]):
             with patch("core.setup.getpass", return_value="typed-key"):
@@ -731,20 +769,22 @@ class TestDotenvResolution:
         with pytest.raises(SystemExit):
             _dotenv_values()
 
-    def test_project_name_read_from_file(self, tmp_path):
+    def test_project_name_read_from_file(self, tmp_path, monkeypatch):
         """The file may set the project name; only the environment is ignored."""
         from core.setup import prompt_project_name
 
-        (tmp_path / ".env").write_text("ARIZE_PROJECT_NAME=from-file\n")
+        _named_env(tmp_path, monkeypatch, "ARIZE_PROJECT_NAME=from-file\n")
 
         with patch("builtins.input", side_effect=AssertionError("prompted")):
             assert prompt_project_name("codex") == "from-file"
 
-    def test_inline_comment_stripped(self, tmp_path):
+    def test_inline_comment_stripped(self, tmp_path, monkeypatch):
         """`KEY=value # note` must not yield a value with the comment attached."""
         from core.setup import prompt_backend
 
-        (tmp_path / ".env").write_text(
+        _named_env(
+            tmp_path,
+            monkeypatch,
             "ARIZE_API_KEY=k # the key\nARIZE_SPACE_ID=space-abc # my main space\n",
         )
 
@@ -754,33 +794,33 @@ class TestDotenvResolution:
         assert creds["space_id"] == "space-abc"
         assert creds["api_key"] == "k"
 
-    def test_tab_before_comment_stripped(self, tmp_path):
+    def test_tab_before_comment_stripped(self, tmp_path, monkeypatch):
         from core.setup import _dotenv_values
 
-        (tmp_path / ".env").write_text("ARIZE_SPACE_ID=space-abc\t# tabbed note\n")
+        _named_env(tmp_path, monkeypatch, "ARIZE_SPACE_ID=space-abc\t# tabbed note\n")
 
         assert _dotenv_values()["ARIZE_SPACE_ID"] == "space-abc"
 
-    def test_hash_in_quoted_value_preserved(self, tmp_path):
+    def test_hash_in_quoted_value_preserved(self, tmp_path, monkeypatch):
         """Quoting is the documented way to keep a literal '#'."""
         from core.setup import _dotenv_values
 
-        (tmp_path / ".env").write_text('ARIZE_PROJECT_NAME="has # hash"\n')
+        _named_env(tmp_path, monkeypatch, 'ARIZE_PROJECT_NAME="has # hash"\n')
 
         assert _dotenv_values()["ARIZE_PROJECT_NAME"] == "has # hash"
 
-    def test_hash_without_leading_space_is_kept(self, tmp_path):
+    def test_hash_without_leading_space_is_kept(self, tmp_path, monkeypatch):
         """A '#' with no preceding whitespace is part of the value, per dotenv."""
         from core.setup import _dotenv_values
 
-        (tmp_path / ".env").write_text("ARIZE_SPACE_ID=space#abc\n")
+        _named_env(tmp_path, monkeypatch, "ARIZE_SPACE_ID=space#abc\n")
 
         assert _dotenv_values()["ARIZE_SPACE_ID"] == "space#abc"
 
-    def test_comment_only_value_is_empty(self, tmp_path):
+    def test_comment_only_value_is_empty(self, tmp_path, monkeypatch):
         from core.setup import _dotenv_values
 
-        (tmp_path / ".env").write_text("ARIZE_SPACE_ID=#nothing here\nARIZE_API_KEY=k\n")
+        _named_env(tmp_path, monkeypatch, "ARIZE_SPACE_ID=#nothing here\nARIZE_API_KEY=k\n")
 
         assert _dotenv_values()["ARIZE_SPACE_ID"] == ""
 
@@ -788,7 +828,7 @@ class TestDotenvResolution:
         """Mixed sources must be visible: which value came from where."""
         from core.setup import prompt_backend
 
-        (tmp_path / ".env").write_text("ARIZE_API_KEY=fresh-key\n")
+        _named_env(tmp_path, monkeypatch, "ARIZE_API_KEY=fresh-key\n")
         monkeypatch.setenv("ARIZE_SPACE_ID", "space-from-env")
 
         with patch("builtins.input", side_effect=AssertionError("prompted")):
@@ -796,7 +836,7 @@ class TestDotenvResolution:
 
         out = capsys.readouterr().out
         assert "$ARIZE_SPACE_ID" in out
-        assert str(tmp_path / ".env") in out
+        assert str(tmp_path / "creds.env") in out
         assert "fresh-key" not in out
 
 
@@ -924,7 +964,7 @@ class TestWriteConfig:
 class TestClaudeSetup:
     """Tests for core.setup.claude."""
 
-    def test_settings_json_phoenix(self, tmp_path):
+    def test_settings_json_phoenix(self, tmp_path, monkeypatch):
         """Claude setup creates settings.json with Phoenix env block."""
         settings_path = tmp_path / ".claude" / "settings.local.json"
 
@@ -943,7 +983,7 @@ class TestClaudeSetup:
         assert result["env"]["PHOENIX_ENDPOINT"] == "http://localhost:6006"
         assert result["env"]["ARIZE_TRACE_ENABLED"] == "true"
 
-    def test_settings_json_arize(self, tmp_path):
+    def test_settings_json_arize(self, tmp_path, monkeypatch):
         """Claude setup creates settings.json with Arize AX env block."""
         settings_path = tmp_path / ".claude" / "settings.local.json"
 
@@ -964,7 +1004,7 @@ class TestClaudeSetup:
         assert result["env"]["ARIZE_OTLP_ENDPOINT"] == "otlp.arize.com:443"
         assert result["env"]["ARIZE_TRACE_ENABLED"] == "true"
 
-    def test_existing_settings_merged(self, tmp_path):
+    def test_existing_settings_merged(self, tmp_path, monkeypatch):
         """Existing settings.json keys are preserved when adding env block."""
         settings_path = tmp_path / ".claude" / "settings.local.json"
         settings_path.parent.mkdir(parents=True)
@@ -989,7 +1029,7 @@ class TestClaudeSetup:
         assert result["env"]["EXISTING_VAR"] == "keep_me"
         assert result["env"]["PHOENIX_ENDPOINT"] == "http://localhost:6006"
 
-    def test_check_existing_config_no_overwrite(self, tmp_path):
+    def test_check_existing_config_no_overwrite(self, tmp_path, monkeypatch):
         """Declining overwrite returns False."""
         settings_path = tmp_path / "settings.json"
         settings_path.write_text(json.dumps({"env": {"PHOENIX_ENDPOINT": "http://localhost:6006"}}))
@@ -1000,7 +1040,7 @@ class TestClaudeSetup:
             result = _check_existing_configuration(settings_path)
         assert result is False
 
-    def test_check_existing_config_overwrite(self, tmp_path):
+    def test_check_existing_config_overwrite(self, tmp_path, monkeypatch):
         """Accepting overwrite returns True."""
         settings_path = tmp_path / "settings.json"
         settings_path.write_text(json.dumps({"env": {"PHOENIX_ENDPOINT": "http://localhost:6006"}}))
@@ -1011,7 +1051,7 @@ class TestClaudeSetup:
             result = _check_existing_configuration(settings_path)
         assert result is True
 
-    def test_check_existing_config_arize_no_overwrite(self, tmp_path):
+    def test_check_existing_config_arize_no_overwrite(self, tmp_path, monkeypatch):
         """Declining overwrite for Arize config returns False."""
         settings_path = tmp_path / "settings.json"
         settings_path.write_text(json.dumps({"env": {"ARIZE_API_KEY": "some-key"}}))
@@ -1022,7 +1062,7 @@ class TestClaudeSetup:
             result = _check_existing_configuration(settings_path)
         assert result is False
 
-    def test_check_no_existing_config(self, tmp_path):
+    def test_check_no_existing_config(self, tmp_path, monkeypatch):
         """No existing config returns True (proceed)."""
         settings_path = tmp_path / "settings.json"
         settings_path.write_text("{}")
@@ -1032,14 +1072,14 @@ class TestClaudeSetup:
         result = _check_existing_configuration(settings_path)
         assert result is True
 
-    def test_load_settings_missing_file(self, tmp_path):
+    def test_load_settings_missing_file(self, tmp_path, monkeypatch):
         """_load_settings returns {} for missing file."""
         from core.setup.claude import _load_settings
 
         result = _load_settings(tmp_path / "nonexistent.json")
         assert result == {}
 
-    def test_load_settings_invalid_json(self, tmp_path):
+    def test_load_settings_invalid_json(self, tmp_path, monkeypatch):
         """_load_settings returns {} for invalid JSON."""
         path = tmp_path / "bad.json"
         path.write_text("not json{{{")
@@ -1168,7 +1208,7 @@ class TestClaudeSetup:
 class TestCodexWriteEnvFile:
     """Tests for _write_env_file()."""
 
-    def test_phoenix_env_file(self, tmp_path):
+    def test_phoenix_env_file(self, tmp_path, monkeypatch):
         """Env file for Phoenix backend has correct exports."""
         env_path = tmp_path / ".codex" / "arize-env.sh"
         from core.setup.codex import _write_env_file
@@ -1182,7 +1222,7 @@ class TestCodexWriteEnvFile:
         # project_name lives in config.json only; not baked into the env file (#74).
         assert "ARIZE_PROJECT_NAME" not in content
 
-    def test_phoenix_env_file_with_api_key(self, tmp_path):
+    def test_phoenix_env_file_with_api_key(self, tmp_path, monkeypatch):
         """Env file for Phoenix with API key includes it."""
         env_path = tmp_path / ".codex" / "arize-env.sh"
         from core.setup.codex import _write_env_file
@@ -1192,7 +1232,7 @@ class TestCodexWriteEnvFile:
         content = env_path.read_text()
         assert 'export PHOENIX_API_KEY="my-key"' in content
 
-    def test_arize_env_file(self, tmp_path):
+    def test_arize_env_file(self, tmp_path, monkeypatch):
         """Env file for Arize AX backend has correct exports."""
         env_path = tmp_path / ".codex" / "arize-env.sh"
         from core.setup.codex import _write_env_file
@@ -1215,7 +1255,7 @@ class TestCodexWriteEnvFile:
         # project_name lives in config.json only; not baked into the env file (#74).
         assert "ARIZE_PROJECT_NAME" not in content
 
-    def test_env_file_creates_parent_dir(self, tmp_path):
+    def test_env_file_creates_parent_dir(self, tmp_path, monkeypatch):
         """_write_env_file creates parent directories."""
         env_path = tmp_path / "deep" / "nested" / "arize-env.sh"
         from core.setup.codex import _write_env_file
@@ -1223,7 +1263,7 @@ class TestCodexWriteEnvFile:
         _write_env_file(env_path, "phoenix", {"endpoint": "http://localhost:6006", "api_key": ""})
         assert env_path.exists()
 
-    def test_env_file_permissions(self, tmp_path):
+    def test_env_file_permissions(self, tmp_path, monkeypatch):
         """Env file should be chmod 600 on Unix."""
         if os.name == "nt":
             pytest.skip("chmod test only on Unix")
@@ -1238,7 +1278,7 @@ class TestCodexWriteEnvFile:
 class TestCodexUpdateToml:
     """Tests for _update_toml_otel_section()."""
 
-    def test_adds_otel_to_empty_file(self, tmp_path):
+    def test_adds_otel_to_empty_file(self, tmp_path, monkeypatch):
         """Adds [otel] section to a new/empty file."""
         toml_path = tmp_path / ".codex" / "config.toml"
         from core.setup.codex import _update_toml_otel_section
@@ -1251,7 +1291,7 @@ class TestCodexUpdateToml:
         assert 'endpoint = "http://127.0.0.1:4318/v1/logs"' in content
         assert 'protocol = "json"' in content
 
-    def test_replaces_existing_otel_section(self, tmp_path):
+    def test_replaces_existing_otel_section(self, tmp_path, monkeypatch):
         """Replaces existing [otel] section with new one."""
         toml_path = tmp_path / "config.toml"
         toml_path.write_text(
@@ -1268,7 +1308,7 @@ class TestCodexUpdateToml:
         assert "[other]" in content
         assert 'foo = "bar"' in content
 
-    def test_preserves_other_sections(self, tmp_path):
+    def test_preserves_other_sections(self, tmp_path, monkeypatch):
         """Other TOML sections are preserved when replacing [otel]."""
         toml_path = tmp_path / "config.toml"
         original = '[auth]\ntoken = "secret"\n\n[otel]\nnotify = ["old-cmd"]\n'
@@ -1284,7 +1324,7 @@ class TestCodexUpdateToml:
         assert "old-cmd" not in content
         assert "[otel]" in content
 
-    def test_replaces_otel_subsection(self, tmp_path):
+    def test_replaces_otel_subsection(self, tmp_path, monkeypatch):
         """Replaces [otel.exporter.otlp-http] as part of otel section."""
         toml_path = tmp_path / "config.toml"
         toml_path.write_text(
@@ -1300,7 +1340,7 @@ class TestCodexUpdateToml:
         assert 'endpoint = "http://127.0.0.1:5555/v1/logs"' in content
         assert "[other]" in content
 
-    def test_preserves_otelother_section(self, tmp_path):
+    def test_preserves_otelother_section(self, tmp_path, monkeypatch):
         """A section named [otelother] should NOT be removed as part of [otel]."""
         toml_path = tmp_path / "config.toml"
         toml_path.write_text('[otel]\nold = "val"\n\n' '[otelother]\nkeep = "this"\n')
@@ -1313,7 +1353,7 @@ class TestCodexUpdateToml:
         assert 'keep = "this"' in content
         assert 'old = "val"' not in content
 
-    def test_custom_port(self, tmp_path):
+    def test_custom_port(self, tmp_path, monkeypatch):
         """Uses the provided collector port."""
         toml_path = tmp_path / "config.toml"
         from core.setup.codex import _update_toml_otel_section

--- a/tests/core/test_shell_router.py
+++ b/tests/core/test_shell_router.py
@@ -10,6 +10,7 @@ import os
 import re
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -136,7 +137,10 @@ class TestHarnessMapping:
         self.text = _read_install_sh()
 
     def test_claude_maps_to_tracing_claude_code(self):
-        assert 'claude)  echo "tracing/claude_code"' in self.text
+        # Both spellings: "claude" is the CLI name, "claude-code" the config key
+        # that list_installed_harnesses() hands back. See
+        # TestConfigKeysResolveInHarnessDir for why the alias exists.
+        assert 'claude|claude-code)  echo "tracing/claude_code"' in self.text
 
     def test_codex_maps_to_tracing_codex(self):
         assert 'codex)   echo "tracing/codex"' in self.text
@@ -490,3 +494,74 @@ class TestWheelDirBehaviour:
 
         assert result.returncode != 0
         assert "no source tree to update" in result.stderr
+
+
+class TestConfigKeysResolveInHarnessDir:
+    """Every key that can appear in config.json must resolve in harness_dir().
+
+    `update` and full `uninstall` discover harnesses through
+    list_installed_harnesses(), which yields *config keys* (each harness's
+    HARNESS_NAME), then look each one up with harness_dir(), which knew only CLI
+    names. Claude Code writes "claude-code" while its CLI name is "claude", so
+    both loops skipped it with "Unknown harness: claude-code (skipping)".
+
+    The consequence was not cosmetic: a full uninstall wiped the venv and left 16
+    hook entries live in ~/.claude/settings.json pointing at the deleted path, so
+    Claude Code then tried to exec missing binaries on every hook event. wipe.py
+    deliberately does not touch settings.json — the per-harness uninstall is the
+    only thing that cleans it, and it was the step being skipped.
+
+    Discovered from the constants rather than hardcoded, so a new harness whose
+    HARNESS_NAME differs from its CLI name fails here instead of in the field.
+    """
+
+    @staticmethod
+    def _config_keys() -> list:
+        import importlib
+
+        repo_root = Path(INSTALL_SH).resolve().parent
+        keys = []
+        for constants in sorted((repo_root / "tracing").glob("*/constants.py")):
+            module = importlib.import_module(f"tracing.{constants.parent.name}.constants")
+            name = getattr(module, "HARNESS_NAME", None)
+            if name:
+                keys.append(name)
+        return keys
+
+    def test_constants_were_discovered(self):
+        """Guard the guard: an empty list would make every test below vacuous."""
+        keys = self._config_keys()
+        assert len(keys) >= 8, f"expected every harness's HARNESS_NAME, found {keys}"
+        assert "claude-code" in keys, "the regression case itself must be covered"
+
+    def test_every_config_key_resolves(self, tmp_path):
+        """Probe through `uninstall`, which is where the lookup actually happens.
+
+        With an empty HOME the command still fails — there is no venv — but it
+        fails *after* harness_dir(), so "Unknown harness" cleanly distinguishes a
+        name that did not resolve from one that did.
+        """
+        for key in self._config_keys():
+            result = subprocess.run(
+                ["bash", INSTALL_SH, "uninstall", key],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env={**os.environ, "NO_COLOR": "1", "HOME": str(tmp_path)},
+                stdin=subprocess.DEVNULL,
+            )
+            assert "Unknown harness" not in result.stderr, f"config key {key!r} does not resolve in harness_dir()"
+
+    def test_cli_names_still_resolve(self):
+        """The alias must not cost us the original spelling."""
+        text = _read_install_sh()
+        for cli_name in ("claude", "codex", "copilot", "cursor", "gemini", "kiro", "opencode", "omp"):
+            assert re.search(rf"^\s+{cli_name}[)|]", text, re.MULTILINE), f"{cli_name} missing from harness_dir()"
+
+    def test_install_dispatch_does_not_gain_an_alias(self):
+        """`install.sh claude-code` should stay an unknown *command*.
+
+        The alias is for resolving discovered config keys. Making it a second way
+        to install the same harness would imply there are two harnesses.
+        """
+        assert "claude|codex|copilot|cursor|gemini|kiro|opencode|omp)" in _read_install_sh()

--- a/tests/core/test_shell_router.py
+++ b/tests/core/test_shell_router.py
@@ -445,7 +445,6 @@ class TestWheelDirBehaviour:
         assert "No coding_harness_tracing-*.whl" in result.stderr
         assert not (tmp_path / ".arize").exists()
 
-    @pytest.mark.slow
     def test_never_downloads_the_repo(self, tmp_path):
         """The whole point: no tarball, no clone, no source tree.
 
@@ -465,7 +464,6 @@ class TestWheelDirBehaviour:
         assert not (tmp_path / ".arize" / "harness" / "pyproject.toml").exists()
         assert not (tmp_path / ".arize" / "harness" / ".git").exists()
 
-    @pytest.mark.slow
     def test_places_install_sh_for_later_commands(self, tmp_path):
         """`status`, `update` and `uninstall` are all documented as running from
         ~/.arize/harness/install.sh, which repo mode gets via the extract.
@@ -480,7 +478,6 @@ class TestWheelDirBehaviour:
         assert placed.is_file()
         assert os.access(placed, os.X_OK)
 
-    @pytest.mark.slow
     def test_update_refuses_without_a_source_tree(self, tmp_path):
         """Rather than quietly converting an offline install to a network one."""
         harness = tmp_path / ".arize" / "harness"

--- a/tests/core/test_shell_router.py
+++ b/tests/core/test_shell_router.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
 
 import pytest
 
@@ -46,11 +47,21 @@ class TestShellSyntax:
         text = _read_install_sh()
         assert "set -euo pipefail" in text, "Missing strict mode"
 
-    def test_line_count_under_400(self):
-        """Router should be ~200-330 lines, well under the old 1919."""
+    def test_line_count_under_460(self):
+        """Router should be ~350-450 lines, well under the old 1919.
+
+        The cap is a ratchet against bash creeping back in: logic here is not
+        unit-testable, not type-checked, and has to be mirrored in install.bat
+        for Windows. Anything that can live in `core/setup/` belongs there.
+
+        Raised from 400 when offline wheel install landed (--wheel-dir): flag
+        parsing and the pip invocation both run before the venv exists, so they
+        cannot move to Python. If you are raising it again, move something to
+        Python first — and change this docstring, not just the number.
+        """
         text = _read_install_sh()
         lines = text.strip().splitlines()
-        assert len(lines) <= 400, f"install.sh has {len(lines)} lines — should be under 400"
+        assert len(lines) <= 460, f"install.sh has {len(lines)} lines — should be under 460"
 
 
 # ---------------------------------------------------------------------------
@@ -291,9 +302,11 @@ class TestDispatchLogic:
         # between them.
         pre_wipe = text[:wipe_idx]
         assert "list_installed_harnesses" in pre_wipe, "Full uninstall does not iterate installed harnesses before wipe"
+        # run_harness_py dispatches to install.py — as a file in repo mode, as a
+        # module in wheel mode. Either way it must run before the wipe.
         assert (
-            'install.py" uninstall' in pre_wipe
-        ), "Full uninstall does not invoke per-harness install.py uninstall before wipe"
+            'run_harness_py "$key" "$vp" uninstall' in pre_wipe
+        ), "Full uninstall does not invoke per-harness uninstall before wipe"
 
     def test_update_calls_pip_install(self):
         assert "pip" in self.text and "install" in self.text
@@ -382,3 +395,101 @@ class TestConstants:
 
     def test_tarball_url(self):
         assert "archive/refs/heads/" in self.text
+
+
+class TestWheelDirParsing:
+    """`--wheel-dir` installs from local wheels, fetching nothing."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.text = _read_install_sh()
+
+    def test_flag_and_env_var_both_wired(self):
+        assert "--wheel-dir)" in self.text
+        assert "ARIZE_WHEEL_DIR" in self.text
+
+    def test_pip_uses_no_index(self):
+        """--no-index is what makes a missing wheel loud instead of a PyPI fetch."""
+        assert '--no-index --find-links "$WHEEL_DIR" coding-harness-tracing' in self.text
+
+    def test_documented_in_usage(self):
+        assert "--wheel-dir DIR" in self.text
+
+    def test_harness_py_falls_back_to_module(self):
+        """A wheel install has no source tree, so install.py runs as a module."""
+        assert 'run_with_tty "$vp" -m "${dir//\\//.}.install"' in self.text
+
+
+class TestWheelDirBehaviour:
+    """Run the script for real, with a throwaway HOME and no network."""
+
+    def _run(self, *args: str, home, wheel_dir=None, timeout=90):
+        env = {**os.environ, "NO_COLOR": "1", "HOME": str(home)}
+        env.pop("ARIZE_WHEEL_DIR", None)
+        cmd = ["bash", INSTALL_SH, *args]
+        if wheel_dir is not None:
+            cmd += ["--wheel-dir", str(wheel_dir)]
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, env=env, stdin=subprocess.DEVNULL)
+
+    def test_missing_directory_is_fatal(self, tmp_path):
+        result = self._run("claude", home=tmp_path, wheel_dir=tmp_path / "nope")
+        assert result.returncode != 0
+        assert "needs a directory" in result.stderr
+
+    def test_directory_without_a_wheel_is_fatal(self, tmp_path):
+        """Fail before touching anything, rather than silently falling back."""
+        empty = tmp_path / "wheels"
+        empty.mkdir()
+        result = self._run("claude", home=tmp_path, wheel_dir=empty)
+        assert result.returncode != 0
+        assert "No coding_harness_tracing-*.whl" in result.stderr
+        assert not (tmp_path / ".arize").exists()
+
+    @pytest.mark.slow
+    def test_never_downloads_the_repo(self, tmp_path):
+        """The whole point: no tarball, no clone, no source tree.
+
+        A deliberately corrupt wheel makes pip fail, which is fine — what
+        matters is that nothing was fetched on the way there.
+        """
+        wheels = tmp_path / "wheels"
+        wheels.mkdir()
+        (wheels / "coding_harness_tracing-0.1.0-py3-none-any.whl").write_bytes(b"not a wheel")
+
+        result = self._run("claude", home=tmp_path, wheel_dir=wheels)
+
+        assert result.returncode != 0
+        combined = result.stdout + result.stderr
+        assert "Downloading coding-harness-tracing tarball" not in combined
+        assert "Extracted to" not in combined
+        assert not (tmp_path / ".arize" / "harness" / "pyproject.toml").exists()
+        assert not (tmp_path / ".arize" / "harness" / ".git").exists()
+
+    @pytest.mark.slow
+    def test_places_install_sh_for_later_commands(self, tmp_path):
+        """`status`, `update` and `uninstall` are all documented as running from
+        ~/.arize/harness/install.sh, which repo mode gets via the extract.
+        Without this copy the install works and then cannot be verified."""
+        wheels = tmp_path / "wheels"
+        wheels.mkdir()
+        (wheels / "coding_harness_tracing-0.1.0-py3-none-any.whl").write_bytes(b"not a wheel")
+
+        self._run("claude", home=tmp_path, wheel_dir=wheels)
+
+        placed = tmp_path / ".arize" / "harness" / "install.sh"
+        assert placed.is_file()
+        assert os.access(placed, os.X_OK)
+
+    @pytest.mark.slow
+    def test_update_refuses_without_a_source_tree(self, tmp_path):
+        """Rather than quietly converting an offline install to a network one."""
+        harness = tmp_path / ".arize" / "harness"
+        (harness / "venv" / "bin").mkdir(parents=True)
+        # A venv python that exists so update gets past its own guard.
+        (harness / "venv" / "bin" / "python").symlink_to(sys.executable)
+        (harness / "venv" / "bin" / "pip").symlink_to(sys.executable)
+
+        result = self._run("update", home=tmp_path)
+
+        assert result.returncode != 0
+        assert "no source tree to update" in result.stderr

--- a/tests/core/test_shell_router.py
+++ b/tests/core/test_shell_router.py
@@ -22,6 +22,25 @@ def _read_install_sh() -> str:
         return f.read()
 
 
+def _run_install_sh(*args, home=None, wheel_dir=None, env_extra=None, timeout=90):
+    """Run install.sh with a predictable environment.
+
+    One helper because three call sites were building this by hand. stdin is
+    always /dev/null: a test that hangs on a prompt is worse than one that fails,
+    and the harness installers do prompt.
+    """
+    env = {**os.environ, "NO_COLOR": "1"}
+    env.pop("ARIZE_WHEEL_DIR", None)
+    if home is not None:
+        env["HOME"] = str(home)
+    if env_extra:
+        env.update(env_extra)
+    cmd = ["bash", INSTALL_SH, *args]
+    if wheel_dir is not None:
+        cmd += ["--wheel-dir", str(wheel_dir)]
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, env=env, stdin=subprocess.DEVNULL)
+
+
 # ---------------------------------------------------------------------------
 # Syntax & structure tests
 # ---------------------------------------------------------------------------
@@ -85,8 +104,6 @@ class TestFunctionsDefined:
             "err",
             "header",
             "command_exists",
-            "tty_input",
-            "tty_read_masked_line",
             "find_python",
             "venv_python",
             "venv_pip",
@@ -117,6 +134,10 @@ class TestFunctionsDefined:
             "write_config",
             "collect_backend_credentials",
             "install_skills",
+            # Dead when removed: never called, and Python's getpass replaced the
+            # masked-input one. Guarded here so they cannot creep back.
+            "tty_input",
+            "tty_read_masked_line",
         ]:
             pattern = rf"^{old_func}\s*\(\)"
             assert not re.search(
@@ -195,51 +216,39 @@ class TestUsageOutput:
 class TestSmokeTests:
     """Run the actual script with safe arguments."""
 
-    def _run(self, *args: str, env_extra: dict | None = None) -> subprocess.CompletedProcess:
-        env = {**os.environ, "NO_COLOR": "1"}
-        if env_extra:
-            env.update(env_extra)
-        return subprocess.run(
-            ["bash", INSTALL_SH, *args],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            env=env,
-        )
-
     def test_help_exits_zero(self):
-        result = self._run("--help")
+        result = _run_install_sh("--help")
         assert result.returncode == 0
         assert "Arize Coding Harness Tracing Installer" in result.stdout
 
     def test_help_flag_h(self):
-        result = self._run("-h")
+        result = _run_install_sh("-h")
         assert result.returncode == 0
         assert "Usage:" in result.stdout
 
     def test_help_word(self):
-        result = self._run("help")
+        result = _run_install_sh("help")
         assert result.returncode == 0
 
     def test_no_args_exits_nonzero(self):
-        result = self._run()
+        result = _run_install_sh()
         assert result.returncode != 0
         assert "Usage:" in result.stdout
 
     def test_bogus_command_exits_nonzero(self):
-        result = self._run("bogus")
+        result = _run_install_sh("bogus")
         assert result.returncode != 0
         assert "Unknown command" in result.stderr
 
     def test_uninstall_bogus_harness_exits_nonzero(self):
         """uninstall <invalid> should fail."""
-        result = self._run("uninstall", "invalid-harness")
+        result = _run_install_sh("uninstall", "invalid-harness")
         assert result.returncode != 0
 
     def test_update_without_install_fails(self):
         """update should fail if no venv exists at ~/.arize/harness/venv."""
         # Use a fake HOME so we don't touch real install
-        result = self._run("update", env_extra={"HOME": "/tmp/arize-test-nonexistent"})
+        result = _run_install_sh("update", env_extra={"HOME": "/tmp/arize-test-nonexistent"})
         assert result.returncode != 0
 
 
@@ -427,16 +436,8 @@ class TestWheelDirParsing:
 class TestWheelDirBehaviour:
     """Run the script for real, with a throwaway HOME and no network."""
 
-    def _run(self, *args: str, home, wheel_dir=None, timeout=90):
-        env = {**os.environ, "NO_COLOR": "1", "HOME": str(home)}
-        env.pop("ARIZE_WHEEL_DIR", None)
-        cmd = ["bash", INSTALL_SH, *args]
-        if wheel_dir is not None:
-            cmd += ["--wheel-dir", str(wheel_dir)]
-        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, env=env, stdin=subprocess.DEVNULL)
-
     def test_missing_directory_is_fatal(self, tmp_path):
-        result = self._run("claude", home=tmp_path, wheel_dir=tmp_path / "nope")
+        result = _run_install_sh("claude", home=tmp_path, wheel_dir=tmp_path / "nope")
         assert result.returncode != 0
         assert "needs a directory" in result.stderr
 
@@ -444,7 +445,7 @@ class TestWheelDirBehaviour:
         """Fail before touching anything, rather than silently falling back."""
         empty = tmp_path / "wheels"
         empty.mkdir()
-        result = self._run("claude", home=tmp_path, wheel_dir=empty)
+        result = _run_install_sh("claude", home=tmp_path, wheel_dir=empty)
         assert result.returncode != 0
         assert "No coding_harness_tracing-*.whl" in result.stderr
         assert not (tmp_path / ".arize").exists()
@@ -459,7 +460,7 @@ class TestWheelDirBehaviour:
         wheels.mkdir()
         (wheels / "coding_harness_tracing-0.1.0-py3-none-any.whl").write_bytes(b"not a wheel")
 
-        result = self._run("claude", home=tmp_path, wheel_dir=wheels)
+        result = _run_install_sh("claude", home=tmp_path, wheel_dir=wheels)
 
         assert result.returncode != 0
         combined = result.stdout + result.stderr
@@ -476,7 +477,7 @@ class TestWheelDirBehaviour:
         wheels.mkdir()
         (wheels / "coding_harness_tracing-0.1.0-py3-none-any.whl").write_bytes(b"not a wheel")
 
-        self._run("claude", home=tmp_path, wheel_dir=wheels)
+        _run_install_sh("claude", home=tmp_path, wheel_dir=wheels)
 
         placed = tmp_path / ".arize" / "harness" / "install.sh"
         assert placed.is_file()
@@ -490,7 +491,7 @@ class TestWheelDirBehaviour:
         (harness / "venv" / "bin" / "python").symlink_to(sys.executable)
         (harness / "venv" / "bin" / "pip").symlink_to(sys.executable)
 
-        result = self._run("update", home=tmp_path)
+        result = _run_install_sh("update", home=tmp_path)
 
         assert result.returncode != 0
         assert "no source tree to update" in result.stderr
@@ -542,14 +543,7 @@ class TestConfigKeysResolveInHarnessDir:
         name that did not resolve from one that did.
         """
         for key in self._config_keys():
-            result = subprocess.run(
-                ["bash", INSTALL_SH, "uninstall", key],
-                capture_output=True,
-                text=True,
-                timeout=30,
-                env={**os.environ, "NO_COLOR": "1", "HOME": str(tmp_path)},
-                stdin=subprocess.DEVNULL,
-            )
+            result = _run_install_sh("uninstall", key, home=tmp_path, timeout=30)
             assert "Unknown harness" not in result.stderr, f"config key {key!r} does not resolve in harness_dir()"
 
     def test_cli_names_still_resolve(self):

--- a/tests/core/test_shell_router.py
+++ b/tests/core/test_shell_router.py
@@ -325,6 +325,39 @@ class TestFlagParsing:
     def test_env_var_default_branch(self):
         assert "ARIZE_INSTALL_BRANCH" in self.text
 
+    def test_non_interactive_flag_parsed(self):
+        assert "--non-interactive|-y)" in self.text
+        assert "export ARIZE_NONINTERACTIVE=1" in self.text
+
+    def test_json_flag_parsed(self):
+        assert "--json)" in self.text
+        assert 'status_args="--json"' in self.text
+
+
+class TestUpdateNonInteractiveGate:
+    """`update` re-registers harnesses, which prompts for each project name.
+
+    With no terminal that used to die with an EOFError. The fallback must be
+    gated on there being no terminal, so an interactive update keeps its prompts.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.text = _read_install_sh()
+
+    def test_update_falls_back_when_no_terminal(self):
+        assert '[[ -n "$_tty_in" ]] || export ARIZE_NONINTERACTIVE=1' in self.text
+
+    def test_gate_lives_in_the_update_arm(self):
+        """Guard against the export drifting somewhere it would always apply."""
+        update_arm = self.text.split("        update)", 1)[1].split("        -h|--help|help)", 1)[0]
+        assert '[[ -n "$_tty_in" ]] || export ARIZE_NONINTERACTIVE=1' in update_arm
+
+    def test_gate_reuses_the_scripts_own_tty_detection(self):
+        """_tty_in is how the rest of the script already decides if it can prompt."""
+        assert '_tty_in="/dev/tty"' in self.text
+        assert self.text.index('_tty_in="/dev/tty"') < self.text.index('[[ -n "$_tty_in" ]] || export')
+
 
 # ---------------------------------------------------------------------------
 # Constants tests

--- a/tests/core/test_status.py
+++ b/tests/core/test_status.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Tests for core/setup/status.py — the machine-readable install report."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def status_paths(tmp_path, monkeypatch):
+    """Point status.py's install dir, venv and config file at tmp_path."""
+    import core.setup as setup
+    import core.setup.status as status
+
+    install_dir = tmp_path / ".arize" / "harness"
+    install_dir.mkdir(parents=True)
+    config_file = install_dir / "config.json"
+
+    monkeypatch.setattr(status, "INSTALL_DIR", install_dir)
+    monkeypatch.setattr(status, "VENV_DIR", install_dir / "venv")
+    monkeypatch.setattr(status, "CONFIG_FILE", config_file)
+    monkeypatch.setattr(setup, "INSTALL_DIR", install_dir)
+
+    return {"install_dir": install_dir, "config_file": config_file}
+
+
+def _write_config(status_paths, config):
+    status_paths["config_file"].write_text(json.dumps(config))
+
+
+class TestCollectStatus:
+    """Tests for collect_status()."""
+
+    def test_empty_when_no_config(self, status_paths):
+        from core.setup.status import collect_status
+
+        result = collect_status()
+
+        assert result["harnesses"] == []
+        assert result["config_exists"] is False
+        assert result["installed"] is False
+
+    def test_installed_reflects_venv(self, status_paths):
+        from core.setup.status import collect_status
+
+        (status_paths["install_dir"] / "venv").mkdir()
+
+        assert collect_status()["installed"] is True
+
+    def test_reports_harness_fields(self, status_paths):
+        from core.setup.status import collect_status
+
+        _write_config(
+            status_paths,
+            {
+                "harnesses": {
+                    "claude-code": {
+                        "project_name": "my-project",
+                        "target": "arize",
+                        "endpoint": "otlp.arize.com:443",
+                        "api_key": "secret-value",
+                        "space_id": "space-abc",
+                    }
+                },
+                "user_id": "alice",
+                "logging": {"prompts": True, "tool_details": False, "tool_content": True},
+            },
+        )
+
+        result = collect_status()
+        entry = result["harnesses"][0]
+
+        assert entry["name"] == "claude-code"
+        assert entry["project_name"] == "my-project"
+        assert entry["target"] == "arize"
+        assert entry["space_id"] == "space-abc"
+        assert entry["api_key_present"] is True
+        assert result["user_id"] == "alice"
+        assert result["logging"]["tool_details"] is False
+
+    def test_never_includes_the_api_key(self, status_paths):
+        """The whole payload must be safe to paste into a bug report."""
+        from core.setup.status import collect_status
+
+        _write_config(
+            status_paths,
+            {"harnesses": {"claude-code": {"target": "arize", "api_key": "super-secret-key"}}},
+        )
+
+        blob = json.dumps(collect_status())
+
+        assert "super-secret-key" not in blob
+        assert "api_key_present" in blob
+
+    def test_missing_api_key_reported_absent(self, status_paths):
+        from core.setup.status import collect_status
+
+        _write_config(status_paths, {"harnesses": {"codex": {"target": "arize", "api_key": ""}}})
+
+        assert collect_status()["harnesses"][0]["api_key_present"] is False
+
+    def test_no_space_id_key_for_phoenix(self, status_paths):
+        from core.setup.status import collect_status
+
+        _write_config(
+            status_paths,
+            {"harnesses": {"cursor": {"target": "phoenix", "endpoint": "http://localhost:6006"}}},
+        )
+
+        assert "space_id" not in collect_status()["harnesses"][0]
+
+    def test_project_name_falls_back_to_harness_name(self, status_paths):
+        from core.setup.status import collect_status
+
+        _write_config(status_paths, {"harnesses": {"gemini": {"target": "arize"}}})
+
+        assert collect_status()["harnesses"][0]["project_name"] == "gemini"
+
+    def test_harnesses_sorted(self, status_paths):
+        from core.setup.status import collect_status
+
+        _write_config(
+            status_paths,
+            {"harnesses": {"omp": {"target": "arize"}, "codex": {"target": "arize"}}},
+        )
+
+        assert [h["name"] for h in collect_status()["harnesses"]] == ["codex", "omp"]
+
+    def test_malformed_entry_skipped(self, status_paths):
+        from core.setup.status import collect_status
+
+        _write_config(status_paths, {"harnesses": {"codex": "not-a-dict"}})
+
+        assert collect_status()["harnesses"] == []
+
+
+class TestRegistrationDetection:
+    """Tests for whether a harness's hooks are actually wired up."""
+
+    def test_registered_when_file_references_install_dir(self, status_paths, tmp_path, monkeypatch):
+        from core.setup import status as status_mod
+
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({"hooks": {"Stop": str(status_paths["install_dir"] / "venv" / "bin" / "hook")}}))
+        monkeypatch.setattr(status_mod, "_registration_paths", lambda h: [settings])
+
+        assert status_mod._registration_state("claude-code") == (True, str(settings))
+
+    def test_not_registered_when_file_is_someone_elses(self, status_paths, tmp_path, monkeypatch):
+        from core.setup import status as status_mod
+
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({"hooks": {"Stop": "/usr/bin/unrelated"}}))
+        monkeypatch.setattr(status_mod, "_registration_paths", lambda h: [settings])
+
+        assert status_mod._registration_state("claude-code") == (False, str(settings))
+
+    def test_not_registered_when_file_absent(self, status_paths, tmp_path, monkeypatch):
+        from core.setup import status as status_mod
+
+        missing = tmp_path / "nope.json"
+        monkeypatch.setattr(status_mod, "_registration_paths", lambda h: [missing])
+
+        registered, path = status_mod._registration_state("claude-code")
+
+        assert registered is False
+        assert path == str(missing)
+
+    def test_unknown_harness_reports_none_not_false(self, status_paths):
+        """Never claim 'not registered' for something we cannot check."""
+        from core.setup.status import _registration_state
+
+        assert _registration_state("not-a-real-harness") == (None, None)
+
+    def test_symlinked_plugin_counts_as_registered(self, status_paths, tmp_path, monkeypatch):
+        from core.setup import status as status_mod
+
+        source = status_paths["install_dir"] / "plugin.ts"
+        source.write_text("// tracing plugin")
+        link = tmp_path / "arize-tracing.ts"
+        link.symlink_to(source)
+        monkeypatch.setattr(status_mod, "_registration_paths", lambda h: [link])
+
+        assert status_mod._registration_state("opencode")[0] is True
+
+    def test_directory_scanned_for_marker(self, status_paths, tmp_path, monkeypatch):
+        """Kiro registers into an agents directory, not a single file."""
+        from core.setup import status as status_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "other.json").write_text("{}")
+        (agents / "arize-traced.json").write_text(str(status_paths["install_dir"] / "venv" / "bin" / "arize-hook-kiro"))
+        monkeypatch.setattr(status_mod, "_registration_paths", lambda h: [agents])
+
+        assert status_mod._registration_state("kiro")[0] is True
+
+    def test_every_known_harness_has_resolvable_paths(self):
+        """Guards against a harness being added to the map with a bad constant."""
+        from core.setup.status import _REGISTRATION, _registration_paths
+
+        for harness in _REGISTRATION:
+            paths = _registration_paths(harness)
+            assert paths, f"{harness} resolved no registration paths"
+            assert all(isinstance(p, Path) for p in paths)
+
+
+class TestCli:
+    """Tests for the command-line surface."""
+
+    def test_json_output_parses(self, status_paths, capsys):
+        from core.setup.status import main
+
+        _write_config(status_paths, {"harnesses": {"codex": {"target": "arize", "api_key": "k"}}})
+
+        assert main(["--json"]) == 0
+        assert json.loads(capsys.readouterr().out)["harnesses"][0]["name"] == "codex"
+
+    def test_exit_nonzero_when_nothing_configured(self, status_paths, capsys):
+        """So a caller can gate on it without parsing output."""
+        from core.setup.status import main
+
+        assert main([]) == 1
+        assert "No harnesses configured" in capsys.readouterr().out
+
+    def test_human_output_hides_the_key(self, status_paths, capsys):
+        from core.setup.status import main
+
+        _write_config(
+            status_paths,
+            {"harnesses": {"codex": {"target": "arize", "api_key": "super-secret-key", "space_id": "s"}}},
+        )
+        main([])
+
+        out = capsys.readouterr().out
+        assert "super-secret-key" not in out
+        assert "API key:  present" in out

--- a/tests/core/test_status.py
+++ b/tests/core/test_status.py
@@ -172,6 +172,21 @@ class TestRegistrationDetection:
         assert registered is False
         assert path == str(missing)
 
+    def test_sibling_install_dir_does_not_count(self, status_paths, tmp_path, monkeypatch):
+        """`harness-old` must not match the marker `harness` on prefix.
+
+        Reporting a stale install as wired up is a false positive in the one
+        command whose job is to tell the truth about that.
+        """
+        from core.setup import status as status_mod
+
+        stale = str(status_paths["install_dir"]) + "-old"
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({"hook": f"{stale}/venv/bin/arize-hook-stop"}))
+        monkeypatch.setattr(status_mod, "_registration_paths", lambda h: [settings])
+
+        assert status_mod._registration_state("claude-code") == (False, str(settings))
+
     def test_unknown_harness_reports_none_not_false(self, status_paths):
         """Never claim 'not registered' for something we cannot check."""
         from core.setup.status import _registration_state

--- a/tests/core/test_status.py
+++ b/tests/core/test_status.py
@@ -22,6 +22,11 @@ def status_paths(tmp_path, monkeypatch):
     monkeypatch.setattr(status, "CONFIG_FILE", config_file)
     monkeypatch.setattr(setup, "INSTALL_DIR", install_dir)
 
+    # Registration lookups otherwise read the developer's real ~/.claude,
+    # ~/.codex and friends, so results would vary by machine. Tests that care
+    # about registration re-patch this with paths of their own.
+    monkeypatch.setattr(status, "_registration_paths", lambda harness: [])
+
     return {"install_dir": install_dir, "config_file": config_file}
 
 
@@ -173,6 +178,33 @@ class TestRegistrationDetection:
 
         assert _registration_state("not-a-real-harness") == (None, None)
 
+    def test_later_path_can_match_when_first_does_not(self, status_paths, tmp_path, monkeypatch):
+        """omp registers via settings.json OR a plugin file — either counts.
+
+        Stopping at the first existing path reported a false negative when the
+        second was the one that matched.
+        """
+        from core.setup import status as status_mod
+
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({"unrelated": True}))
+        plugin = tmp_path / "arize-tracing.ts"
+        plugin.write_text(f"// hook at {status_paths['install_dir']}/venv/bin/arize-hook-omp")
+        monkeypatch.setattr(status_mod, "_registration_paths", lambda h: [settings, plugin])
+
+        assert status_mod._registration_state("omp") == (True, str(plugin))
+
+    def test_reports_inspected_path_when_none_match(self, status_paths, tmp_path, monkeypatch):
+        """A False verdict should name a file that actually exists."""
+        from core.setup import status as status_mod
+
+        missing = tmp_path / "absent.json"
+        present = tmp_path / "settings.json"
+        present.write_text(json.dumps({"unrelated": True}))
+        monkeypatch.setattr(status_mod, "_registration_paths", lambda h: [missing, present])
+
+        assert status_mod._registration_state("omp") == (False, str(present))
+
     def test_symlinked_plugin_counts_as_registered(self, status_paths, tmp_path, monkeypatch):
         from core.setup import status as status_mod
 
@@ -217,12 +249,63 @@ class TestCli:
         assert main(["--json"]) == 0
         assert json.loads(capsys.readouterr().out)["harnesses"][0]["name"] == "codex"
 
-    def test_exit_nonzero_when_nothing_configured(self, status_paths, capsys):
+    def test_exit_1_when_nothing_configured(self, status_paths, capsys):
         """So a caller can gate on it without parsing output."""
         from core.setup.status import main
 
         assert main([]) == 1
         assert "No harnesses configured" in capsys.readouterr().out
+
+    def test_exit_2_when_hooks_missing(self, status_paths, tmp_path, monkeypatch, capsys):
+        """Regression: this used to exit 0 while the payload said registered=false.
+
+        Anything gating on the exit code alone concluded the install was fine.
+        """
+        from core.setup import status as status_mod
+
+        _write_config(status_paths, {"harnesses": {"codex": {"target": "arize", "api_key": "k"}}})
+        monkeypatch.setattr(status_mod, "_registration_paths", lambda h: [tmp_path / "absent.toml"])
+
+        assert status_mod.main([]) == 2
+
+        out = capsys.readouterr().out
+        assert "Hooks are missing for: codex" in out
+
+    def test_exit_0_when_everything_registered(self, status_paths, tmp_path, monkeypatch):
+        from core.setup import status as status_mod
+
+        _write_config(status_paths, {"harnesses": {"codex": {"target": "arize", "api_key": "k"}}})
+        settings = tmp_path / "config.toml"
+        settings.write_text(str(status_paths["install_dir"] / "venv" / "bin" / "arize-hook-codex-notify"))
+        monkeypatch.setattr(status_mod, "_registration_paths", lambda h: [settings])
+
+        assert status_mod.main([]) == 0
+
+    def test_unknown_registration_is_not_treated_as_failure(self, status_paths):
+        """Cannot-tell must not be reported as broken — that is guessing too."""
+        from core.setup.status import collect_status, main
+
+        _write_config(status_paths, {"harnesses": {"mystery-harness": {"target": "arize", "api_key": "k"}}})
+
+        assert collect_status()["unregistered"] == []
+        assert main([]) == 0
+
+    def test_healthy_flag_mirrors_the_exit_code(self, status_paths, tmp_path, monkeypatch):
+        """JSON consumers get the same verdict without inspecting each entry."""
+        from core.setup import status as status_mod
+
+        _write_config(status_paths, {"harnesses": {"codex": {"target": "arize", "api_key": "k"}}})
+        monkeypatch.setattr(status_mod, "_registration_paths", lambda h: [tmp_path / "absent.toml"])
+
+        status = status_mod.collect_status()
+
+        assert status["healthy"] is False
+        assert status["unregistered"] == ["codex"]
+
+    def test_healthy_false_when_nothing_configured(self, status_paths):
+        from core.setup.status import collect_status
+
+        assert collect_status()["healthy"] is False
 
     def test_human_output_hides_the_key(self, status_paths, capsys):
         from core.setup.status import main

--- a/tracing/kiro/install.py
+++ b/tracing/kiro/install.py
@@ -15,8 +15,11 @@ from core.setup import (
     dry_run,
     ensure_harness_installed,
     ensure_shared_runtime,
+    env_flag,
+    env_value,
     info,
     merge_harness_entry,
+    non_interactive,
     prompt_backend,
     prompt_content_logging,
     prompt_project_name,
@@ -100,7 +103,16 @@ def uninstall() -> None:
 
 
 def _prompt_agent_name() -> str:
-    """Ask the user which agent to install hooks into. Default arize-traced."""
+    """Ask the user which agent to install hooks into. Default arize-traced.
+
+    Kiro is the one harness with a prompt of its own, so it also needs its own
+    non-interactive source: ARIZE_KIRO_AGENT.
+    """
+    if non_interactive():
+        name = env_value("ARIZE_KIRO_AGENT") or DEFAULT_AGENT_NAME
+        info(f"Kiro agent: {name}")
+        return name
+
     raw = input(f"Agent name to install tracing into [{DEFAULT_AGENT_NAME}]: ").strip()
     return raw or DEFAULT_AGENT_NAME
 
@@ -205,10 +217,18 @@ def _unregister_all_kiro_hooks() -> None:
 
 
 def _maybe_set_default(name: str) -> None:
-    """Ask the user whether to set this agent as Kiro's default."""
-    raw = input(f"Set '{name}' as Kiro's default agent? [y/N]: ").strip().lower()
-    if raw not in ("y", "yes"):
-        return
+    """Ask the user whether to set this agent as Kiro's default.
+
+    Non-interactive installs keep the prompt's own [y/N] default and leave the
+    user's default agent alone unless ARIZE_KIRO_SET_DEFAULT opts in.
+    """
+    if non_interactive():
+        if not env_flag("ARIZE_KIRO_SET_DEFAULT", default=False):
+            return
+    else:
+        raw = input(f"Set '{name}' as Kiro's default agent? [y/N]: ").strip().lower()
+        if raw not in ("y", "yes"):
+            return
     if dry_run():
         info(f"would run: kiro-cli agent set-default {name}")
         return


### PR DESCRIPTION
## Summary

The setup wizards are interactive-only — every value comes from `input()`/`getpass()`, with no flags and no env-var seeding. That makes a scripted, CI, or coding-agent-driven install impossible: piped stdin either hangs or hits `EOFError` on the first prompt.

This adds `--non-interactive` (`-y`). In that mode the four shared prompts in `core/setup` resolve from a dotenv file or the environment instead of asking, and a missing required value is a hard error rather than a prompt.

```bash
ax api-keys create --env-file .env      # writes ARIZE_API_KEY
echo 'ARIZE_SPACE_ID=<space-id>' >> .env
./install.sh claude --non-interactive
```

It grew two companions while being tested against a real machine, both in scope for "an agent can drive this":

- **`status` / `status --json`** — reports each configured harness *and*, separately, whether its hooks are actually wired into that harness's own settings file. Both must be true for traces to appear, and `config.json` alone never proved the second. Exits non-zero when nothing is configured, so a caller can gate on it without parsing output.
- **`update` no longer dies without a terminal** — it re-registers every configured harness, which prompts per harness, so it hit `EOFError` in CI partway through and left some harnesses registered and others not.

Design notes worth reviewing:

- **All 8 harnesses funnel through the same 4 prompt functions**, so none of the per-harness `install.py` files needed to change. Kiro is the exception — it has two prompts of its own, handled via `ARIZE_KIRO_AGENT` / `ARIZE_KIRO_SET_DEFAULT`. Repointing someone's default Kiro agent stays opt-in.
- **The dotenv file takes precedence over existing environment variables.** This is the counterintuitive one, and it fixes a real bug: an installed harness exports `ARIZE_API_KEY`, `ARIZE_SPACE_ID` and `ARIZE_PROJECT_NAME` into *every* agent session via its settings file — exactly the environment this feature runs in. Reading the environment first paired a fresh key from `.env` with a stale space ID from the environment. A file is chosen; those variables are usually inherited.
- **`ARIZE_PROJECT_NAME` is read from the file only**, never the ambient environment, for the same reason — otherwise installing codex tracing from inside a traced Claude Code session named the codex project `claude-code` and collided both harnesses' spans.
- **No `--api-key` flag**, deliberately. A key in argv leaks into shell history, `ps`, and a coding agent's transcript. The file path keeps it out of all three.
- **Env vars are only consulted under the flag.** Without it, behavior is byte-identical to today — otherwise anyone with `ARIZE_API_KEY` exported for runtime use would find the wizard mysteriously skipping questions.
- **Every resolved value reports its source** (dotenv path, `$VAR`, or default) so a wrong-credentials install is diagnosable. The key itself is never echoed.
- **Content logging defaults to capture-everything**, matching the interactive wizard — see the open question below.

## Type of change

- [x] New feature
- [x] Bug fix

## How tested

**All 8 harnesses, no TTY at all** (`env -i`, no stdin), credentials from `.env`, under `ARIZE_DRY_RUN=1`. Kiro was 1 of 3 that initially failed, and that is what surfaced its two extra prompts. Re-verified after every subsequent commit, since they all touch shared resolution code:

```
claude_code → claude-code    cursor   → cursor      opencode → opencode
codex       → codex          gemini   → gemini      omp      → omp
copilot     → copilot        kiro     → kiro
```

That table is also the regression check for project naming — each harness must name its own project, not inherit `ARIZE_PROJECT_NAME=claude-code` from the ambient session.

**Real (non-dry-run) installs** against a temp `HOME`: `config.json` written correctly with mode `0600`, hooks registered, re-install does not re-prompt.

**Failure paths** — missing space ID, missing everything, and an API key with no backend all exit `1` with an actionable message and write no partial config.

**Secret handling** — asserted in tests that the API key reaches neither stdout nor stderr, and that the `status` payload never contains it. Also verified with `grep -c` over real installer output.

**Precedence**, verified end to end with a `.env` and a conflicting exported variable: the file wins for keys it defines, the environment still fills in what it doesn't, and interactive installs ignore the file entirely.

**Dotenv parsing** — `export`, single and double quotes, blank lines, comment lines, malformed lines, unrelated keys (`OPENAI_API_KEY`, `DATABASE_URL`) ignored, inline `# comment` stripped, tab-before-`#` stripped, `space#abc` kept intact, `"has # hash"` preserved when quoted.

**`status`** — against a real two-harness install: correct output, then hooks file deleted → `NOT registered`, then a settings file containing someone else's hooks → `NOT registered`, then nothing configured → exit `1`. An unknown harness reports `null`, never a guessed `false`.

**`update` with no terminal** — reproduced the `EOFError` on the re-register path, confirmed the fix takes the stored value, and confirmed a *custom* project name survives rather than being reset to the harness default.

**Gates** (per `CONTRIBUTING.md`):

- `pytest tests/ -m "not slow"` → **2248 passed**
- `pre-commit run --all-files` → **all 18 hooks pass**
- CI green on **Python 3.9–3.14** and lint

Three local failures (`test_claude_adapter.py`, `test_cursor_hook.py`) are **pre-existing and local-only** — they reproduce on base commit `b29b96b` in a clean worktree and pass in CI. Cause: `tests/conftest.py` isolates `config.json` but not the environment, so `ARIZE_PROJECT_NAME` from a real install leaks in and those tests fail on any machine that actually has this tool installed. Unrelated to this branch; noted below.

## Review findings addressed

Ran the repo's `code-review` skill on the branch. It found two real bugs in this code, both since fixed with regression tests:

1. Ambient environment overriding the dotenv file, producing mixed-source credentials (the precedence note above).
2. Unquoted trailing comments corrupting values — `ARIZE_SPACE_ID=abc # my space` silently yielded a malformed space ID.

Plus a reporting bug it prompted: the success line credited `ARIZE_API_KEY` regardless of the real source, which hid exactly the mixed-source case. Now every value names where it came from, and sources ignored by design are never credited.

## Not included

- **Empty Enter at the backend prompt selects Phoenix** (`core/setup/__init__.py`, `choice in ("1", "phoenix", "Phoenix", "")`) — a silently wrong backend for interactive users. Left out because fixing it changes existing behavior and `test_phoenix_empty_choice_defaults_to_phoenix` currently asserts it.
- **`tests/conftest.py` does not clear `ARIZE_*` / `PHOENIX_*`** — the local-only failures above. Pre-existing; wants its own PR.
- **`install.sh claude codex` silently installs only `claude`** — `subcmd` is captured but the install branch never reads it. No error, no warning.

## Open question

Non-interactive content logging defaults to capture-everything, matching the interactive wizard. Since `update` can now run without a terminal, a config with no `logging:` block gets prompts and tool output captured **without anyone having chosen it**. Options: keep parity and document loudly, default to the safe values, or refuse and require the three `ARIZE_LOG_*` variables. This is a privacy call rather than a technical one, so I have not picked for you.

## Checklist

- [x] Tests pass (`pytest`; 3 pre-existing local-only failures explained above, CI green)
- [x] Pre-commit clean (`pre-commit run --all-files`)
- [x] Ran the `code-review` skill and addressed findings
- [x] Docs updated if needed (README: non-interactive install, updating, and status sections)
