### PR TITLE
Export Phoenix spans via OTLP to /v1/traces instead of the REST API

### DIFF
--- a/core/common.py
+++ b/core/common.py
@@ -578,11 +578,11 @@ def _inject_arize_project_name(span_dict: dict, project_name: str) -> dict:
     return payload
 
 
-def _inject_phoenix_project_name(span_dict: dict, project_name: str) -> dict:
-    """Return a copy of span_dict with openinference.project.name on every resource.
+def _inject_openinference_project_resource_attr(span_dict: dict, project_name: str) -> dict:
+    """Return a copy of span_dict with the openinference.project.name resource attribute.
 
-    Phoenix routes OTLP-ingested spans to a project via this resource attribute.
-    Modifies a deep copy — does not mutate the original.
+    Phoenix routes OTLP-ingested spans to a project via this OpenInference
+    resource attribute. Modifies a deep copy — does not mutate the original.
     """
     import copy
 
@@ -812,7 +812,7 @@ def send_span(span_dict: dict) -> bool:
             api_key = backend.get("api_key", "")
             url = f"{endpoint.rstrip('/')}/v1/traces"
             # Phoenix's OTLP HTTP endpoint only accepts binary protobuf.
-            payload = _inject_phoenix_project_name(span_dict, project)
+            payload = _inject_openinference_project_resource_attr(span_dict, project)
             body = _otlp_json_to_protobuf(payload)
             headers = {"Content-Type": "application/x-protobuf"}
             if api_key:

--- a/core/common.py
+++ b/core/common.py
@@ -586,7 +586,7 @@ def _inject_project_attr(span_dict: dict, key: str, project_name: str, per_span:
 
 
 def _inject_arize_project_name(span_dict: dict, project_name: str) -> dict:
-    """Arize requires arize.project.name on each span, not just the resource."""
+    """Arize AX (not Phoenix) requires arize.project.name on each span, not just the resource."""
     return _inject_project_attr(span_dict, "arize.project.name", project_name, per_span=True)
 
 

--- a/core/common.py
+++ b/core/common.py
@@ -562,12 +562,15 @@ def resolve_backend(span_dict: dict) -> dict:
 
 
 def _inject_project_attr(span_dict: dict, key: str, project_name: str, per_span: bool = False) -> dict:
-    """Return a copy of span_dict with a project attribute on every resource.
+    """Return a copy of span_dict with {key: project_name} added as a resource
+    attribute on every resource in resourceSpans.
 
-    With per_span=True the attribute is also appended to each span's
-    attributes. Copies only the mutated path (payloads carry full prompt and
-    tool output text, so a deep copy would be O(payload) per send); untouched
-    span data is shared with the original, which is never mutated.
+    With per_span=True the attribute is also appended to each individual
+    span's attributes (required by Arize AX, which reads the project off each
+    span rather than the resource). Copies only the mutated path (payloads
+    carry full prompt and tool output text, so a deep copy would be
+    O(payload) per send); untouched span data is shared with the original,
+    which is never mutated.
     """
     project_attr = {"key": key, "value": _to_otlp_attr_value(project_name)}
 
@@ -587,12 +590,21 @@ def _inject_project_attr(span_dict: dict, key: str, project_name: str, per_span:
 
 def _inject_arize_project_name(span_dict: dict, project_name: str) -> dict:
     """Arize AX (not Phoenix) requires arize.project.name on each span, not just the resource."""
-    return _inject_project_attr(span_dict, "arize.project.name", project_name, per_span=True)
+    return _inject_project_attr(
+        span_dict,
+        key="arize.project.name",
+        project_name=project_name,
+        per_span=True,
+    )
 
 
 def _inject_openinference_project_resource_attr(span_dict: dict, project_name: str) -> dict:
     """Phoenix routes OTLP-ingested spans to a project via this resource attribute."""
-    return _inject_project_attr(span_dict, "openinference.project.name", project_name)
+    return _inject_project_attr(
+        span_dict,
+        key="openinference.project.name",
+        project_name=project_name,
+    )
 
 
 def _post_otlp(url: str, body: bytes, headers: dict, label: str) -> bool:
@@ -654,7 +666,7 @@ def send_span(span_dict: dict) -> bool:
                 endpoint = endpoint[: -len("/v1/traces")]
             url = f"{endpoint}/v1/traces"
             # Phoenix's OTLP HTTP endpoint only accepts binary protobuf.
-            payload = _inject_openinference_project_resource_attr(span_dict, project)
+            payload = _inject_openinference_project_resource_attr(span_dict, project_name=project)
             body = otlp_json_to_protobuf(payload)
             headers = {"Content-Type": "application/x-protobuf"}
             if api_key:
@@ -667,7 +679,7 @@ def send_span(span_dict: dict) -> bool:
             space_id = backend.get("space_id", "")
 
             # Inject arize.project.name into span attributes (required by Arize)
-            payload = _inject_arize_project_name(span_dict, project)
+            payload = _inject_arize_project_name(span_dict, project_name=project)
 
             # Normalize endpoint to HTTPS URL for HTTP/JSON transport
             if endpoint.startswith("http://") or endpoint.startswith("https://"):

--- a/core/common.py
+++ b/core/common.py
@@ -8,7 +8,6 @@ build_span/build_multi_span from common.sh lines 277-317 / codex common.sh lines
 """
 
 import atexit
-import copy
 import functools
 import json
 import os
@@ -566,17 +565,24 @@ def _inject_project_attr(span_dict: dict, key: str, project_name: str, per_span:
     """Return a copy of span_dict with a project attribute on every resource.
 
     With per_span=True the attribute is also appended to each span's
-    attributes. Modifies a deep copy — does not mutate the original.
+    attributes. Copies only the mutated path (payloads carry full prompt and
+    tool output text, so a deep copy would be O(payload) per send); untouched
+    span data is shared with the original, which is never mutated.
     """
-    payload = copy.deepcopy(span_dict)
     project_attr = {"key": key, "value": _to_otlp_attr_value(project_name)}
-    for rs in payload.get("resourceSpans", []):
-        rs.setdefault("resource", {}).setdefault("attributes", []).append(project_attr)
+
+    def _with_attr(owner: dict) -> dict:
+        return {**owner, "attributes": [*owner.get("attributes", []), project_attr]}
+
+    new_resource_spans = []
+    for rs in span_dict.get("resourceSpans", []):
+        new_rs = {**rs, "resource": _with_attr(rs.get("resource", {}))}
         if per_span:
-            for ss in rs.get("scopeSpans", []):
-                for span in ss.get("spans", []):
-                    span.setdefault("attributes", []).append(project_attr)
-    return payload
+            new_rs["scopeSpans"] = [
+                {**ss, "spans": [_with_attr(span) for span in ss.get("spans", [])]} for ss in rs.get("scopeSpans", [])
+            ]
+        new_resource_spans.append(new_rs)
+    return {**span_dict, "resourceSpans": new_resource_spans}
 
 
 def _inject_arize_project_name(span_dict: dict, project_name: str) -> dict:
@@ -641,7 +647,12 @@ def send_span(span_dict: dict) -> bool:
             project = backend["project_name"]
             endpoint = backend["endpoint"]
             api_key = backend.get("api_key", "")
-            url = f"{endpoint.rstrip('/')}/v1/traces"
+            # Tolerate endpoints configured as the full OTLP URL (Phoenix's
+            # PHOENIX_COLLECTOR_ENDPOINT convention) — avoid /v1/traces/v1/traces.
+            endpoint = endpoint.rstrip("/")
+            if endpoint.endswith("/v1/traces"):
+                endpoint = endpoint[: -len("/v1/traces")]
+            url = f"{endpoint}/v1/traces"
             # Phoenix's OTLP HTTP endpoint only accepts binary protobuf.
             payload = _inject_openinference_project_resource_attr(span_dict, project)
             body = otlp_json_to_protobuf(payload)

--- a/core/common.py
+++ b/core/common.py
@@ -15,9 +15,7 @@ import shutil
 import sys
 import time
 import urllib.error
-import urllib.parse
 import urllib.request
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO, Optional
 
@@ -580,118 +578,202 @@ def _inject_arize_project_name(span_dict: dict, project_name: str) -> dict:
     return payload
 
 
-def _otlp_attr_value_to_python(value: dict):
-    """Convert an OTLP AnyValue JSON object to a plain JSON value."""
+def _inject_phoenix_project_name(span_dict: dict, project_name: str) -> dict:
+    """Return a copy of span_dict with openinference.project.name on every resource.
+
+    Phoenix routes OTLP-ingested spans to a project via this resource attribute.
+    Modifies a deep copy — does not mutate the original.
+    """
+    import copy
+
+    payload = copy.deepcopy(span_dict)
+    project_attr = {"key": "openinference.project.name", "value": {"stringValue": project_name}}
+    for rs in payload.get("resourceSpans", []):
+        rs.setdefault("resource", {}).setdefault("attributes", []).append(project_attr)
+    return payload
+
+
+# --- OTLP protobuf wire-format encoding ------------------------------------
+# Phoenix's OTLP HTTP endpoint (/v1/traces) only accepts binary protobuf, and
+# hooks must run on the stdlib alone (no protobuf/OTel SDK dependency), so the
+# OTLP JSON dicts built by build_span() are encoded to the protobuf wire format
+# by hand. Field numbers follow the stable OTLP v1 trace schema
+# (opentelemetry/proto/trace/v1/trace.proto).
+
+
+def _pb_varint(n: int) -> bytes:
+    """Encode an unsigned varint."""
+    out = bytearray()
+    while True:
+        bits = n & 0x7F
+        n >>= 7
+        if n:
+            out.append(bits | 0x80)
+        else:
+            out.append(bits)
+            return bytes(out)
+
+
+def _pb_varint_field(field: int, n: int) -> bytes:
+    return _pb_varint(field << 3) + _pb_varint(n & 0xFFFFFFFFFFFFFFFF)
+
+
+def _pb_fixed64_field(field: int, n: int) -> bytes:
+    import struct
+
+    return _pb_varint(field << 3 | 1) + struct.pack("<Q", n & 0xFFFFFFFFFFFFFFFF)
+
+
+def _pb_double_field(field: int, value: float) -> bytes:
+    import struct
+
+    return _pb_varint(field << 3 | 1) + struct.pack("<d", float(value))
+
+
+def _pb_len_field(field: int, payload: bytes) -> bytes:
+    return _pb_varint(field << 3 | 2) + _pb_varint(len(payload)) + payload
+
+
+def _pb_string_field(field: int, value: str) -> bytes:
+    return _pb_len_field(field, str(value).encode("utf-8"))
+
+
+def _pb_any_value(value: dict) -> bytes:
+    """Encode an OTLP JSON AnyValue object as an AnyValue message."""
     if not isinstance(value, dict):
-        return value
+        return _pb_string_field(1, str(value))
     if "stringValue" in value:
-        return value["stringValue"]
+        return _pb_string_field(1, value["stringValue"])
     if "boolValue" in value:
-        return value["boolValue"]
+        return _pb_varint_field(2, 1 if value["boolValue"] else 0)
     if "intValue" in value:
         try:
-            return int(value["intValue"])
+            return _pb_varint_field(3, int(value["intValue"]))
         except (TypeError, ValueError):
-            return value["intValue"]
+            return _pb_string_field(1, str(value["intValue"]))
     if "doubleValue" in value:
-        return value["doubleValue"]
-    if "bytesValue" in value:
-        return value["bytesValue"]
+        return _pb_double_field(4, value["doubleValue"])
     if "arrayValue" in value:
         values = value.get("arrayValue", {}).get("values", [])
-        return [_otlp_attr_value_to_python(item) for item in values]
+        body = b"".join(_pb_len_field(1, _pb_any_value(v)) for v in values)
+        return _pb_len_field(5, body)
     if "kvlistValue" in value:
         values = value.get("kvlistValue", {}).get("values", [])
-        return {item.get("key", ""): _otlp_attr_value_to_python(item.get("value", {})) for item in values}
-    return value
+        body = b"".join(_pb_len_field(1, _pb_key_value(kv)) for kv in values)
+        return _pb_len_field(6, body)
+    if "bytesValue" in value:
+        import base64
+
+        try:
+            raw = base64.b64decode(value["bytesValue"])
+        except Exception:
+            raw = str(value["bytesValue"]).encode("utf-8")
+        return _pb_len_field(7, raw)
+    return b""
 
 
-def _otlp_attrs_to_dict(attrs: list) -> dict:
-    """Convert OTLP attribute arrays to the object shape Phoenix REST expects."""
-    result = {}
-    for attr in attrs or []:
-        key = attr.get("key")
-        if not key:
-            continue
-        result[key] = _otlp_attr_value_to_python(attr.get("value", {}))
-    return result
+def _pb_key_value(attr: dict) -> bytes:
+    """Encode an OTLP JSON attribute {key, value} as a KeyValue message."""
+    out = _pb_string_field(1, attr.get("key", ""))
+    out += _pb_len_field(2, _pb_any_value(attr.get("value", {})))
+    return out
 
 
-def _unix_nano_to_iso(value) -> str:
-    """Convert OTLP Unix nanoseconds to an ISO-8601 UTC timestamp."""
+def _pb_hex_field(field: int, hex_str: str) -> bytes:
+    """Encode a hex-encoded id (traceId/spanId) as a bytes field; empty if invalid."""
     try:
-        ns = int(value)
-    except (TypeError, ValueError):
-        raise ValueError(f"Invalid Unix nanosecond timestamp: {value!r}")
-    seconds, nanos = divmod(ns, 1_000_000_000)
-    dt = datetime.fromtimestamp(seconds, tz=timezone.utc).replace(microsecond=nanos // 1000)
-    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        raw = bytes.fromhex(hex_str or "")
+    except ValueError:
+        raw = b""
+    if not raw:
+        return b""
+    return _pb_len_field(field, raw)
 
 
-def _phoenix_status_code(status: dict) -> str:
-    """Convert OTLP status code enum values to Phoenix status strings."""
-    if not isinstance(status, dict):
-        return "UNSET"
-    raw_code = status.get("code", 0)
-    if raw_code is None:
-        raw_code = 0
+def _pb_span(span: dict) -> bytes:
+    """Encode an OTLP JSON span as a Span message."""
+    out = _pb_hex_field(1, span.get("traceId", ""))
+    out += _pb_hex_field(2, span.get("spanId", ""))
+    out += _pb_hex_field(4, span.get("parentSpanId", ""))
+    out += _pb_string_field(5, span.get("name", "unknown"))
     try:
-        code = int(raw_code)
+        kind = int(span.get("kind", 0))
     except (TypeError, ValueError):
-        code = 0
-    return {1: "OK", 2: "ERROR"}.get(code, "UNSET")
+        kind = 0
+    if kind:
+        out += _pb_varint_field(6, kind)
+    for field, key in ((7, "startTimeUnixNano"), (8, "endTimeUnixNano")):
+        try:
+            out += _pb_fixed64_field(field, int(span.get(key, "")))
+        except (TypeError, ValueError):
+            raise ValueError(f"Invalid Unix nanosecond timestamp for {key}: {span.get(key)!r}")
+    for attr in span.get("attributes", []) or []:
+        out += _pb_len_field(9, _pb_key_value(attr))
+    for event in span.get("events", []) or []:
+        ev = b""
+        try:
+            ev += _pb_fixed64_field(1, int(event.get("timeUnixNano")))
+        except (TypeError, ValueError):
+            pass
+        ev += _pb_string_field(2, event.get("name", "event"))
+        for attr in event.get("attributes", []) or []:
+            ev += _pb_len_field(3, _pb_key_value(attr))
+        out += _pb_len_field(11, ev)
+    status = span.get("status") or {}
+    if isinstance(status, dict) and status:
+        st = b""
+        if status.get("message"):
+            st += _pb_string_field(2, status["message"])
+        try:
+            code = int(status.get("code", 0) or 0)
+        except (TypeError, ValueError):
+            code = 0
+        if code:
+            st += _pb_varint_field(3, code)
+        out += _pb_len_field(15, st)
+    return out
 
 
-def _phoenix_span_kind(span: dict, attrs: dict) -> str:
-    """Prefer OpenInference span kind attributes, falling back to OTLP kind."""
-    oi_kind = attrs.get("openinference.span.kind")
-    if oi_kind:
-        return str(oi_kind).upper()
-    try:
-        otlp_kind = int(span.get("kind", 0))
-    except (TypeError, ValueError):
-        otlp_kind = 0
-    return {2: "SERVER", 3: "CLIENT", 4: "PRODUCER", 5: "CONSUMER"}.get(otlp_kind, "UNKNOWN")
-
-
-def _otlp_to_phoenix_payload(span_dict: dict) -> dict:
-    """Translate OTLP JSON into Phoenix's native REST create-spans schema."""
-    phoenix_spans = []
+def _otlp_json_to_protobuf(span_dict: dict) -> bytes:
+    """Encode an OTLP JSON payload as an ExportTraceServiceRequest protobuf."""
+    out = b""
     for rs in span_dict.get("resourceSpans", []):
-        resource_attrs = _otlp_attrs_to_dict(rs.get("resource", {}).get("attributes", []))
+        rs_body = b""
+        resource = b"".join(
+            _pb_len_field(1, _pb_key_value(attr)) for attr in rs.get("resource", {}).get("attributes", []) or []
+        )
+        rs_body += _pb_len_field(1, resource)
         for ss in rs.get("scopeSpans", []):
+            ss_body = b""
+            scope = ss.get("scope") or {}
+            scope_msg = _pb_string_field(1, scope.get("name", "")) if scope.get("name") else b""
+            if scope.get("version"):
+                scope_msg += _pb_string_field(2, scope["version"])
+            if scope_msg:
+                ss_body += _pb_len_field(1, scope_msg)
             for span in ss.get("spans", []):
-                attrs = {**resource_attrs, **_otlp_attrs_to_dict(span.get("attributes", []))}
-                item = {
-                    "name": span.get("name", "unknown"),
-                    "context": {
-                        "trace_id": span.get("traceId", ""),
-                        "span_id": span.get("spanId", ""),
-                    },
-                    "span_kind": _phoenix_span_kind(span, attrs),
-                    "start_time": _unix_nano_to_iso(span.get("startTimeUnixNano")),
-                    "end_time": _unix_nano_to_iso(span.get("endTimeUnixNano")),
-                    "status_code": _phoenix_status_code(span.get("status", {})),
-                    "status_message": (span.get("status", {}) or {}).get("message", ""),
-                    "attributes": attrs,
-                }
-                parent_id = span.get("parentSpanId")
-                if parent_id:
-                    item["parent_id"] = parent_id
+                ss_body += _pb_len_field(2, _pb_span(span))
+            rs_body += _pb_len_field(2, ss_body)
+        out += _pb_len_field(1, rs_body)
+    return out
 
-                events = []
-                for event in span.get("events", []) or []:
-                    events.append(
-                        {
-                            "name": event.get("name", "event"),
-                            "timestamp": _unix_nano_to_iso(event.get("timeUnixNano")),
-                            "attributes": _otlp_attrs_to_dict(event.get("attributes", [])),
-                        }
-                    )
-                if events:
-                    item["events"] = events
-                phoenix_spans.append(item)
-    return {"data": phoenix_spans}
+
+def _post_otlp(url: str, body: bytes, headers: dict, label: str) -> bool:
+    """POST an encoded OTLP payload, logging failures. Returns True on 2xx."""
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return 200 <= resp.status < 300
+    except urllib.error.HTTPError as e:
+        try:
+            detail = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            detail = ""
+        error(f"{label} send failed: HTTP {e.code}: {detail or e.reason}")
+        return False
+    except Exception as e:
+        error(f"{label} send failed: {e}")
+        return False
 
 
 def _extract_span_name(span_dict: dict) -> str:
@@ -728,26 +810,14 @@ def send_span(span_dict: dict) -> bool:
             project = backend["project_name"]
             endpoint = backend["endpoint"]
             api_key = backend.get("api_key", "")
-            project_identifier = urllib.parse.quote(project, safe="")
-            url = f"{endpoint.rstrip('/')}/v1/projects/{project_identifier}/spans"
-            body = json.dumps(_otlp_to_phoenix_payload(span_dict)).encode("utf-8")
-            headers = {"Content-Type": "application/json"}
+            url = f"{endpoint.rstrip('/')}/v1/traces"
+            # Phoenix's OTLP HTTP endpoint only accepts binary protobuf.
+            payload = _inject_phoenix_project_name(span_dict, project)
+            body = _otlp_json_to_protobuf(payload)
+            headers = {"Content-Type": "application/x-protobuf"}
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"
-            req = urllib.request.Request(url, data=body, headers=headers, method="POST")
-            try:
-                with urllib.request.urlopen(req, timeout=10) as resp:
-                    return 200 <= resp.status < 300
-            except urllib.error.HTTPError as e:
-                try:
-                    detail = e.read().decode("utf-8", errors="replace")
-                except Exception:
-                    detail = ""
-                error(f"Phoenix send failed: HTTP {e.code}: {detail or e.reason}")
-                return False
-            except Exception as e:
-                error(f"Phoenix send failed: {e}")
-                return False
+            return _post_otlp(url, body, headers, "Phoenix")
         elif target == "arize":
             project = backend["project_name"]
             endpoint = backend.get("endpoint", "otlp.arize.com:443")
@@ -763,26 +833,12 @@ def send_span(span_dict: dict) -> bool:
             else:
                 url = f"https://{endpoint}/v1/traces"
 
-            body = json.dumps(payload).encode("utf-8")
             headers = {
                 "Content-Type": "application/json",
                 "authorization": f"Bearer {api_key}",
                 "space_id": space_id,
             }
-            req = urllib.request.Request(url, data=body, headers=headers, method="POST")
-            try:
-                with urllib.request.urlopen(req, timeout=10) as resp:
-                    return 200 <= resp.status < 300
-            except urllib.error.HTTPError as e:
-                try:
-                    detail = e.read().decode("utf-8", errors="replace")
-                except Exception:
-                    detail = ""
-                error(f"Arize send failed: HTTP {e.code}: {detail or e.reason}")
-                return False
-            except Exception as e:
-                error(f"Arize send failed: {e}")
-                return False
+            return _post_otlp(url, json.dumps(payload).encode("utf-8"), headers, "Arize")
         else:
             error("No backend configured (set PHOENIX_ENDPOINT or ARIZE_API_KEY+ARIZE_SPACE_ID)")
             return False

--- a/core/common.py
+++ b/core/common.py
@@ -8,6 +8,7 @@ build_span/build_multi_span from common.sh lines 277-317 / codex common.sh lines
 """
 
 import atexit
+import copy
 import functools
 import json
 import os
@@ -18,6 +19,8 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import IO, Optional
+
+from core.otlp_proto import otlp_json_to_protobuf
 
 # ---------------------------------------------------------------------------
 # Environment helper — reads tracing-related env vars with defaults
@@ -559,203 +562,31 @@ def resolve_backend(span_dict: dict) -> dict:
     return {"target": "none", "project_name": project_name}
 
 
-def _inject_arize_project_name(span_dict: dict, project_name: str) -> dict:
-    """Return a copy of span_dict with arize.project.name on every span's attributes.
+def _inject_project_attr(span_dict: dict, key: str, project_name: str, per_span: bool = False) -> dict:
+    """Return a copy of span_dict with a project attribute on every resource.
 
-    Arize requires this attribute on each span (not just the resource).
-    Modifies a shallow copy — does not mutate the original.
+    With per_span=True the attribute is also appended to each span's
+    attributes. Modifies a deep copy — does not mutate the original.
     """
-    import copy
-
     payload = copy.deepcopy(span_dict)
-    project_attr = {"key": "arize.project.name", "value": {"stringValue": project_name}}
+    project_attr = {"key": key, "value": _to_otlp_attr_value(project_name)}
     for rs in payload.get("resourceSpans", []):
-        # Also add to resource attributes
         rs.setdefault("resource", {}).setdefault("attributes", []).append(project_attr)
-        for ss in rs.get("scopeSpans", []):
-            for span in ss.get("spans", []):
-                span.setdefault("attributes", []).append(project_attr)
+        if per_span:
+            for ss in rs.get("scopeSpans", []):
+                for span in ss.get("spans", []):
+                    span.setdefault("attributes", []).append(project_attr)
     return payload
+
+
+def _inject_arize_project_name(span_dict: dict, project_name: str) -> dict:
+    """Arize requires arize.project.name on each span, not just the resource."""
+    return _inject_project_attr(span_dict, "arize.project.name", project_name, per_span=True)
 
 
 def _inject_openinference_project_resource_attr(span_dict: dict, project_name: str) -> dict:
-    """Return a copy of span_dict with the openinference.project.name resource attribute.
-
-    Phoenix routes OTLP-ingested spans to a project via this OpenInference
-    resource attribute. Modifies a deep copy — does not mutate the original.
-    """
-    import copy
-
-    payload = copy.deepcopy(span_dict)
-    project_attr = {"key": "openinference.project.name", "value": {"stringValue": project_name}}
-    for rs in payload.get("resourceSpans", []):
-        rs.setdefault("resource", {}).setdefault("attributes", []).append(project_attr)
-    return payload
-
-
-# --- OTLP protobuf wire-format encoding ------------------------------------
-# Phoenix's OTLP HTTP endpoint (/v1/traces) only accepts binary protobuf, and
-# hooks must run on the stdlib alone (no protobuf/OTel SDK dependency), so the
-# OTLP JSON dicts built by build_span() are encoded to the protobuf wire format
-# by hand. Field numbers follow the stable OTLP v1 trace schema
-# (opentelemetry/proto/trace/v1/trace.proto).
-
-
-def _pb_varint(n: int) -> bytes:
-    """Encode an unsigned varint."""
-    out = bytearray()
-    while True:
-        bits = n & 0x7F
-        n >>= 7
-        if n:
-            out.append(bits | 0x80)
-        else:
-            out.append(bits)
-            return bytes(out)
-
-
-def _pb_varint_field(field: int, n: int) -> bytes:
-    return _pb_varint(field << 3) + _pb_varint(n & 0xFFFFFFFFFFFFFFFF)
-
-
-def _pb_fixed64_field(field: int, n: int) -> bytes:
-    import struct
-
-    return _pb_varint(field << 3 | 1) + struct.pack("<Q", n & 0xFFFFFFFFFFFFFFFF)
-
-
-def _pb_double_field(field: int, value: float) -> bytes:
-    import struct
-
-    return _pb_varint(field << 3 | 1) + struct.pack("<d", float(value))
-
-
-def _pb_len_field(field: int, payload: bytes) -> bytes:
-    return _pb_varint(field << 3 | 2) + _pb_varint(len(payload)) + payload
-
-
-def _pb_string_field(field: int, value: str) -> bytes:
-    return _pb_len_field(field, str(value).encode("utf-8"))
-
-
-def _pb_any_value(value: dict) -> bytes:
-    """Encode an OTLP JSON AnyValue object as an AnyValue message."""
-    if not isinstance(value, dict):
-        return _pb_string_field(1, str(value))
-    if "stringValue" in value:
-        return _pb_string_field(1, value["stringValue"])
-    if "boolValue" in value:
-        return _pb_varint_field(2, 1 if value["boolValue"] else 0)
-    if "intValue" in value:
-        try:
-            return _pb_varint_field(3, int(value["intValue"]))
-        except (TypeError, ValueError):
-            return _pb_string_field(1, str(value["intValue"]))
-    if "doubleValue" in value:
-        return _pb_double_field(4, value["doubleValue"])
-    if "arrayValue" in value:
-        values = value.get("arrayValue", {}).get("values", [])
-        body = b"".join(_pb_len_field(1, _pb_any_value(v)) for v in values)
-        return _pb_len_field(5, body)
-    if "kvlistValue" in value:
-        values = value.get("kvlistValue", {}).get("values", [])
-        body = b"".join(_pb_len_field(1, _pb_key_value(kv)) for kv in values)
-        return _pb_len_field(6, body)
-    if "bytesValue" in value:
-        import base64
-
-        try:
-            raw = base64.b64decode(value["bytesValue"])
-        except Exception:
-            raw = str(value["bytesValue"]).encode("utf-8")
-        return _pb_len_field(7, raw)
-    return b""
-
-
-def _pb_key_value(attr: dict) -> bytes:
-    """Encode an OTLP JSON attribute {key, value} as a KeyValue message."""
-    out = _pb_string_field(1, attr.get("key", ""))
-    out += _pb_len_field(2, _pb_any_value(attr.get("value", {})))
-    return out
-
-
-def _pb_hex_field(field: int, hex_str: str) -> bytes:
-    """Encode a hex-encoded id (traceId/spanId) as a bytes field; empty if invalid."""
-    try:
-        raw = bytes.fromhex(hex_str or "")
-    except ValueError:
-        raw = b""
-    if not raw:
-        return b""
-    return _pb_len_field(field, raw)
-
-
-def _pb_span(span: dict) -> bytes:
-    """Encode an OTLP JSON span as a Span message."""
-    out = _pb_hex_field(1, span.get("traceId", ""))
-    out += _pb_hex_field(2, span.get("spanId", ""))
-    out += _pb_hex_field(4, span.get("parentSpanId", ""))
-    out += _pb_string_field(5, span.get("name", "unknown"))
-    try:
-        kind = int(span.get("kind", 0))
-    except (TypeError, ValueError):
-        kind = 0
-    if kind:
-        out += _pb_varint_field(6, kind)
-    for field, key in ((7, "startTimeUnixNano"), (8, "endTimeUnixNano")):
-        try:
-            out += _pb_fixed64_field(field, int(span.get(key, "")))
-        except (TypeError, ValueError):
-            raise ValueError(f"Invalid Unix nanosecond timestamp for {key}: {span.get(key)!r}")
-    for attr in span.get("attributes", []) or []:
-        out += _pb_len_field(9, _pb_key_value(attr))
-    for event in span.get("events", []) or []:
-        ev = b""
-        try:
-            ev += _pb_fixed64_field(1, int(event.get("timeUnixNano")))
-        except (TypeError, ValueError):
-            pass
-        ev += _pb_string_field(2, event.get("name", "event"))
-        for attr in event.get("attributes", []) or []:
-            ev += _pb_len_field(3, _pb_key_value(attr))
-        out += _pb_len_field(11, ev)
-    status = span.get("status") or {}
-    if isinstance(status, dict) and status:
-        st = b""
-        if status.get("message"):
-            st += _pb_string_field(2, status["message"])
-        try:
-            code = int(status.get("code", 0) or 0)
-        except (TypeError, ValueError):
-            code = 0
-        if code:
-            st += _pb_varint_field(3, code)
-        out += _pb_len_field(15, st)
-    return out
-
-
-def _otlp_json_to_protobuf(span_dict: dict) -> bytes:
-    """Encode an OTLP JSON payload as an ExportTraceServiceRequest protobuf."""
-    out = b""
-    for rs in span_dict.get("resourceSpans", []):
-        rs_body = b""
-        resource = b"".join(
-            _pb_len_field(1, _pb_key_value(attr)) for attr in rs.get("resource", {}).get("attributes", []) or []
-        )
-        rs_body += _pb_len_field(1, resource)
-        for ss in rs.get("scopeSpans", []):
-            ss_body = b""
-            scope = ss.get("scope") or {}
-            scope_msg = _pb_string_field(1, scope.get("name", "")) if scope.get("name") else b""
-            if scope.get("version"):
-                scope_msg += _pb_string_field(2, scope["version"])
-            if scope_msg:
-                ss_body += _pb_len_field(1, scope_msg)
-            for span in ss.get("spans", []):
-                ss_body += _pb_len_field(2, _pb_span(span))
-            rs_body += _pb_len_field(2, ss_body)
-        out += _pb_len_field(1, rs_body)
-    return out
+    """Phoenix routes OTLP-ingested spans to a project via this resource attribute."""
+    return _inject_project_attr(span_dict, "openinference.project.name", project_name)
 
 
 def _post_otlp(url: str, body: bytes, headers: dict, label: str) -> bool:
@@ -813,7 +644,7 @@ def send_span(span_dict: dict) -> bool:
             url = f"{endpoint.rstrip('/')}/v1/traces"
             # Phoenix's OTLP HTTP endpoint only accepts binary protobuf.
             payload = _inject_openinference_project_resource_attr(span_dict, project)
-            body = _otlp_json_to_protobuf(payload)
+            body = otlp_json_to_protobuf(payload)
             headers = {"Content-Type": "application/x-protobuf"}
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"

--- a/core/otlp_proto.py
+++ b/core/otlp_proto.py
@@ -1,0 +1,158 @@
+"""Stdlib-only OTLP protobuf wire-format encoding.
+
+Phoenix's OTLP HTTP endpoint (/v1/traces) only accepts binary protobuf, and
+hooks must run on the stdlib alone (no protobuf/OTel SDK dependency), so the
+OTLP JSON dicts built by build_span() are encoded to the protobuf wire format
+by hand. Field numbers follow the stable OTLP v1 trace schema
+(opentelemetry/proto/trace/v1/trace.proto).
+"""
+
+import base64
+import struct
+
+
+def _pb_varint(n: int) -> bytes:
+    """Encode an unsigned varint."""
+    out = bytearray()
+    while True:
+        bits = n & 0x7F
+        n >>= 7
+        if n:
+            out.append(bits | 0x80)
+        else:
+            out.append(bits)
+            return bytes(out)
+
+
+def _pb_varint_field(field: int, n: int) -> bytes:
+    return _pb_varint(field << 3) + _pb_varint(n & 0xFFFFFFFFFFFFFFFF)
+
+
+def _pb_fixed64_field(field: int, n: int) -> bytes:
+    return _pb_varint(field << 3 | 1) + struct.pack("<Q", n & 0xFFFFFFFFFFFFFFFF)
+
+
+def _pb_double_field(field: int, value: float) -> bytes:
+    return _pb_varint(field << 3 | 1) + struct.pack("<d", float(value))
+
+
+def _pb_len_field(field: int, payload: bytes) -> bytes:
+    return _pb_varint(field << 3 | 2) + _pb_varint(len(payload)) + payload
+
+
+def _pb_string_field(field: int, value: str) -> bytes:
+    return _pb_len_field(field, str(value).encode("utf-8"))
+
+
+def _pb_any_value(value: dict) -> bytes:
+    """Encode an OTLP JSON AnyValue object; unknown/malformed values encode empty."""
+    if not isinstance(value, dict):
+        return b""
+    if "stringValue" in value:
+        return _pb_string_field(1, value["stringValue"])
+    if "boolValue" in value:
+        return _pb_varint_field(2, 1 if value["boolValue"] else 0)
+    if "intValue" in value:
+        try:
+            return _pb_varint_field(3, int(value["intValue"]))
+        except (TypeError, ValueError):
+            return b""
+    if "doubleValue" in value:
+        return _pb_double_field(4, value["doubleValue"])
+    if "arrayValue" in value:
+        values = value.get("arrayValue", {}).get("values", [])
+        return _pb_len_field(5, b"".join(_pb_len_field(1, _pb_any_value(v)) for v in values))
+    if "kvlistValue" in value:
+        values = value.get("kvlistValue", {}).get("values", [])
+        return _pb_len_field(6, _pb_key_values(1, values))
+    if "bytesValue" in value:
+        try:
+            return _pb_len_field(7, base64.b64decode(value["bytesValue"]))
+        except Exception:
+            return b""
+    return b""
+
+
+def _pb_key_value(attr: dict) -> bytes:
+    """Encode an OTLP JSON attribute {key, value} as a KeyValue message."""
+    out = _pb_string_field(1, attr.get("key", ""))
+    out += _pb_len_field(2, _pb_any_value(attr.get("value", {})))
+    return out
+
+
+def _pb_key_values(field: int, attrs: list) -> bytes:
+    """Encode a repeated-KeyValue list under the given field number."""
+    return b"".join(_pb_len_field(field, _pb_key_value(attr)) for attr in attrs or [])
+
+
+def _pb_hex_field(field: int, hex_str: str) -> bytes:
+    """Encode a hex-encoded id (traceId/spanId) as a bytes field; empty if invalid."""
+    try:
+        raw = bytes.fromhex(hex_str or "")
+    except ValueError:
+        raw = b""
+    if not raw:
+        return b""
+    return _pb_len_field(field, raw)
+
+
+def _pb_span(span: dict) -> bytes:
+    """Encode an OTLP JSON span as a Span message."""
+    out = _pb_hex_field(1, span.get("traceId", ""))
+    out += _pb_hex_field(2, span.get("spanId", ""))
+    out += _pb_hex_field(4, span.get("parentSpanId", ""))
+    out += _pb_string_field(5, span.get("name", "unknown"))
+    try:
+        kind = int(span.get("kind", 0))
+    except (TypeError, ValueError):
+        kind = 0
+    if kind:
+        out += _pb_varint_field(6, kind)
+    for field, key in ((7, "startTimeUnixNano"), (8, "endTimeUnixNano")):
+        try:
+            out += _pb_fixed64_field(field, int(span.get(key, "")))
+        except (TypeError, ValueError):
+            raise ValueError(f"Invalid Unix nanosecond timestamp for {key}: {span.get(key)!r}")
+    out += _pb_key_values(9, span.get("attributes", []))
+    for event in span.get("events", []) or []:
+        ev = b""
+        try:
+            ev += _pb_fixed64_field(1, int(event.get("timeUnixNano", "")))
+        except (TypeError, ValueError):
+            pass
+        ev += _pb_string_field(2, event.get("name", "event"))
+        ev += _pb_key_values(3, event.get("attributes", []))
+        out += _pb_len_field(11, ev)
+    status = span.get("status") or {}
+    if status:
+        st = b""
+        if status.get("message"):
+            st += _pb_string_field(2, status["message"])
+        try:
+            code = int(status.get("code", 0) or 0)
+        except (TypeError, ValueError):
+            code = 0
+        if code:
+            st += _pb_varint_field(3, code)
+        out += _pb_len_field(15, st)
+    return out
+
+
+def otlp_json_to_protobuf(span_dict: dict) -> bytes:
+    """Encode an OTLP JSON payload as an ExportTraceServiceRequest protobuf."""
+    out = b""
+    for rs in span_dict.get("resourceSpans", []):
+        rs_body = _pb_len_field(1, _pb_key_values(1, rs.get("resource", {}).get("attributes", [])))
+        for ss in rs.get("scopeSpans", []):
+            scope = ss.get("scope") or {}
+            scope_msg = b""
+            if scope.get("name"):
+                scope_msg += _pb_string_field(1, scope["name"])
+            if scope.get("version"):
+                scope_msg += _pb_string_field(2, scope["version"])
+            ss_body = _pb_len_field(1, scope_msg) if scope_msg else b""
+            for span in ss.get("spans", []):
+                ss_body += _pb_len_field(2, _pb_span(span))
+            rs_body += _pb_len_field(2, ss_body)
+        out += _pb_len_field(1, rs_body)
+    return out

--- a/core/otlp_proto.py
+++ b/core/otlp_proto.py
@@ -5,10 +5,27 @@ hooks must run on the stdlib alone (no protobuf/OTel SDK dependency), so the
 OTLP JSON dicts built by build_span() are encoded to the protobuf wire format
 by hand. Field numbers follow the stable OTLP v1 trace schema
 (opentelemetry/proto/trace/v1/trace.proto).
+
+The module is layered bottom-up:
+
+1. Wire-format primitives — one encoder per protobuf wire type.
+2. OTLP value encoders — OTLP JSON leaf values (AnyValue, KeyValue,
+   hex-encoded ids, Unix-nanosecond timestamps).
+3. Trace message encoders — Span and Span.Link messages.
+4. Public API — otlp_json_to_protobuf(), the only intended entry point.
+
+Malformed *optional* values encode to nothing (fail-soft: a bad attribute
+should not drop the span), while malformed *required* values (ids,
+timestamps) raise ValueError so send_span() cannot report success for a span
+the backend would orphan or reject.
 """
 
 import base64
 import struct
+
+# ---------------------------------------------------------------------------
+# Wire-format primitives — one encoder per protobuf wire type
+# ---------------------------------------------------------------------------
 
 
 def _pb_varint(n: int) -> bytes:
@@ -52,6 +69,12 @@ def _pb_len_field(field: int, payload: bytes) -> bytes:
 def _pb_string_field(field: int, value: str) -> bytes:
     """Encode a UTF-8 string as a length-delimited field."""
     return _pb_len_field(field, str(value).encode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# OTLP value encoders — OTLP JSON leaf values (fail-soft on optional fields,
+# ValueError on required ids/timestamps)
+# ---------------------------------------------------------------------------
 
 
 def _pb_uint_field(field: int, value) -> bytes:
@@ -137,6 +160,11 @@ def _pb_time_field(field: int, value, label: str) -> bytes:
         raise ValueError(f"Invalid Unix nanosecond timestamp for {label}: {value!r}")
 
 
+# ---------------------------------------------------------------------------
+# Trace message encoders — Span and Span.Link
+# ---------------------------------------------------------------------------
+
+
 def _pb_link(link: dict) -> bytes:
     """Encode an OTLP JSON span link as a Span.Link message."""
     out = _pb_hex_field(1, link.get("traceId", ""), "link traceId", required=True)
@@ -151,7 +179,12 @@ def _pb_link(link: dict) -> bytes:
 
 
 def _pb_span(span: dict) -> bytes:
-    """Encode an OTLP JSON span as a Span message."""
+    """Encode an OTLP JSON span as a Span message.
+
+    Events and Status are encoded inline (they have no other callers); links
+    delegate to _pb_link. Raises ValueError via _pb_hex_field/_pb_time_field
+    on missing or malformed ids and timestamps.
+    """
     out = _pb_hex_field(1, span.get("traceId", ""), "traceId", required=True)
     out += _pb_hex_field(2, span.get("spanId", ""), "spanId", required=True)
     if span.get("traceState"):
@@ -195,8 +228,19 @@ def _pb_span(span: dict) -> bytes:
     return out
 
 
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
 def otlp_json_to_protobuf(span_dict: dict) -> bytes:
-    """Encode an OTLP JSON payload as an ExportTraceServiceRequest protobuf."""
+    """Encode an OTLP JSON payload as an ExportTraceServiceRequest protobuf.
+
+    Walks the resourceSpans → scopeSpans → spans hierarchy, encoding
+    Resource and InstrumentationScope messages inline. Raises ValueError on
+    spans with missing/malformed ids or timestamps (see _pb_hex_field and
+    _pb_time_field); everything else encodes fail-soft.
+    """
     out = b""
     for rs in span_dict.get("resourceSpans", []):
         resource = rs.get("resource", {})

--- a/core/otlp_proto.py
+++ b/core/otlp_proto.py
@@ -32,6 +32,10 @@ def _pb_fixed64_field(field: int, n: int) -> bytes:
     return _pb_varint(field << 3 | 1) + struct.pack("<Q", n & 0xFFFFFFFFFFFFFFFF)
 
 
+def _pb_fixed32_field(field: int, n: int) -> bytes:
+    return _pb_varint(field << 3 | 5) + struct.pack("<I", n & 0xFFFFFFFF)
+
+
 def _pb_double_field(field: int, value: float) -> bytes:
     return _pb_varint(field << 3 | 1) + struct.pack("<d", float(value))
 
@@ -42,6 +46,15 @@ def _pb_len_field(field: int, payload: bytes) -> bytes:
 
 def _pb_string_field(field: int, value: str) -> bytes:
     return _pb_len_field(field, str(value).encode("utf-8"))
+
+
+def _pb_uint_field(field: int, value) -> bytes:
+    """Encode an optional non-negative int field; zero/missing/malformed encode nothing."""
+    try:
+        n = int(value or 0)
+    except (TypeError, ValueError):
+        n = 0
+    return _pb_varint_field(field, n) if n else b""
 
 
 def _pb_any_value(value: dict) -> bytes:
@@ -58,7 +71,10 @@ def _pb_any_value(value: dict) -> bytes:
         except (TypeError, ValueError):
             return b""
     if "doubleValue" in value:
-        return _pb_double_field(4, value["doubleValue"])
+        try:
+            return _pb_double_field(4, value["doubleValue"])
+        except (TypeError, ValueError):
+            return b""
     if "arrayValue" in value:
         values = value.get("arrayValue", {}).get("values", [])
         return _pb_len_field(5, b"".join(_pb_len_field(1, _pb_any_value(v)) for v in values))
@@ -85,22 +101,51 @@ def _pb_key_values(field: int, attrs: list) -> bytes:
     return b"".join(_pb_len_field(field, _pb_key_value(attr)) for attr in attrs or [])
 
 
-def _pb_hex_field(field: int, hex_str: str) -> bytes:
-    """Encode a hex-encoded id (traceId/spanId) as a bytes field; empty if invalid."""
+def _pb_hex_field(field: int, hex_str, label: str, required: bool = False) -> bytes:
+    """Encode a hex-encoded id (traceId/spanId) as a bytes field.
+
+    Raises ValueError on a non-string or non-hex id, and on a missing/empty id
+    when required — a silently omitted id would orphan the span (all-zero
+    trace) or promote it to a trace root while send_span reports success.
+    """
     try:
         raw = bytes.fromhex(hex_str or "")
-    except ValueError:
-        raw = b""
+    except (TypeError, ValueError):
+        raise ValueError(f"Invalid hex {label}: {hex_str!r}")
     if not raw:
+        if required:
+            raise ValueError(f"Missing {label}")
         return b""
     return _pb_len_field(field, raw)
 
 
+def _pb_time_field(field: int, value, label: str) -> bytes:
+    try:
+        return _pb_fixed64_field(field, int(value if value is not None else ""))
+    except (TypeError, ValueError):
+        raise ValueError(f"Invalid Unix nanosecond timestamp for {label}: {value!r}")
+
+
+def _pb_link(link: dict) -> bytes:
+    """Encode an OTLP JSON span link as a Span.Link message."""
+    out = _pb_hex_field(1, link.get("traceId", ""), "link traceId", required=True)
+    out += _pb_hex_field(2, link.get("spanId", ""), "link spanId", required=True)
+    if link.get("traceState"):
+        out += _pb_string_field(3, link["traceState"])
+    out += _pb_key_values(4, link.get("attributes", []))
+    out += _pb_uint_field(5, link.get("droppedAttributesCount"))
+    if link.get("flags"):
+        out += _pb_fixed32_field(6, int(link["flags"]))
+    return out
+
+
 def _pb_span(span: dict) -> bytes:
     """Encode an OTLP JSON span as a Span message."""
-    out = _pb_hex_field(1, span.get("traceId", ""))
-    out += _pb_hex_field(2, span.get("spanId", ""))
-    out += _pb_hex_field(4, span.get("parentSpanId", ""))
+    out = _pb_hex_field(1, span.get("traceId", ""), "traceId", required=True)
+    out += _pb_hex_field(2, span.get("spanId", ""), "spanId", required=True)
+    if span.get("traceState"):
+        out += _pb_string_field(3, span["traceState"])
+    out += _pb_hex_field(4, span.get("parentSpanId", ""), "parentSpanId")
     out += _pb_string_field(5, span.get("name", "unknown"))
     try:
         kind = int(span.get("kind", 0))
@@ -108,21 +153,20 @@ def _pb_span(span: dict) -> bytes:
         kind = 0
     if kind:
         out += _pb_varint_field(6, kind)
-    for field, key in ((7, "startTimeUnixNano"), (8, "endTimeUnixNano")):
-        try:
-            out += _pb_fixed64_field(field, int(span.get(key, "")))
-        except (TypeError, ValueError):
-            raise ValueError(f"Invalid Unix nanosecond timestamp for {key}: {span.get(key)!r}")
+    out += _pb_time_field(7, span.get("startTimeUnixNano"), "startTimeUnixNano")
+    out += _pb_time_field(8, span.get("endTimeUnixNano"), "endTimeUnixNano")
     out += _pb_key_values(9, span.get("attributes", []))
+    out += _pb_uint_field(10, span.get("droppedAttributesCount"))
     for event in span.get("events", []) or []:
-        ev = b""
-        try:
-            ev += _pb_fixed64_field(1, int(event.get("timeUnixNano", "")))
-        except (TypeError, ValueError):
-            pass
+        ev = _pb_time_field(1, event.get("timeUnixNano"), "event timeUnixNano")
         ev += _pb_string_field(2, event.get("name", "event"))
         ev += _pb_key_values(3, event.get("attributes", []))
+        ev += _pb_uint_field(4, event.get("droppedAttributesCount"))
         out += _pb_len_field(11, ev)
+    out += _pb_uint_field(12, span.get("droppedEventsCount"))
+    for link in span.get("links", []) or []:
+        out += _pb_len_field(13, _pb_link(link))
+    out += _pb_uint_field(14, span.get("droppedLinksCount"))
     status = span.get("status") or {}
     if status:
         st = b""
@@ -135,6 +179,8 @@ def _pb_span(span: dict) -> bytes:
         if code:
             st += _pb_varint_field(3, code)
         out += _pb_len_field(15, st)
+    if span.get("flags"):
+        out += _pb_fixed32_field(16, int(span["flags"]))
     return out
 
 
@@ -142,7 +188,10 @@ def otlp_json_to_protobuf(span_dict: dict) -> bytes:
     """Encode an OTLP JSON payload as an ExportTraceServiceRequest protobuf."""
     out = b""
     for rs in span_dict.get("resourceSpans", []):
-        rs_body = _pb_len_field(1, _pb_key_values(1, rs.get("resource", {}).get("attributes", [])))
+        resource = rs.get("resource", {})
+        resource_msg = _pb_key_values(1, resource.get("attributes", []))
+        resource_msg += _pb_uint_field(2, resource.get("droppedAttributesCount"))
+        rs_body = _pb_len_field(1, resource_msg)
         for ss in rs.get("scopeSpans", []):
             scope = ss.get("scope") or {}
             scope_msg = b""
@@ -150,9 +199,15 @@ def otlp_json_to_protobuf(span_dict: dict) -> bytes:
                 scope_msg += _pb_string_field(1, scope["name"])
             if scope.get("version"):
                 scope_msg += _pb_string_field(2, scope["version"])
+            scope_msg += _pb_key_values(3, scope.get("attributes", []))
+            scope_msg += _pb_uint_field(4, scope.get("droppedAttributesCount"))
             ss_body = _pb_len_field(1, scope_msg) if scope_msg else b""
             for span in ss.get("spans", []):
                 ss_body += _pb_len_field(2, _pb_span(span))
+            if ss.get("schemaUrl"):
+                ss_body += _pb_string_field(3, ss["schemaUrl"])
             rs_body += _pb_len_field(2, ss_body)
+        if rs.get("schemaUrl"):
+            rs_body += _pb_string_field(3, rs["schemaUrl"])
         out += _pb_len_field(1, rs_body)
     return out

--- a/core/otlp_proto.py
+++ b/core/otlp_proto.py
@@ -4,7 +4,8 @@ Phoenix's OTLP HTTP endpoint (/v1/traces) only accepts binary protobuf, and
 hooks must run on the stdlib alone (no protobuf/OTel SDK dependency), so the
 OTLP JSON dicts built by build_span() are encoded to the protobuf wire format
 by hand. Field numbers follow the stable OTLP v1 trace schema
-(opentelemetry/proto/trace/v1/trace.proto).
+(opentelemetry/proto/trace/v1/trace.proto):
+https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto
 
 The module is layered bottom-up:
 

--- a/core/otlp_proto.py
+++ b/core/otlp_proto.py
@@ -25,26 +25,32 @@ def _pb_varint(n: int) -> bytes:
 
 
 def _pb_varint_field(field: int, n: int) -> bytes:
+    """Encode a varint field (wire type 0), masking the value to 64 bits."""
     return _pb_varint(field << 3) + _pb_varint(n & 0xFFFFFFFFFFFFFFFF)
 
 
 def _pb_fixed64_field(field: int, n: int) -> bytes:
+    """Encode a little-endian fixed64 field (wire type 1)."""
     return _pb_varint(field << 3 | 1) + struct.pack("<Q", n & 0xFFFFFFFFFFFFFFFF)
 
 
 def _pb_fixed32_field(field: int, n: int) -> bytes:
+    """Encode a little-endian fixed32 field (wire type 5)."""
     return _pb_varint(field << 3 | 5) + struct.pack("<I", n & 0xFFFFFFFF)
 
 
 def _pb_double_field(field: int, value: float) -> bytes:
+    """Encode an IEEE-754 double field (wire type 1)."""
     return _pb_varint(field << 3 | 1) + struct.pack("<d", float(value))
 
 
 def _pb_len_field(field: int, payload: bytes) -> bytes:
+    """Encode a length-delimited field (wire type 2): tag, length, payload."""
     return _pb_varint(field << 3 | 2) + _pb_varint(len(payload)) + payload
 
 
 def _pb_string_field(field: int, value: str) -> bytes:
+    """Encode a UTF-8 string as a length-delimited field."""
     return _pb_len_field(field, str(value).encode("utf-8"))
 
 
@@ -120,6 +126,11 @@ def _pb_hex_field(field: int, hex_str, label: str, required: bool = False) -> by
 
 
 def _pb_time_field(field: int, value, label: str) -> bytes:
+    """Encode a Unix-nanosecond timestamp as a fixed64 field.
+
+    Raises ValueError on a missing or non-integer timestamp — OTLP requires
+    both span timestamps, and a silently defaulted one would corrupt durations.
+    """
     try:
         return _pb_fixed64_field(field, int(value if value is not None else ""))
     except (TypeError, ValueError):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,7 +122,12 @@ class _CollectorHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         length = int(self.headers.get("Content-Length", 0))
         body = self.rfile.read(length)
-        self.server._received.append(json.loads(body))
+        if self.headers.get("Content-Type", "").startswith("application/json"):
+            # Arize path: OTLP/JSON
+            self.server._received.append(json.loads(body))
+        else:
+            # Phoenix path: OTLP binary protobuf — record raw bytes
+            self.server._received.append(body)
         self.send_response(200)
         self.end_headers()
 
@@ -143,7 +148,8 @@ class _CollectorHandler(BaseHTTPRequestHandler):
 def mock_collector():
     """Start a real HTTP server on a random port.
 
-    Accepts POST /v1/spans (records body) and GET /health (returns 200).
+    Accepts POST /v1/traces (records the body: parsed JSON for
+    application/json, raw bytes for protobuf) and GET /health (returns 200).
     Yields dict: {"url": "http://127.0.0.1:{port}", "received": [...], "port": int}
     Server is torn down after the test.
     """

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -14,7 +14,7 @@ from core.common import (
     FileLock,
     StateManager,
     _attrs_to_otlp,
-    _inject_phoenix_project_name,
+    _inject_openinference_project_resource_attr,
     _otlp_json_to_protobuf,
     _resolve_kind,
     _to_otlp_attr_value,
@@ -1045,7 +1045,7 @@ class TestPhoenixProjectNameInjection:
             ]
         }
 
-        result = _inject_phoenix_project_name(payload, "my-project")
+        result = _inject_openinference_project_resource_attr(payload, "my-project")
 
         resource_attrs = result["resourceSpans"][0]["resource"]["attributes"]
         assert {"key": "openinference.project.name", "value": {"stringValue": "my-project"}} in resource_attrs
@@ -1055,7 +1055,7 @@ class TestPhoenixProjectNameInjection:
     def test_creates_resource_when_missing(self):
         payload = {"resourceSpans": [{"scopeSpans": [{"spans": [{"name": "s"}]}]}]}
 
-        result = _inject_phoenix_project_name(payload, "proj")
+        result = _inject_openinference_project_resource_attr(payload, "proj")
 
         assert result["resourceSpans"][0]["resource"]["attributes"] == [
             {"key": "openinference.project.name", "value": {"stringValue": "proj"}}
@@ -1248,7 +1248,7 @@ class TestSendSpan:
         assert req.method == "POST"
         # Body is the OTLP payload with openinference.project.name appended to
         # the resource attributes for project routing, encoded as protobuf.
-        expected_payload = _inject_phoenix_project_name(self._SAMPLE_SPAN, "my-project")
+        expected_payload = _inject_openinference_project_resource_attr(self._SAMPLE_SPAN, "my-project")
         assert req.data == _otlp_json_to_protobuf(expected_payload)
         # Sanity-check the encoded resource attributes include the project name.
         rs = _pb_decode(_pb_decode(req.data)[1][0])

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -15,7 +15,6 @@ from core.common import (
     StateManager,
     _attrs_to_otlp,
     _inject_openinference_project_resource_attr,
-    _otlp_json_to_protobuf,
     _resolve_kind,
     _to_otlp_attr_value,
     build_multi_span,
@@ -30,6 +29,7 @@ from core.common import (
     restore_stderr_from_log_file,
     send_span,
 )
+from core.otlp_proto import otlp_json_to_protobuf
 
 # ── Logging tests ──────────────────────────────────────────────────────────
 
@@ -880,157 +880,6 @@ class TestBuildMultiSpan:
         assert scope["name"] == "override-scope"
 
 
-# ── Minimal protobuf wire-format decoder (test helper) ────────────────────
-
-
-def _pb_read_varint(data, i):
-    result = shift = 0
-    while True:
-        byte = data[i]
-        result |= (byte & 0x7F) << shift
-        i += 1
-        if not byte & 0x80:
-            return result, i
-        shift += 7
-
-
-def _pb_decode(data):
-    """Decode a protobuf message into {field: [values]} (varint ints, raw bytes otherwise)."""
-    fields = {}
-    i = 0
-    while i < len(data):
-        tag, i = _pb_read_varint(data, i)
-        field, wire_type = tag >> 3, tag & 7
-        if wire_type == 0:
-            value, i = _pb_read_varint(data, i)
-        elif wire_type == 1:
-            value = data[i : i + 8]
-            i += 8
-        elif wire_type == 2:
-            length, i = _pb_read_varint(data, i)
-            value = data[i : i + length]
-            i += length
-        else:
-            raise ValueError(f"unsupported wire type {wire_type}")
-        fields.setdefault(field, []).append(value)
-    return fields
-
-
-def _pb_fixed64_int(raw):
-    import struct
-
-    return struct.unpack("<Q", raw)[0]
-
-
-# ── OTLP protobuf encoding tests ──────────────────────────────────────────
-
-
-class TestOtlpProtobufEncoding:
-    def test_encodes_span_fields(self):
-        payload = {
-            "resourceSpans": [
-                {
-                    "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": "svc"}}]},
-                    "scopeSpans": [
-                        {
-                            "scope": {"name": "scope"},
-                            "spans": [
-                                {
-                                    "traceId": "0123456789abcdef0123456789abcdef",
-                                    "spanId": "abcdef1234567890",
-                                    "parentSpanId": "1122334455667788",
-                                    "name": "tool-call",
-                                    "kind": 1,
-                                    "startTimeUnixNano": "1000000000",
-                                    "endTimeUnixNano": "1500000000",
-                                    "attributes": [
-                                        {"key": "openinference.span.kind", "value": {"stringValue": "TOOL"}},
-                                        {"key": "count", "value": {"intValue": "3"}},
-                                        {"key": "ok", "value": {"boolValue": True}},
-                                        {"key": "score", "value": {"doubleValue": 0.5}},
-                                    ],
-                                    "events": [
-                                        {
-                                            "name": "exception",
-                                            "timeUnixNano": "1250000000",
-                                            "attributes": [{"key": "message", "value": {"stringValue": "boom"}}],
-                                        }
-                                    ],
-                                    "status": {"code": 2, "message": "failed"},
-                                }
-                            ],
-                        }
-                    ],
-                }
-            ]
-        }
-
-        encoded = _otlp_json_to_protobuf(payload)
-
-        # ExportTraceServiceRequest.resource_spans[0]
-        rs = _pb_decode(_pb_decode(encoded)[1][0])
-        # Resource.attributes[0] is service.name
-        resource_attr = _pb_decode(_pb_decode(rs[1][0])[1][0])
-        assert resource_attr[1][0] == b"service.name"
-        assert _pb_decode(resource_attr[2][0])[1][0] == b"svc"
-
-        ss = _pb_decode(rs[2][0])
-        assert _pb_decode(ss[1][0])[1][0] == b"scope"
-
-        span = _pb_decode(ss[2][0])
-        assert span[1][0] == bytes.fromhex("0123456789abcdef0123456789abcdef")
-        assert span[2][0] == bytes.fromhex("abcdef1234567890")
-        assert span[4][0] == bytes.fromhex("1122334455667788")
-        assert span[5][0] == b"tool-call"
-        assert span[6][0] == 1
-        assert _pb_fixed64_int(span[7][0]) == 1_000_000_000
-        assert _pb_fixed64_int(span[8][0]) == 1_500_000_000
-
-        attrs = {}
-        for raw in span[9]:
-            kv = _pb_decode(raw)
-            attrs[kv[1][0]] = _pb_decode(kv[2][0])
-        assert attrs[b"openinference.span.kind"][1][0] == b"TOOL"
-        assert attrs[b"count"][3][0] == 3
-        assert attrs[b"ok"][2][0] == 1
-        import struct
-
-        assert struct.unpack("<d", attrs[b"score"][4][0])[0] == 0.5
-
-        event = _pb_decode(span[11][0])
-        assert _pb_fixed64_int(event[1][0]) == 1_250_000_000
-        assert event[2][0] == b"exception"
-        event_attr = _pb_decode(event[3][0])
-        assert event_attr[1][0] == b"message"
-
-        status = _pb_decode(span[15][0])
-        assert status[2][0] == b"failed"
-        assert status[3][0] == 2
-
-    def test_rejects_missing_span_timestamp(self):
-        payload = {
-            "resourceSpans": [
-                {
-                    "scopeSpans": [
-                        {
-                            "spans": [
-                                {
-                                    "traceId": "t" * 32,
-                                    "spanId": "s" * 16,
-                                    "name": "missing-time",
-                                    "endTimeUnixNano": "2000000000",
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        }
-
-        with pytest.raises(ValueError, match="Invalid Unix nanosecond timestamp"):
-            _otlp_json_to_protobuf(payload)
-
-
 # ── Phoenix project-name injection tests ──────────────────────────────────
 
 
@@ -1248,16 +1097,9 @@ class TestSendSpan:
         assert req.method == "POST"
         # Body is the OTLP payload with openinference.project.name appended to
         # the resource attributes for project routing, encoded as protobuf.
+        # (Encoding correctness itself is covered in test_otlp_proto.py.)
         expected_payload = _inject_openinference_project_resource_attr(self._SAMPLE_SPAN, "my-project")
-        assert req.data == _otlp_json_to_protobuf(expected_payload)
-        # Sanity-check the encoded resource attributes include the project name.
-        rs = _pb_decode(_pb_decode(req.data)[1][0])
-        resource_attrs = {}
-        for raw in _pb_decode(rs[1][0])[1]:
-            kv = _pb_decode(raw)
-            resource_attrs[kv[1][0]] = _pb_decode(kv[2][0])[1][0]
-        assert resource_attrs[b"openinference.project.name"] == b"my-project"
-        assert resource_attrs[b"service.name"] == b"test-service"
+        assert req.data == otlp_json_to_protobuf(expected_payload)
 
     @mock.patch("core.common.resolve_backend")
     @mock.patch("core.common.urllib.request.urlopen")

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -9,6 +9,7 @@ import urllib.error
 from unittest import mock
 
 import pytest
+from test_otlp_proto import _pb_attrs, _pb_decode
 
 from core.common import (
     FileLock,
@@ -29,7 +30,6 @@ from core.common import (
     restore_stderr_from_log_file,
     send_span,
 )
-from test_otlp_proto import _pb_attrs, _pb_decode
 
 # ── Logging tests ──────────────────────────────────────────────────────────
 

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -894,7 +894,7 @@ class TestPhoenixProjectNameInjection:
             ]
         }
 
-        result = _inject_openinference_project_resource_attr(payload, "my-project")
+        result = _inject_openinference_project_resource_attr(payload, project_name="my-project")
 
         resource_attrs = result["resourceSpans"][0]["resource"]["attributes"]
         assert {"key": "openinference.project.name", "value": {"stringValue": "my-project"}} in resource_attrs
@@ -904,7 +904,7 @@ class TestPhoenixProjectNameInjection:
     def test_creates_resource_when_missing(self):
         payload = {"resourceSpans": [{"scopeSpans": [{"spans": [{"name": "s"}]}]}]}
 
-        result = _inject_openinference_project_resource_attr(payload, "proj")
+        result = _inject_openinference_project_resource_attr(payload, project_name="proj")
 
         assert result["resourceSpans"][0]["resource"]["attributes"] == [
             {"key": "openinference.project.name", "value": {"stringValue": "proj"}}

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -29,7 +29,7 @@ from core.common import (
     restore_stderr_from_log_file,
     send_span,
 )
-from core.otlp_proto import otlp_json_to_protobuf
+from test_otlp_proto import _pb_attrs, _pb_decode
 
 # ── Logging tests ──────────────────────────────────────────────────────────
 
@@ -1095,11 +1095,36 @@ class TestSendSpan:
         assert req.get_header("Content-type") == "application/x-protobuf"
         assert req.get_header("Authorization") == "Bearer test-key"
         assert req.method == "POST"
-        # Body is the OTLP payload with openinference.project.name appended to
-        # the resource attributes for project routing, encoded as protobuf.
-        # (Encoding correctness itself is covered in test_otlp_proto.py.)
-        expected_payload = _inject_openinference_project_resource_attr(self._SAMPLE_SPAN, "my-project")
-        assert req.data == otlp_json_to_protobuf(expected_payload)
+        # Decode the protobuf body independently to verify project routing and
+        # payload passthrough (full encoding coverage lives in test_otlp_proto.py).
+        rs = _pb_decode(_pb_decode(req.data)[1][0])
+        resource_attrs = _pb_attrs(_pb_decode(rs[1][0])[1])
+        assert resource_attrs[b"openinference.project.name"][1][0] == b"my-project"
+        assert resource_attrs[b"service.name"][1][0] == b"test-service"
+        span = _pb_decode(_pb_decode(rs[2][0])[2][0])
+        assert span[5][0] == b"test-span"
+
+    @mock.patch("core.common.resolve_backend")
+    @mock.patch("core.common.urllib.request.urlopen")
+    def test_phoenix_endpoint_with_otlp_path_not_doubled(self, mock_urlopen, mock_resolve, monkeypatch):
+        """An endpoint already ending in /v1/traces does not get the path appended again."""
+        monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
+        monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
+
+        mock_resolve.return_value = {
+            "target": "phoenix",
+            "endpoint": "http://phoenix:6006/v1/traces",
+            "api_key": "",
+            "project_name": "default",
+        }
+        mock_resp = mock.MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = mock.Mock(return_value=mock_resp)
+        mock_resp.__exit__ = mock.Mock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        assert send_span(self._SAMPLE_SPAN) is True
+        assert mock_urlopen.call_args[0][0].full_url == "http://phoenix:6006/v1/traces"
 
     @mock.patch("core.common.resolve_backend")
     @mock.patch("core.common.urllib.request.urlopen")

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -14,7 +14,8 @@ from core.common import (
     FileLock,
     StateManager,
     _attrs_to_otlp,
-    _otlp_to_phoenix_payload,
+    _inject_phoenix_project_name,
+    _otlp_json_to_protobuf,
     _resolve_kind,
     _to_otlp_attr_value,
     build_multi_span,
@@ -879,11 +880,53 @@ class TestBuildMultiSpan:
         assert scope["name"] == "override-scope"
 
 
-# ── Phoenix REST payload translation tests ────────────────────────────────
+# ── Minimal protobuf wire-format decoder (test helper) ────────────────────
 
 
-class TestPhoenixPayloadTranslation:
-    def test_translates_otlp_payload_to_phoenix_create_spans_body(self):
+def _pb_read_varint(data, i):
+    result = shift = 0
+    while True:
+        byte = data[i]
+        result |= (byte & 0x7F) << shift
+        i += 1
+        if not byte & 0x80:
+            return result, i
+        shift += 7
+
+
+def _pb_decode(data):
+    """Decode a protobuf message into {field: [values]} (varint ints, raw bytes otherwise)."""
+    fields = {}
+    i = 0
+    while i < len(data):
+        tag, i = _pb_read_varint(data, i)
+        field, wire_type = tag >> 3, tag & 7
+        if wire_type == 0:
+            value, i = _pb_read_varint(data, i)
+        elif wire_type == 1:
+            value = data[i : i + 8]
+            i += 8
+        elif wire_type == 2:
+            length, i = _pb_read_varint(data, i)
+            value = data[i : i + length]
+            i += length
+        else:
+            raise ValueError(f"unsupported wire type {wire_type}")
+        fields.setdefault(field, []).append(value)
+    return fields
+
+
+def _pb_fixed64_int(raw):
+    import struct
+
+    return struct.unpack("<Q", raw)[0]
+
+
+# ── OTLP protobuf encoding tests ──────────────────────────────────────────
+
+
+class TestOtlpProtobufEncoding:
+    def test_encodes_span_fields(self):
         payload = {
             "resourceSpans": [
                 {
@@ -893,9 +936,9 @@ class TestPhoenixPayloadTranslation:
                             "scope": {"name": "scope"},
                             "spans": [
                                 {
-                                    "traceId": "t" * 32,
-                                    "spanId": "s" * 16,
-                                    "parentSpanId": "p" * 16,
+                                    "traceId": "0123456789abcdef0123456789abcdef",
+                                    "spanId": "abcdef1234567890",
+                                    "parentSpanId": "1122334455667788",
                                     "name": "tool-call",
                                     "kind": 1,
                                     "startTimeUnixNano": "1000000000",
@@ -903,6 +946,8 @@ class TestPhoenixPayloadTranslation:
                                     "attributes": [
                                         {"key": "openinference.span.kind", "value": {"stringValue": "TOOL"}},
                                         {"key": "count", "value": {"intValue": "3"}},
+                                        {"key": "ok", "value": {"boolValue": True}},
+                                        {"key": "score", "value": {"doubleValue": 0.5}},
                                     ],
                                     "events": [
                                         {
@@ -920,36 +965,49 @@ class TestPhoenixPayloadTranslation:
             ]
         }
 
-        result = _otlp_to_phoenix_payload(payload)
+        encoded = _otlp_json_to_protobuf(payload)
 
-        assert result == {
-            "data": [
-                {
-                    "name": "tool-call",
-                    "context": {"trace_id": "t" * 32, "span_id": "s" * 16},
-                    "span_kind": "TOOL",
-                    "start_time": "1970-01-01T00:00:01.000000Z",
-                    "end_time": "1970-01-01T00:00:01.500000Z",
-                    "status_code": "ERROR",
-                    "status_message": "failed",
-                    "attributes": {
-                        "service.name": "svc",
-                        "openinference.span.kind": "TOOL",
-                        "count": 3,
-                    },
-                    "parent_id": "p" * 16,
-                    "events": [
-                        {
-                            "name": "exception",
-                            "timestamp": "1970-01-01T00:00:01.250000Z",
-                            "attributes": {"message": "boom"},
-                        }
-                    ],
-                }
-            ]
-        }
+        # ExportTraceServiceRequest.resource_spans[0]
+        rs = _pb_decode(_pb_decode(encoded)[1][0])
+        # Resource.attributes[0] is service.name
+        resource_attr = _pb_decode(_pb_decode(rs[1][0])[1][0])
+        assert resource_attr[1][0] == b"service.name"
+        assert _pb_decode(resource_attr[2][0])[1][0] == b"svc"
 
-    def test_rejects_missing_phoenix_span_timestamp(self):
+        ss = _pb_decode(rs[2][0])
+        assert _pb_decode(ss[1][0])[1][0] == b"scope"
+
+        span = _pb_decode(ss[2][0])
+        assert span[1][0] == bytes.fromhex("0123456789abcdef0123456789abcdef")
+        assert span[2][0] == bytes.fromhex("abcdef1234567890")
+        assert span[4][0] == bytes.fromhex("1122334455667788")
+        assert span[5][0] == b"tool-call"
+        assert span[6][0] == 1
+        assert _pb_fixed64_int(span[7][0]) == 1_000_000_000
+        assert _pb_fixed64_int(span[8][0]) == 1_500_000_000
+
+        attrs = {}
+        for raw in span[9]:
+            kv = _pb_decode(raw)
+            attrs[kv[1][0]] = _pb_decode(kv[2][0])
+        assert attrs[b"openinference.span.kind"][1][0] == b"TOOL"
+        assert attrs[b"count"][3][0] == 3
+        assert attrs[b"ok"][2][0] == 1
+        import struct
+
+        assert struct.unpack("<d", attrs[b"score"][4][0])[0] == 0.5
+
+        event = _pb_decode(span[11][0])
+        assert _pb_fixed64_int(event[1][0]) == 1_250_000_000
+        assert event[2][0] == b"exception"
+        event_attr = _pb_decode(event[3][0])
+        assert event_attr[1][0] == b"message"
+
+        status = _pb_decode(span[15][0])
+        assert status[2][0] == b"failed"
+        assert status[3][0] == 2
+
+    def test_rejects_missing_span_timestamp(self):
         payload = {
             "resourceSpans": [
                 {
@@ -970,7 +1028,38 @@ class TestPhoenixPayloadTranslation:
         }
 
         with pytest.raises(ValueError, match="Invalid Unix nanosecond timestamp"):
-            _otlp_to_phoenix_payload(payload)
+            _otlp_json_to_protobuf(payload)
+
+
+# ── Phoenix project-name injection tests ──────────────────────────────────
+
+
+class TestPhoenixProjectNameInjection:
+    def test_injects_project_name_into_resource_attributes(self):
+        payload = {
+            "resourceSpans": [
+                {
+                    "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": "svc"}}]},
+                    "scopeSpans": [{"spans": [{"traceId": "t" * 32, "spanId": "s" * 16, "name": "tool-call"}]}],
+                }
+            ]
+        }
+
+        result = _inject_phoenix_project_name(payload, "my-project")
+
+        resource_attrs = result["resourceSpans"][0]["resource"]["attributes"]
+        assert {"key": "openinference.project.name", "value": {"stringValue": "my-project"}} in resource_attrs
+        # Original payload is not mutated
+        assert len(payload["resourceSpans"][0]["resource"]["attributes"]) == 1
+
+    def test_creates_resource_when_missing(self):
+        payload = {"resourceSpans": [{"scopeSpans": [{"spans": [{"name": "s"}]}]}]}
+
+        result = _inject_phoenix_project_name(payload, "proj")
+
+        assert result["resourceSpans"][0]["resource"]["attributes"] == [
+            {"key": "openinference.project.name", "value": {"stringValue": "proj"}}
+        ]
 
 
 # ── EnvConfig property tests ──────────────────────────────────────────────
@@ -1134,7 +1223,7 @@ class TestSendSpan:
     @mock.patch("core.common.resolve_backend")
     @mock.patch("core.common.urllib.request.urlopen")
     def test_phoenix_direct_send(self, mock_urlopen, mock_resolve, monkeypatch):
-        """send_span sends directly to Phoenix REST endpoint."""
+        """send_span sends OTLP protobuf to Phoenix's OTLP HTTP endpoint."""
         monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
         monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
 
@@ -1153,32 +1242,22 @@ class TestSendSpan:
         assert send_span(self._SAMPLE_SPAN) is True
 
         req = mock_urlopen.call_args[0][0]
-        assert req.full_url == "http://phoenix:6006/v1/projects/my-project/spans"
-        assert req.get_header("Content-type") == "application/json"
+        assert req.full_url == "http://phoenix:6006/v1/traces"
+        assert req.get_header("Content-type") == "application/x-protobuf"
         assert req.get_header("Authorization") == "Bearer test-key"
         assert req.method == "POST"
-        body = json.loads(req.data)
-        assert body == {
-            "data": [
-                {
-                    "name": "test-span",
-                    "context": {
-                        "trace_id": "0123456789abcdef0123456789abcdef",
-                        "span_id": "abcdef1234567890",
-                    },
-                    "span_kind": "LLM",
-                    "start_time": "1970-01-01T00:00:01.000000Z",
-                    "end_time": "1970-01-01T00:00:02.000000Z",
-                    "status_code": "OK",
-                    "status_message": "",
-                    "attributes": {
-                        "service.name": "test-service",
-                        "openinference.span.kind": "LLM",
-                        "input.value": "hello",
-                    },
-                }
-            ]
-        }
+        # Body is the OTLP payload with openinference.project.name appended to
+        # the resource attributes for project routing, encoded as protobuf.
+        expected_payload = _inject_phoenix_project_name(self._SAMPLE_SPAN, "my-project")
+        assert req.data == _otlp_json_to_protobuf(expected_payload)
+        # Sanity-check the encoded resource attributes include the project name.
+        rs = _pb_decode(_pb_decode(req.data)[1][0])
+        resource_attrs = {}
+        for raw in _pb_decode(rs[1][0])[1]:
+            kv = _pb_decode(raw)
+            resource_attrs[kv[1][0]] = _pb_decode(kv[2][0])[1][0]
+        assert resource_attrs[b"openinference.project.name"] == b"my-project"
+        assert resource_attrs[b"service.name"] == b"test-service"
 
     @mock.patch("core.common.resolve_backend")
     @mock.patch("core.common.urllib.request.urlopen")
@@ -1234,7 +1313,7 @@ class TestSendSpan:
             "project_name": "default",
         }
         mock_urlopen.side_effect = urllib.error.HTTPError(
-            "http://phoenix:6006/v1/projects/default/spans",
+            "http://phoenix:6006/v1/traces",
             400,
             "Bad Request",
             {},

--- a/tests/core/test_otlp_proto.py
+++ b/tests/core/test_otlp_proto.py
@@ -60,6 +60,17 @@ def _pb_attrs(raw_key_values):
     return attrs
 
 
+def _span_payload(span):
+    """Wrap a single span dict in a minimal OTLP JSON payload."""
+    return {"resourceSpans": [{"scopeSpans": [{"spans": [span]}]}]}
+
+
+def _decode_first_span(encoded):
+    """Decode ExportTraceServiceRequest bytes down to the first Span's fields."""
+    rs = _pb_decode(_pb_decode(encoded)[1][0])
+    return _pb_decode(_pb_decode(rs[2][0])[2][0])
+
+
 # ── OTLP protobuf encoding tests ──────────────────────────────────────────
 
 
@@ -137,25 +148,112 @@ class TestOtlpProtobufEncoding:
         assert status[2][0] == b"failed"
         assert status[3][0] == 2
 
+    def test_encodes_links_and_optional_fields(self):
+        payload = _span_payload(
+            {
+                "traceId": "ab" * 16,
+                "spanId": "cd" * 8,
+                "name": "linked",
+                "traceState": "vendor=1",
+                "startTimeUnixNano": "1000000000",
+                "endTimeUnixNano": "2000000000",
+                "droppedAttributesCount": 2,
+                "links": [
+                    {
+                        "traceId": "ef" * 16,
+                        "spanId": "01" * 8,
+                        "attributes": [{"key": "rel", "value": {"stringValue": "child"}}],
+                    }
+                ],
+            }
+        )
+
+        span = _decode_first_span(otlp_json_to_protobuf(payload))
+
+        assert span[3][0] == b"vendor=1"
+        assert span[10][0] == 2
+        link = _pb_decode(span[13][0])
+        assert link[1][0] == bytes.fromhex("ef" * 16)
+        assert link[2][0] == bytes.fromhex("01" * 8)
+        assert _pb_attrs(link[4])[b"rel"][1][0] == b"child"
+
+    def test_malformed_double_encodes_empty_value(self):
+        payload = _span_payload(
+            {
+                "traceId": "ab" * 16,
+                "spanId": "cd" * 8,
+                "name": "bad-double",
+                "startTimeUnixNano": "1000000000",
+                "endTimeUnixNano": "2000000000",
+                "attributes": [{"key": "bad", "value": {"doubleValue": None}}],
+            }
+        )
+
+        span = _decode_first_span(otlp_json_to_protobuf(payload))
+
+        # The malformed attribute degrades to an empty AnyValue; the span survives.
+        assert _pb_attrs(span[9])[b"bad"] == {}
+
     def test_rejects_missing_span_timestamp(self):
-        payload = {
-            "resourceSpans": [
-                {
-                    "scopeSpans": [
-                        {
-                            "spans": [
-                                {
-                                    "traceId": "t" * 32,
-                                    "spanId": "s" * 16,
-                                    "name": "missing-time",
-                                    "endTimeUnixNano": "2000000000",
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        }
+        payload = _span_payload(
+            {
+                "traceId": "ab" * 16,
+                "spanId": "cd" * 8,
+                "name": "missing-time",
+                "endTimeUnixNano": "2000000000",
+            }
+        )
 
         with pytest.raises(ValueError, match="Invalid Unix nanosecond timestamp"):
             otlp_json_to_protobuf(payload)
+
+    def test_rejects_missing_event_timestamp(self):
+        payload = _span_payload(
+            {
+                "traceId": "ab" * 16,
+                "spanId": "cd" * 8,
+                "name": "bad-event",
+                "startTimeUnixNano": "1000000000",
+                "endTimeUnixNano": "2000000000",
+                "events": [{"name": "no-time"}],
+            }
+        )
+
+        with pytest.raises(ValueError, match="Invalid Unix nanosecond timestamp for event"):
+            otlp_json_to_protobuf(payload)
+
+    @pytest.mark.parametrize(
+        "span_ids, message",
+        [
+            ({"traceId": "t" * 32, "spanId": "cd" * 8}, "Invalid hex traceId"),
+            ({"traceId": "ab" * 16, "spanId": 12345}, "Invalid hex spanId"),
+            ({"traceId": "", "spanId": "cd" * 8}, "Missing traceId"),
+            ({"traceId": "ab" * 16, "spanId": "cd" * 8, "parentSpanId": "zz"}, "Invalid hex parentSpanId"),
+        ],
+    )
+    def test_rejects_bad_ids(self, span_ids, message):
+        payload = _span_payload(
+            {
+                "name": "bad-ids",
+                "startTimeUnixNano": "1000000000",
+                "endTimeUnixNano": "2000000000",
+                **span_ids,
+            }
+        )
+
+        with pytest.raises(ValueError, match=message):
+            otlp_json_to_protobuf(payload)
+
+    def test_missing_parent_span_id_is_fine(self):
+        payload = _span_payload(
+            {
+                "traceId": "ab" * 16,
+                "spanId": "cd" * 8,
+                "name": "root",
+                "startTimeUnixNano": "1000000000",
+                "endTimeUnixNano": "2000000000",
+            }
+        )
+
+        span = _decode_first_span(otlp_json_to_protobuf(payload))
+        assert 4 not in span  # no parentSpanId field encoded

--- a/tests/core/test_otlp_proto.py
+++ b/tests/core/test_otlp_proto.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for core.otlp_proto — stdlib OTLP protobuf wire-format encoding."""
+
+import struct
+
+import pytest
+
+from core.otlp_proto import otlp_json_to_protobuf
+
+# ── Minimal protobuf wire-format decoder (test helper) ────────────────────
+
+
+def _pb_read_varint(data, i):
+    result = shift = 0
+    while True:
+        byte = data[i]
+        result |= (byte & 0x7F) << shift
+        i += 1
+        if not byte & 0x80:
+            return result, i
+        shift += 7
+
+
+def _pb_decode(data):
+    """Decode a protobuf message into {field: [values]} (varint ints, raw bytes otherwise)."""
+    fields = {}
+    i = 0
+    while i < len(data):
+        tag, i = _pb_read_varint(data, i)
+        field, wire_type = tag >> 3, tag & 7
+        if wire_type == 0:
+            value, i = _pb_read_varint(data, i)
+        elif wire_type == 1:
+            value = data[i : i + 8]
+            i += 8
+        elif wire_type == 2:
+            length, i = _pb_read_varint(data, i)
+            value = data[i : i + length]
+            i += length
+        else:
+            raise ValueError(f"unsupported wire type {wire_type}")
+        fields.setdefault(field, []).append(value)
+    return fields
+
+
+def _pb_fixed64_int(raw):
+    return struct.unpack("<Q", raw)[0]
+
+
+def _pb_double_val(raw):
+    return struct.unpack("<d", raw)[0]
+
+
+def _pb_attrs(raw_key_values):
+    """Decode repeated KeyValue messages into {key bytes: decoded AnyValue fields}."""
+    attrs = {}
+    for raw in raw_key_values:
+        kv = _pb_decode(raw)
+        attrs[kv[1][0]] = _pb_decode(kv[2][0])
+    return attrs
+
+
+# ── OTLP protobuf encoding tests ──────────────────────────────────────────
+
+
+class TestOtlpProtobufEncoding:
+    def test_encodes_span_fields(self):
+        payload = {
+            "resourceSpans": [
+                {
+                    "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": "svc"}}]},
+                    "scopeSpans": [
+                        {
+                            "scope": {"name": "scope"},
+                            "spans": [
+                                {
+                                    "traceId": "0123456789abcdef0123456789abcdef",
+                                    "spanId": "abcdef1234567890",
+                                    "parentSpanId": "1122334455667788",
+                                    "name": "tool-call",
+                                    "kind": 1,
+                                    "startTimeUnixNano": "1000000000",
+                                    "endTimeUnixNano": "1500000000",
+                                    "attributes": [
+                                        {"key": "openinference.span.kind", "value": {"stringValue": "TOOL"}},
+                                        {"key": "count", "value": {"intValue": "3"}},
+                                        {"key": "ok", "value": {"boolValue": True}},
+                                        {"key": "score", "value": {"doubleValue": 0.5}},
+                                    ],
+                                    "events": [
+                                        {
+                                            "name": "exception",
+                                            "timeUnixNano": "1250000000",
+                                            "attributes": [{"key": "message", "value": {"stringValue": "boom"}}],
+                                        }
+                                    ],
+                                    "status": {"code": 2, "message": "failed"},
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        encoded = otlp_json_to_protobuf(payload)
+
+        # ExportTraceServiceRequest.resource_spans[0]
+        rs = _pb_decode(_pb_decode(encoded)[1][0])
+        resource_attrs = _pb_attrs(_pb_decode(rs[1][0])[1])
+        assert resource_attrs[b"service.name"][1][0] == b"svc"
+
+        ss = _pb_decode(rs[2][0])
+        assert _pb_decode(ss[1][0])[1][0] == b"scope"
+
+        span = _pb_decode(ss[2][0])
+        assert span[1][0] == bytes.fromhex("0123456789abcdef0123456789abcdef")
+        assert span[2][0] == bytes.fromhex("abcdef1234567890")
+        assert span[4][0] == bytes.fromhex("1122334455667788")
+        assert span[5][0] == b"tool-call"
+        assert span[6][0] == 1
+        assert _pb_fixed64_int(span[7][0]) == 1_000_000_000
+        assert _pb_fixed64_int(span[8][0]) == 1_500_000_000
+
+        attrs = _pb_attrs(span[9])
+        assert attrs[b"openinference.span.kind"][1][0] == b"TOOL"
+        assert attrs[b"count"][3][0] == 3
+        assert attrs[b"ok"][2][0] == 1
+        assert _pb_double_val(attrs[b"score"][4][0]) == 0.5
+
+        event = _pb_decode(span[11][0])
+        assert _pb_fixed64_int(event[1][0]) == 1_250_000_000
+        assert event[2][0] == b"exception"
+        assert _pb_attrs(event[3])[b"message"][1][0] == b"boom"
+
+        status = _pb_decode(span[15][0])
+        assert status[2][0] == b"failed"
+        assert status[3][0] == 2
+
+    def test_rejects_missing_span_timestamp(self):
+        payload = {
+            "resourceSpans": [
+                {
+                    "scopeSpans": [
+                        {
+                            "spans": [
+                                {
+                                    "traceId": "t" * 32,
+                                    "spanId": "s" * 16,
+                                    "name": "missing-time",
+                                    "endTimeUnixNano": "2000000000",
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+
+        with pytest.raises(ValueError, match="Invalid Unix nanosecond timestamp"):
+            otlp_json_to_protobuf(payload)

--- a/tests/core/test_otlp_proto.py
+++ b/tests/core/test_otlp_proto.py
@@ -11,6 +11,7 @@ from core.otlp_proto import otlp_json_to_protobuf
 
 
 def _pb_read_varint(data, i):
+    """Read a varint from data starting at index i; return (value, next index)."""
     result = shift = 0
     while True:
         byte = data[i]
@@ -44,10 +45,12 @@ def _pb_decode(data):
 
 
 def _pb_fixed64_int(raw):
+    """Unpack 8 little-endian bytes as an unsigned int."""
     return struct.unpack("<Q", raw)[0]
 
 
 def _pb_double_val(raw):
+    """Unpack 8 little-endian bytes as an IEEE-754 double."""
     return struct.unpack("<d", raw)[0]
 
 


### PR DESCRIPTION
Fixes #121

## What changed

Phoenix spans were exported via Phoenix's native REST create-spans endpoint (`POST /v1/projects/{project}/spans`), with a custom translation layer converting OTLP JSON into Phoenix's REST schema. Spans now go through the standard OTLP/HTTP export mechanism:

- **`POST {endpoint}/v1/traces`** with the OTLP payload, exactly like any OTel SDK exporter.
- **Project routing** via the `openinference.project.name` resource attribute (Phoenix's standard OTLP project-routing mechanism) instead of the URL path.
- The OTLP→Phoenix-REST translation helpers (`_otlp_to_phoenix_payload`, `_otlp_attrs_to_dict`, `_unix_nano_to_iso`, `_phoenix_status_code`, `_phoenix_span_kind`, `_otlp_attr_value_to_python`) are deleted — Phoenix now derives span kind, status, and timestamps from the OTLP data itself.
- The Phoenix and Arize branches of `send_span()` now share one `_post_otlp()` helper.
