### PR TITLE
fix(claude): decode hook stdin as UTF-8

### DIFF
--- a/tests/tracing/claude/test_claude_hook.py
+++ b/tests/tracing/claude/test_claude_hook.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests for tracing.claude_code.hooks.handlers — the 10 Claude Code hook handlers."""
 
+import io
 import json
 import sys
 from pathlib import Path
@@ -102,6 +103,19 @@ class TestReadStdin:
         """Valid JSON is parsed."""
         with mock.patch.object(sys, "stdin", new=__import__("io").StringIO('{"a": 1}')):
             assert _read_stdin() == {"a": 1}
+
+    def test_utf8_payload_ignores_text_wrapper_encoding(self):
+        """Hook JSON is decoded as UTF-8, independently of the host locale."""
+        payload = json.dumps({"prompt": "Привет 한글 العربية"}, ensure_ascii=False).encode("utf-8")
+        stdin = io.TextIOWrapper(io.BytesIO(payload), encoding="ascii")
+        with mock.patch.object(sys, "stdin", new=stdin):
+            assert _read_stdin() == {"prompt": "Привет 한글 العربية"}
+
+    def test_invalid_utf8_returns_empty_dict(self):
+        """Malformed UTF-8 is rejected rather than silently replaced."""
+        stdin = io.TextIOWrapper(io.BytesIO(b'{"prompt": "\xff"}'), encoding="ascii")
+        with mock.patch.object(sys, "stdin", new=stdin):
+            assert _read_stdin() == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tracing/claude_code/hooks/handlers.py
+++ b/tracing/claude_code/hooks/handlers.py
@@ -43,11 +43,12 @@ from .transcript import parse_claude_transcript
 
 
 def _read_stdin() -> dict:
-    """Read JSON from stdin. Returns {} on empty/invalid input."""
+    """Read UTF-8 JSON from stdin. Returns {} on empty/invalid input."""
     try:
-        raw = sys.stdin.read()
+        buffer = getattr(sys.stdin, "buffer", None)
+        raw = buffer.read().decode("utf-8") if buffer is not None else sys.stdin.read()
         return json.loads(raw) if raw else {}
-    except (json.JSONDecodeError, OSError):
+    except (UnicodeDecodeError, json.JSONDecodeError, OSError):
         return {}
 
 


### PR DESCRIPTION
## Summary

- read Claude hook stdin from the underlying binary buffer when available
- decode hook payloads explicitly as strict UTF-8 instead of relying on the host locale
- return `{}` for malformed UTF-8, consistent with the existing invalid-input contract
- preserve compatibility with text-only stdin streams such as `io.StringIO`

## Tests

- added a multilingual UTF-8 payload test under an ASCII text wrapper
- added a malformed UTF-8 rejection test
- `uv run pytest tests/ -m "not slow"`: 2569 passed, 1 skipped
- `uv run pre-commit run --all-files`: passed
- Python 3.9 targeted `TestReadStdin`: 5 passed

Fixes #119
