### PR TITLE
feat: add a custom OTLP target for non-Arize collectors

### DIFF
--- a/core/common.py
+++ b/core/common.py
@@ -71,11 +71,15 @@ class _Env:
     def _resolve_target(self, harness_cfg: dict) -> str:
         """Resolve the backend target: env-derived wins over the config target.
 
-        ``PHOENIX_ENDPOINT`` → phoenix; ``ARIZE_API_KEY``+``ARIZE_SPACE_ID`` →
-        arize; otherwise ``harness_cfg['target']`` (``""`` if unset). Mirrors the
-        precedence in :func:`resolve_backend` so project-name resolution stays in
-        sync with the backend actually chosen.
+        ``CUSTOM_OTLP_ENDPOINT`` → custom (highest priority — the most explicit
+        thing a caller can say is "send spans here"); ``PHOENIX_ENDPOINT`` →
+        phoenix; ``ARIZE_API_KEY``+``ARIZE_SPACE_ID`` → arize; otherwise
+        ``harness_cfg['target']`` (``""`` if unset). Mirrors the precedence in
+        :func:`resolve_backend` so project-name resolution stays in sync with
+        the backend actually chosen.
         """
+        if self.custom_otlp_endpoint:
+            return "custom"
         if self.phoenix_endpoint:
             return "phoenix"
         if self.api_key and self.space_id:
@@ -149,21 +153,21 @@ class _Env:
 
     @property
     def custom_otlp_endpoint(self) -> str:
-        # Live runtime override for the arize-target endpoint, distinct from
-        # ARIZE_OTLP_ENDPOINT (which is only consulted by the interactive setup
-        # wizard when writing harness_cfg['endpoint'] to config.json). Lets a
-        # team redirect spans to a non-Arize-branded OTLP collector (e.g. one
-        # that strips PII, or an internal collector) without editing
-        # config.json. See issue #120.
+        # Selects and configures the "custom" target: any generic OTLP/HTTP
+        # collector (e.g. an internal Jaeger instance) that isn't Arize or
+        # Phoenix. Distinct from ARIZE_OTLP_ENDPOINT (which is only consulted
+        # by the interactive setup wizard when writing harness_cfg['endpoint']
+        # for the arize target). See issue #120.
         return os.environ.get("CUSTOM_OTLP_ENDPOINT", "")
 
     @property
     def custom_auth_command(self) -> str:
         # Shell command run immediately before each span POST to produce a
-        # fresh bearer token, for backends whose credentials expire faster
-        # than a Claude Code session (e.g. an internal SSO-derived token).
-        # Overrides a static api_key when set. Falls back to the per-harness
-        # 'token_command' config.json field when unset.
+        # fresh bearer token for the "custom" target, for backends whose
+        # credentials expire faster than a Claude Code session (e.g. an
+        # internal SSO-derived token). Overrides a static api_key when set.
+        # Falls back to the per-harness 'token_command' config.json field
+        # when unset.
         return os.environ.get("CUSTOM_AUTH_COMMAND", "")
 
     @functools.cached_property
@@ -451,8 +455,9 @@ def resolve_project_name(target: str, harness_cfg: dict, fallback: str = "") -> 
     The env override is framework-scoped so a value configured for one backend
     never leaks into another: the Phoenix backend honors ``PHOENIX_PROJECT``
     then ``PHOENIX_PROJECT_NAME``; the Arize backend honors
-    ``ARIZE_PROJECT_NAME``. When the target is unknown, either generic var is
-    accepted for backward compatibility.
+    ``ARIZE_PROJECT_NAME``. The ``custom`` target has no dedicated env var of
+    its own — like an unrecognized target, it falls back to accepting either
+    generic var, for backward compatibility.
 
     This is why, on the Phoenix backend, the ``ARIZE_PROJECT_NAME`` the Claude
     Code installer historically baked into ``settings.json`` is ignored — see
@@ -479,24 +484,27 @@ def resolve_backend(span_dict: dict) -> dict:
     purely via the runtime env block in ~/.claude/settings.json.
 
     Env vars consulted:
+      - CUSTOM_OTLP_ENDPOINT  → target=custom (highest priority; overrides
+        both config target and the other env-derived targets). Points at any
+        generic OTLP/HTTP collector — e.g. an internal Jaeger instance — that
+        isn't Arize or Phoenix. See #120.
+      - CUSTOM_AUTH_COMMAND   → shell command for the custom target, run
+        before each request to produce a fresh bearer token; overrides
+        harness_cfg['token_command']. See send_span() for how it's used.
       - PHOENIX_ENDPOINT      → target=phoenix (overrides config target)
       - ARIZE_API_KEY         → target=arize when paired with ARIZE_SPACE_ID
       - ARIZE_SPACE_ID        → required for arize when env-only
       - ARIZE_PROJECT_NAME    → project_name override (Arize backend only)
       - PHOENIX_PROJECT /
         PHOENIX_PROJECT_NAME  → project_name override (Phoenix backend only)
-      - CUSTOM_OTLP_ENDPOINT  → endpoint override (Arize backend only; wins
-        over harness_cfg['endpoint'] and the otlp.arize.com default). Lets a
-        team redirect spans to a non-Arize-branded OTLP collector. See #120.
-      - CUSTOM_AUTH_COMMAND   → shell command override (Arize backend only)
-        for harness_cfg['token_command']; see send_span() for how it's used.
 
     service_name is pulled from the span's resource attributes
     (resource.attributes[service.name]).
 
     Returns:
       {"target": "phoenix", "endpoint", "api_key", "project_name"} or
-      {"target": "arize",   "endpoint", "api_key", "space_id", "token_command", "project_name"}
+      {"target": "arize",   "endpoint", "api_key", "space_id", "project_name"} or
+      {"target": "custom",  "endpoint", "api_key", "token_command", "project_name"}
 
     On any missing required field, logs a clear error via error() and
     returns {"target": "none", "project_name": project_name_or_""}.
@@ -559,14 +567,13 @@ def resolve_backend(span_dict: dict) -> dict:
         }
 
     if target == "arize":
-        endpoint = env.custom_otlp_endpoint or harness_cfg.get("endpoint", "") or "otlp.arize.com:443"
+        endpoint = harness_cfg.get("endpoint", "") or "otlp.arize.com:443"
         api_key = env.api_key or harness_cfg.get("api_key", "")
         space_id = env.space_id or harness_cfg.get("space_id", "")
-        token_command = env.custom_auth_command or harness_cfg.get("token_command", "")
 
         missing = []
-        if not api_key and not token_command:
-            missing.append("api_key (set ARIZE_API_KEY) or token_command")
+        if not api_key:
+            missing.append("api_key (set ARIZE_API_KEY)")
         if not space_id:
             missing.append("space_id (set ARIZE_SPACE_ID)")
         if missing:
@@ -580,11 +587,31 @@ def resolve_backend(span_dict: dict) -> dict:
             "endpoint": endpoint,
             "api_key": api_key,
             "space_id": space_id,
+            "project_name": project_name,
+        }
+
+    if target == "custom":
+        endpoint = env.custom_otlp_endpoint or harness_cfg.get("endpoint", "")
+        api_key = env.api_key or harness_cfg.get("api_key", "")
+        token_command = env.custom_auth_command or harness_cfg.get("token_command", "")
+
+        missing = []
+        if not endpoint:
+            missing.append("endpoint (set CUSTOM_OTLP_ENDPOINT or add 'endpoint' to config.json)")
+        if not api_key and not token_command:
+            missing.append("api_key or token_command")
+        if missing:
+            error(f"Incomplete custom config for harness '{service_name}': missing {', '.join(missing)}.")
+            return {"target": "none", "project_name": project_name}
+        return {
+            "target": "custom",
+            "endpoint": endpoint,
+            "api_key": api_key,
             "token_command": token_command,
             "project_name": project_name,
         }
 
-    error(f"Unknown target '{target}' for harness '{service_name}'. " f"Expected 'arize' or 'phoenix'.")
+    error(f"Unknown target '{target}' for harness '{service_name}'. " f"Expected 'arize', 'phoenix', or 'custom'.")
     return {"target": "none", "project_name": project_name}
 
 
@@ -766,7 +793,7 @@ def send_span(span_dict: dict) -> bool:
     ``~/.arize/harness/config.json``. If neither path yields a complete
     backend, the span is dropped and an error is logged.
 
-    On the arize target, if a ``token_command`` was resolved (via
+    On the custom target, if a ``token_command`` was resolved (via
     CUSTOM_AUTH_COMMAND or harness_cfg['token_command']), it is run
     immediately before the request to obtain a fresh bearer token —
     supporting credentials that expire faster than a session (e.g. an
@@ -813,17 +840,8 @@ def send_span(span_dict: dict) -> bool:
         elif target == "arize":
             project = backend["project_name"]
             endpoint = backend.get("endpoint", "otlp.arize.com:443")
-            api_key = backend.get("api_key", "")
+            api_key = backend["api_key"]
             space_id = backend.get("space_id", "")
-
-            token_command = backend.get("token_command", "")
-            if token_command:
-                fresh_token = _resolve_token_via_command(token_command)
-                if fresh_token:
-                    api_key = fresh_token
-                elif not api_key:
-                    error("token_command produced no token and no static api_key is set; dropping span")
-                    return False
 
             # Inject arize.project.name into span attributes (required by Arize)
             payload = _inject_arize_project_name(span_dict, project)
@@ -853,6 +871,44 @@ def send_span(span_dict: dict) -> bool:
                 return False
             except Exception as e:
                 error(f"Arize send failed: {e}")
+                return False
+        elif target == "custom":
+            endpoint = backend.get("endpoint", "")
+            api_key = backend.get("api_key", "")
+            token_command = backend.get("token_command", "")
+
+            if token_command:
+                fresh_token = _resolve_token_via_command(token_command)
+                if fresh_token:
+                    api_key = fresh_token
+                elif not api_key:
+                    error("token_command produced no token and no static api_key is set; dropping span")
+                    return False
+
+            # Normalize endpoint to HTTPS URL for HTTP/JSON transport
+            if endpoint.startswith("http://") or endpoint.startswith("https://"):
+                url = f"{endpoint.rstrip('/')}/v1/traces"
+            else:
+                url = f"https://{endpoint}/v1/traces"
+
+            # Raw OTLP payload — no Arize-specific attribute injection or space_id header.
+            body = json.dumps(span_dict).encode("utf-8")
+            headers = {"Content-Type": "application/json"}
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+            req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+            try:
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    return 200 <= resp.status < 300
+            except urllib.error.HTTPError as e:
+                try:
+                    detail = e.read().decode("utf-8", errors="replace")
+                except Exception:
+                    detail = ""
+                error(f"Custom send failed: HTTP {e.code}: {detail or e.reason}")
+                return False
+            except Exception as e:
+                error(f"Custom send failed: {e}")
                 return False
         else:
             error("No backend configured (set PHOENIX_ENDPOINT or ARIZE_API_KEY+ARIZE_SPACE_ID)")

--- a/core/common.py
+++ b/core/common.py
@@ -12,6 +12,7 @@ import functools
 import json
 import os
 import shutil
+import subprocess
 import sys
 import time
 import urllib.error
@@ -145,6 +146,25 @@ class _Env:
     @property
     def space_id(self) -> str:
         return os.environ.get("ARIZE_SPACE_ID", "")
+
+    @property
+    def custom_otlp_endpoint(self) -> str:
+        # Live runtime override for the arize-target endpoint, distinct from
+        # ARIZE_OTLP_ENDPOINT (which is only consulted by the interactive setup
+        # wizard when writing harness_cfg['endpoint'] to config.json). Lets a
+        # team redirect spans to a non-Arize-branded OTLP collector (e.g. one
+        # that strips PII, or an internal Jaeger instance) without editing
+        # config.json. See issue #120.
+        return os.environ.get("CUSTOM_OTLP_ENDPOINT", "")
+
+    @property
+    def custom_auth_command(self) -> str:
+        # Shell command run immediately before each span POST to produce a
+        # fresh bearer token, for backends whose credentials expire faster
+        # than a Claude Code session (e.g. an internal SSO-derived token).
+        # Overrides a static api_key when set. Falls back to the per-harness
+        # 'token_command' config.json field when unset.
+        return os.environ.get("CUSTOM_AUTH_COMMAND", "")
 
     @functools.cached_property
     def _top_level_config(self) -> dict:
@@ -465,13 +485,18 @@ def resolve_backend(span_dict: dict) -> dict:
       - ARIZE_PROJECT_NAME    → project_name override (Arize backend only)
       - PHOENIX_PROJECT /
         PHOENIX_PROJECT_NAME  → project_name override (Phoenix backend only)
+      - CUSTOM_OTLP_ENDPOINT  → endpoint override (Arize backend only; wins
+        over harness_cfg['endpoint'] and the otlp.arize.com default). Lets a
+        team redirect spans to a non-Arize-branded OTLP collector. See #120.
+      - CUSTOM_AUTH_COMMAND   → shell command override (Arize backend only)
+        for harness_cfg['token_command']; see send_span() for how it's used.
 
     service_name is pulled from the span's resource attributes
     (resource.attributes[service.name]).
 
     Returns:
       {"target": "phoenix", "endpoint", "api_key", "project_name"} or
-      {"target": "arize",   "endpoint", "api_key", "space_id", "project_name"}
+      {"target": "arize",   "endpoint", "api_key", "space_id", "token_command", "project_name"}
 
     On any missing required field, logs a clear error via error() and
     returns {"target": "none", "project_name": project_name_or_""}.
@@ -534,13 +559,14 @@ def resolve_backend(span_dict: dict) -> dict:
         }
 
     if target == "arize":
-        endpoint = harness_cfg.get("endpoint", "") or "otlp.arize.com:443"
+        endpoint = env.custom_otlp_endpoint or harness_cfg.get("endpoint", "") or "otlp.arize.com:443"
         api_key = env.api_key or harness_cfg.get("api_key", "")
         space_id = env.space_id or harness_cfg.get("space_id", "")
+        token_command = env.custom_auth_command or harness_cfg.get("token_command", "")
 
         missing = []
-        if not api_key:
-            missing.append("api_key (set ARIZE_API_KEY)")
+        if not api_key and not token_command:
+            missing.append("api_key (set ARIZE_API_KEY) or token_command")
         if not space_id:
             missing.append("space_id (set ARIZE_SPACE_ID)")
         if missing:
@@ -554,6 +580,7 @@ def resolve_backend(span_dict: dict) -> dict:
             "endpoint": endpoint,
             "api_key": api_key,
             "space_id": space_id,
+            "token_command": token_command,
             "project_name": project_name,
         }
 
@@ -694,6 +721,34 @@ def _otlp_to_phoenix_payload(span_dict: dict) -> dict:
     return {"data": phoenix_spans}
 
 
+def _resolve_token_via_command(command: str) -> str:
+    """Run a shell command to obtain a fresh bearer token, returning "" on failure.
+
+    Supports rotating/short-TTL credentials (e.g. an SSO-derived token that
+    expires within a session) without requiring a wrapper around the hook
+    binaries. Never raises; logs via error() and returns "" on any failure so
+    callers can fall back to a static api_key.
+    """
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            error(f"token_command failed (exit {result.returncode}): {result.stderr.strip()}")
+            return ""
+        token = result.stdout.strip()
+        if not token:
+            error("token_command succeeded but produced no output")
+        return token
+    except Exception as e:
+        error(f"token_command failed: {e}")
+        return ""
+
+
 def _extract_span_name(span_dict: dict) -> str:
     """Extract the first span name from an OTLP payload."""
     try:
@@ -710,6 +765,13 @@ def send_span(span_dict: dict) -> bool:
     ARIZE_PROJECT_NAME) before falling back to
     ``~/.arize/harness/config.json``. If neither path yields a complete
     backend, the span is dropped and an error is logged.
+
+    On the arize target, if a ``token_command`` was resolved (via
+    CUSTOM_AUTH_COMMAND or harness_cfg['token_command']), it is run
+    immediately before the request to obtain a fresh bearer token —
+    supporting credentials that expire faster than a session (e.g. an
+    SSO-derived token). Falls back to the static api_key if the command
+    fails or produces no output; drops the span if neither is usable.
 
     Never raises. Returns True on success, False on failure.
     """
@@ -751,8 +813,17 @@ def send_span(span_dict: dict) -> bool:
         elif target == "arize":
             project = backend["project_name"]
             endpoint = backend.get("endpoint", "otlp.arize.com:443")
-            api_key = backend["api_key"]
+            api_key = backend.get("api_key", "")
             space_id = backend.get("space_id", "")
+
+            token_command = backend.get("token_command", "")
+            if token_command:
+                fresh_token = _resolve_token_via_command(token_command)
+                if fresh_token:
+                    api_key = fresh_token
+                elif not api_key:
+                    error("token_command produced no token and no static api_key is set; dropping span")
+                    return False
 
             # Inject arize.project.name into span attributes (required by Arize)
             payload = _inject_arize_project_name(span_dict, project)

--- a/core/common.py
+++ b/core/common.py
@@ -153,7 +153,7 @@ class _Env:
         # ARIZE_OTLP_ENDPOINT (which is only consulted by the interactive setup
         # wizard when writing harness_cfg['endpoint'] to config.json). Lets a
         # team redirect spans to a non-Arize-branded OTLP collector (e.g. one
-        # that strips PII, or an internal Jaeger instance) without editing
+        # that strips PII, or an internal collector) without editing
         # config.json. See issue #120.
         return os.environ.get("CUSTOM_OTLP_ENDPOINT", "")
 

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -1323,16 +1323,15 @@ class TestSendSpan:
     @mock.patch("core.common._resolve_token_via_command")
     @mock.patch("core.common.resolve_backend")
     @mock.patch("core.common.urllib.request.urlopen")
-    def test_arize_token_command_used_as_bearer_token(self, mock_urlopen, mock_resolve, mock_token_cmd, monkeypatch):
+    def test_custom_token_command_used_as_bearer_token(self, mock_urlopen, mock_resolve, mock_token_cmd, monkeypatch):
         """When token_command is set, its output is used as the Authorization bearer token."""
         monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
         monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
 
         mock_resolve.return_value = {
-            "target": "arize",
+            "target": "custom",
             "api_key": "stale-static-key",
-            "space_id": "my-space",
-            "endpoint": "otlp.arize.com:443",
+            "endpoint": "otlp-collector.internal.example.com:443",
             "token_command": "fetch-token",
             "project_name": "proj",
         }
@@ -1352,7 +1351,7 @@ class TestSendSpan:
     @mock.patch("core.common._resolve_token_via_command")
     @mock.patch("core.common.resolve_backend")
     @mock.patch("core.common.urllib.request.urlopen")
-    def test_arize_token_command_falls_back_to_static_api_key(
+    def test_custom_token_command_falls_back_to_static_api_key(
         self, mock_urlopen, mock_resolve, mock_token_cmd, monkeypatch
     ):
         """If token_command fails (empty result), the static api_key is used instead."""
@@ -1360,10 +1359,9 @@ class TestSendSpan:
         monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
 
         mock_resolve.return_value = {
-            "target": "arize",
+            "target": "custom",
             "api_key": "fallback-key",
-            "space_id": "my-space",
-            "endpoint": "otlp.arize.com:443",
+            "endpoint": "otlp-collector.internal.example.com:443",
             "token_command": "fetch-token",
             "project_name": "proj",
         }
@@ -1380,16 +1378,15 @@ class TestSendSpan:
 
     @mock.patch("core.common._resolve_token_via_command")
     @mock.patch("core.common.resolve_backend")
-    def test_arize_token_command_no_fallback_drops_span(self, mock_resolve, mock_token_cmd, monkeypatch):
+    def test_custom_token_command_no_fallback_drops_span(self, mock_resolve, mock_token_cmd, monkeypatch):
         """If token_command fails and there's no static api_key, the span is dropped."""
         monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
         monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
 
         mock_resolve.return_value = {
-            "target": "arize",
+            "target": "custom",
             "api_key": "",
-            "space_id": "my-space",
-            "endpoint": "otlp.arize.com:443",
+            "endpoint": "otlp-collector.internal.example.com:443",
             "token_command": "fetch-token",
             "project_name": "proj",
         }
@@ -1399,16 +1396,16 @@ class TestSendSpan:
 
     @mock.patch("core.common.resolve_backend")
     @mock.patch("core.common.urllib.request.urlopen")
-    def test_arize_custom_otlp_endpoint_used_verbatim(self, mock_urlopen, mock_resolve, monkeypatch):
+    def test_custom_otlp_endpoint_used_verbatim(self, mock_urlopen, mock_resolve, monkeypatch):
         """resolve_backend's endpoint (as overridden by CUSTOM_OTLP_ENDPOINT) is used as-is."""
         monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
         monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
 
         mock_resolve.return_value = {
-            "target": "arize",
+            "target": "custom",
             "api_key": "my-key",
-            "space_id": "my-space",
             "endpoint": "otlp-collector.internal.example.com:443",
+            "token_command": "",
             "project_name": "proj",
         }
         mock_resp = mock.MagicMock()
@@ -1420,6 +1417,32 @@ class TestSendSpan:
         assert send_span(self._SAMPLE_SPAN) is True
         req = mock_urlopen.call_args[0][0]
         assert req.full_url == "https://otlp-collector.internal.example.com:443/v1/traces"
+        assert req.get_header("Authorization") == "Bearer my-key"
+        assert req.get_header("Space_id") is None
+
+    @mock.patch("core.common.resolve_backend")
+    @mock.patch("core.common.urllib.request.urlopen")
+    def test_custom_no_api_key_omits_authorization_header(self, mock_urlopen, mock_resolve, monkeypatch):
+        """A custom target with no api_key/token_command sends no Authorization header."""
+        monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
+        monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
+
+        mock_resolve.return_value = {
+            "target": "custom",
+            "api_key": "",
+            "endpoint": "otlp-collector.internal.example.com:443",
+            "token_command": "",
+            "project_name": "proj",
+        }
+        mock_resp = mock.MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = mock.Mock(return_value=mock_resp)
+        mock_resp.__exit__ = mock.Mock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        assert send_span(self._SAMPLE_SPAN) is True
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Authorization") is None
 
     @mock.patch("core.common.resolve_backend")
     def test_no_backend_returns_false(self, mock_resolve, monkeypatch):
@@ -1877,7 +1900,18 @@ class TestResolveBackend:
         stderr = capsys.readouterr().err
         assert "No service.name attribute found" in stderr
 
-    # ── CUSTOM_OTLP_ENDPOINT / token_command (issue #120) ──────────────────
+    # ── custom target: CUSTOM_OTLP_ENDPOINT / token_command (issue #120) ────
+
+    def test_custom_otlp_endpoint_selects_custom_target(self, monkeypatch):
+        """CUSTOM_OTLP_ENDPOINT alone resolves target=custom, no space_id required."""
+        monkeypatch.setenv("CUSTOM_OTLP_ENDPOINT", "otlp-collector.internal.example.com:443")
+        monkeypatch.setenv("CUSTOM_AUTH_COMMAND", "fetch-token")
+        monkeypatch.setattr("core.config.load_config", lambda: {})
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["target"] == "custom"
+        assert result["endpoint"] == "otlp-collector.internal.example.com:443"
+        assert "space_id" not in result
 
     def test_custom_otlp_endpoint_overrides_config_endpoint(self, monkeypatch):
         """CUSTOM_OTLP_ENDPOINT env wins over harness_cfg['endpoint']."""
@@ -1885,10 +1919,9 @@ class TestResolveBackend:
         cfg = {
             "harnesses": {
                 "claude-code": {
-                    "target": "arize",
-                    "endpoint": "otlp.arize.com:443",
+                    "target": "custom",
+                    "endpoint": "other-collector.example.com:443",
                     "api_key": "ak",
-                    "space_id": "sp",
                 },
             },
         }
@@ -1897,33 +1930,41 @@ class TestResolveBackend:
         result = resolve_backend(self._make_span("claude-code"))
         assert result["endpoint"] == "otlp-collector.internal.example.com:443"
 
-    def test_custom_otlp_endpoint_overrides_default(self, monkeypatch):
-        """CUSTOM_OTLP_ENDPOINT wins even with no config entry (default otlp.arize.com)."""
-        monkeypatch.setenv("ARIZE_API_KEY", "ak-env")
-        monkeypatch.setenv("ARIZE_SPACE_ID", "space-env")
-        monkeypatch.setenv("CUSTOM_OTLP_ENDPOINT", "custom-collector.example.com:443")
-        monkeypatch.setattr("core.config.load_config", lambda: {})
-
-        result = resolve_backend(self._make_span("claude-code"))
-        assert result["endpoint"] == "custom-collector.example.com:443"
-
-    def test_no_custom_otlp_endpoint_keeps_config_endpoint(self, monkeypatch):
-        """Without CUSTOM_OTLP_ENDPOINT, harness_cfg['endpoint'] is unaffected."""
+    def test_custom_endpoint_from_config_without_env(self, monkeypatch):
+        """A config-only 'custom' target (no CUSTOM_OTLP_ENDPOINT env) resolves from config.json."""
         monkeypatch.delenv("CUSTOM_OTLP_ENDPOINT", raising=False)
         cfg = {
             "harnesses": {
                 "claude-code": {
-                    "target": "arize",
-                    "endpoint": "otlp.arize.com:443",
+                    "target": "custom",
+                    "endpoint": "otlp-collector.internal.example.com:443",
                     "api_key": "ak",
-                    "space_id": "sp",
                 },
             },
         }
         monkeypatch.setattr("core.config.load_config", lambda: cfg)
 
         result = resolve_backend(self._make_span("claude-code"))
-        assert result["endpoint"] == "otlp.arize.com:443"
+        assert result["target"] == "custom"
+        assert result["endpoint"] == "otlp-collector.internal.example.com:443"
+
+    def test_custom_missing_endpoint_errors(self, capsys, monkeypatch):
+        """A 'custom' target with no endpoint anywhere → none, with an actionable error."""
+        monkeypatch.delenv("CUSTOM_OTLP_ENDPOINT", raising=False)
+        cfg = {
+            "harnesses": {
+                "claude-code": {
+                    "target": "custom",
+                    "api_key": "ak",
+                },
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["target"] == "none"
+        stderr = capsys.readouterr().err
+        assert "endpoint" in stderr
 
     def test_token_command_from_config(self, monkeypatch):
         """harness_cfg['token_command'] is surfaced on the resolved backend dict."""
@@ -1931,9 +1972,8 @@ class TestResolveBackend:
         cfg = {
             "harnesses": {
                 "claude-code": {
-                    "target": "arize",
-                    "endpoint": "otlp.arize.com:443",
-                    "space_id": "sp",
+                    "target": "custom",
+                    "endpoint": "otlp-collector.internal.example.com:443",
                     "token_command": "generate-token --for otlp-collector",
                 },
             },
@@ -1941,7 +1981,7 @@ class TestResolveBackend:
         monkeypatch.setattr("core.config.load_config", lambda: cfg)
 
         result = resolve_backend(self._make_span("claude-code"))
-        assert result["target"] == "arize"
+        assert result["target"] == "custom"
         assert result["token_command"] == "generate-token --for otlp-collector"
         assert result["api_key"] == ""
 
@@ -1951,8 +1991,8 @@ class TestResolveBackend:
         cfg = {
             "harnesses": {
                 "claude-code": {
-                    "target": "arize",
-                    "space_id": "sp",
+                    "target": "custom",
+                    "endpoint": "otlp-collector.internal.example.com:443",
                     "token_command": "config-token-cmd",
                 },
             },
@@ -1967,8 +2007,8 @@ class TestResolveBackend:
         cfg = {
             "harnesses": {
                 "claude-code": {
-                    "target": "arize",
-                    "space_id": "sp",
+                    "target": "custom",
+                    "endpoint": "otlp-collector.internal.example.com:443",
                     "token_command": "fetch-token",
                 },
             },
@@ -1976,7 +2016,7 @@ class TestResolveBackend:
         monkeypatch.setattr("core.config.load_config", lambda: cfg)
 
         result = resolve_backend(self._make_span("claude-code"))
-        assert result["target"] == "arize"
+        assert result["target"] == "custom"
         assert capsys.readouterr().err == ""
 
     def test_missing_api_key_and_token_command_errors(self, capsys, monkeypatch):
@@ -1984,8 +2024,8 @@ class TestResolveBackend:
         cfg = {
             "harnesses": {
                 "claude-code": {
-                    "target": "arize",
-                    "space_id": "sp",
+                    "target": "custom",
+                    "endpoint": "otlp-collector.internal.example.com:443",
                 },
             },
         }
@@ -1994,7 +2034,19 @@ class TestResolveBackend:
         result = resolve_backend(self._make_span("claude-code"))
         assert result["target"] == "none"
         stderr = capsys.readouterr().err
-        assert "token_command" in stderr
+        assert "api_key or token_command" in stderr
+
+    def test_custom_otlp_endpoint_takes_priority_over_arize_and_phoenix(self, monkeypatch):
+        """CUSTOM_OTLP_ENDPOINT wins even when ARIZE_*/PHOENIX_ENDPOINT are also set."""
+        monkeypatch.setenv("CUSTOM_OTLP_ENDPOINT", "otlp-collector.internal.example.com:443")
+        monkeypatch.setenv("ARIZE_API_KEY", "ak-env")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "space-env")
+        monkeypatch.setenv("PHOENIX_ENDPOINT", "http://env:6006")
+        monkeypatch.setattr("core.config.load_config", lambda: {})
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["target"] == "custom"
+        assert result["endpoint"] == "otlp-collector.internal.example.com:443"
 
 
 # ── send_span integration edge cases ─────────────────────────────────────

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -1334,7 +1334,7 @@ class TestSendSpan:
             "api_key": "stale-static-key",
             "space_id": "my-space",
             "endpoint": "otlp.arize.com:443",
-            "token_command": "usso -print",
+            "token_command": "fetch-token",
             "project_name": "proj",
         }
         mock_token_cmd.return_value = "fresh-rotated-token"
@@ -1346,7 +1346,7 @@ class TestSendSpan:
 
         assert send_span(self._SAMPLE_SPAN) is True
 
-        mock_token_cmd.assert_called_once_with("usso -print")
+        mock_token_cmd.assert_called_once_with("fetch-token")
         req = mock_urlopen.call_args[0][0]
         assert req.get_header("Authorization") == "Bearer fresh-rotated-token"
 
@@ -1365,7 +1365,7 @@ class TestSendSpan:
             "api_key": "fallback-key",
             "space_id": "my-space",
             "endpoint": "otlp.arize.com:443",
-            "token_command": "usso -print",
+            "token_command": "fetch-token",
             "project_name": "proj",
         }
         mock_token_cmd.return_value = ""
@@ -1391,7 +1391,7 @@ class TestSendSpan:
             "api_key": "",
             "space_id": "my-space",
             "endpoint": "otlp.arize.com:443",
-            "token_command": "usso -print",
+            "token_command": "fetch-token",
             "project_name": "proj",
         }
         mock_token_cmd.return_value = ""
@@ -1409,7 +1409,7 @@ class TestSendSpan:
             "target": "arize",
             "api_key": "my-key",
             "space_id": "my-space",
-            "endpoint": "jaeger-otlp-staging.uberinternal.com:443",
+            "endpoint": "otlp-collector.internal.example.com:443",
             "project_name": "proj",
         }
         mock_resp = mock.MagicMock()
@@ -1420,7 +1420,7 @@ class TestSendSpan:
 
         assert send_span(self._SAMPLE_SPAN) is True
         req = mock_urlopen.call_args[0][0]
-        assert req.full_url == "https://jaeger-otlp-staging.uberinternal.com:443/v1/traces"
+        assert req.full_url == "https://otlp-collector.internal.example.com:443/v1/traces"
 
     @mock.patch("core.common.resolve_backend")
     def test_no_backend_returns_false(self, mock_resolve, monkeypatch):
@@ -1882,7 +1882,7 @@ class TestResolveBackend:
 
     def test_custom_otlp_endpoint_overrides_config_endpoint(self, monkeypatch):
         """CUSTOM_OTLP_ENDPOINT env wins over harness_cfg['endpoint']."""
-        monkeypatch.setenv("CUSTOM_OTLP_ENDPOINT", "jaeger-otlp-staging.uberinternal.com:443")
+        monkeypatch.setenv("CUSTOM_OTLP_ENDPOINT", "otlp-collector.internal.example.com:443")
         cfg = {
             "harnesses": {
                 "claude-code": {
@@ -1896,7 +1896,7 @@ class TestResolveBackend:
         monkeypatch.setattr("core.config.load_config", lambda: cfg)
 
         result = resolve_backend(self._make_span("claude-code"))
-        assert result["endpoint"] == "jaeger-otlp-staging.uberinternal.com:443"
+        assert result["endpoint"] == "otlp-collector.internal.example.com:443"
 
     def test_custom_otlp_endpoint_overrides_default(self, monkeypatch):
         """CUSTOM_OTLP_ENDPOINT wins even with no config entry (default otlp.arize.com)."""
@@ -1935,7 +1935,7 @@ class TestResolveBackend:
                     "target": "arize",
                     "endpoint": "otlp.arize.com:443",
                     "space_id": "sp",
-                    "token_command": "usso -ussh jaeger-otlp-staging.uberinternal.com -print",
+                    "token_command": "generate-token --for otlp-collector",
                 },
             },
         }
@@ -1943,7 +1943,7 @@ class TestResolveBackend:
 
         result = resolve_backend(self._make_span("claude-code"))
         assert result["target"] == "arize"
-        assert result["token_command"] == "usso -ussh jaeger-otlp-staging.uberinternal.com -print"
+        assert result["token_command"] == "generate-token --for otlp-collector"
         assert result["api_key"] == ""
 
     def test_custom_auth_command_env_overrides_config_token_command(self, monkeypatch):
@@ -1970,7 +1970,7 @@ class TestResolveBackend:
                 "claude-code": {
                     "target": "arize",
                     "space_id": "sp",
-                    "token_command": "usso -print",
+                    "token_command": "fetch-token",
                 },
             },
         }

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -16,7 +16,6 @@ from core.common import (
     _attrs_to_otlp,
     _otlp_to_phoenix_payload,
     _resolve_kind,
-    _resolve_token_via_command,
     _to_otlp_attr_value,
     build_multi_span,
     build_span,

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -16,6 +16,7 @@ from core.common import (
     _attrs_to_otlp,
     _otlp_to_phoenix_payload,
     _resolve_kind,
+    _resolve_token_via_command,
     _to_otlp_attr_value,
     build_multi_span,
     build_span,
@@ -1320,6 +1321,107 @@ class TestSendSpan:
         assert send_span(self._SAMPLE_SPAN) is False
         assert "unable to validate authorization from span" in capsys.readouterr().err
 
+    @mock.patch("core.common._resolve_token_via_command")
+    @mock.patch("core.common.resolve_backend")
+    @mock.patch("core.common.urllib.request.urlopen")
+    def test_arize_token_command_used_as_bearer_token(self, mock_urlopen, mock_resolve, mock_token_cmd, monkeypatch):
+        """When token_command is set, its output is used as the Authorization bearer token."""
+        monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
+        monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
+
+        mock_resolve.return_value = {
+            "target": "arize",
+            "api_key": "stale-static-key",
+            "space_id": "my-space",
+            "endpoint": "otlp.arize.com:443",
+            "token_command": "usso -print",
+            "project_name": "proj",
+        }
+        mock_token_cmd.return_value = "fresh-rotated-token"
+        mock_resp = mock.MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = mock.Mock(return_value=mock_resp)
+        mock_resp.__exit__ = mock.Mock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        assert send_span(self._SAMPLE_SPAN) is True
+
+        mock_token_cmd.assert_called_once_with("usso -print")
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer fresh-rotated-token"
+
+    @mock.patch("core.common._resolve_token_via_command")
+    @mock.patch("core.common.resolve_backend")
+    @mock.patch("core.common.urllib.request.urlopen")
+    def test_arize_token_command_falls_back_to_static_api_key(
+        self, mock_urlopen, mock_resolve, mock_token_cmd, monkeypatch
+    ):
+        """If token_command fails (empty result), the static api_key is used instead."""
+        monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
+        monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
+
+        mock_resolve.return_value = {
+            "target": "arize",
+            "api_key": "fallback-key",
+            "space_id": "my-space",
+            "endpoint": "otlp.arize.com:443",
+            "token_command": "usso -print",
+            "project_name": "proj",
+        }
+        mock_token_cmd.return_value = ""
+        mock_resp = mock.MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = mock.Mock(return_value=mock_resp)
+        mock_resp.__exit__ = mock.Mock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        assert send_span(self._SAMPLE_SPAN) is True
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer fallback-key"
+
+    @mock.patch("core.common._resolve_token_via_command")
+    @mock.patch("core.common.resolve_backend")
+    def test_arize_token_command_no_fallback_drops_span(self, mock_resolve, mock_token_cmd, monkeypatch):
+        """If token_command fails and there's no static api_key, the span is dropped."""
+        monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
+        monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
+
+        mock_resolve.return_value = {
+            "target": "arize",
+            "api_key": "",
+            "space_id": "my-space",
+            "endpoint": "otlp.arize.com:443",
+            "token_command": "usso -print",
+            "project_name": "proj",
+        }
+        mock_token_cmd.return_value = ""
+
+        assert send_span(self._SAMPLE_SPAN) is False
+
+    @mock.patch("core.common.resolve_backend")
+    @mock.patch("core.common.urllib.request.urlopen")
+    def test_arize_custom_otlp_endpoint_used_verbatim(self, mock_urlopen, mock_resolve, monkeypatch):
+        """resolve_backend's endpoint (as overridden by CUSTOM_OTLP_ENDPOINT) is used as-is."""
+        monkeypatch.delenv("ARIZE_DRY_RUN", raising=False)
+        monkeypatch.delenv("ARIZE_VERBOSE", raising=False)
+
+        mock_resolve.return_value = {
+            "target": "arize",
+            "api_key": "my-key",
+            "space_id": "my-space",
+            "endpoint": "jaeger-otlp-staging.uberinternal.com:443",
+            "project_name": "proj",
+        }
+        mock_resp = mock.MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = mock.Mock(return_value=mock_resp)
+        mock_resp.__exit__ = mock.Mock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        assert send_span(self._SAMPLE_SPAN) is True
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://jaeger-otlp-staging.uberinternal.com:443/v1/traces"
+
     @mock.patch("core.common.resolve_backend")
     def test_no_backend_returns_false(self, mock_resolve, monkeypatch):
         """send_span returns False when no backend is configured."""
@@ -1411,6 +1513,8 @@ class TestResolveBackend:
             "ARIZE_PROJECT_NAME",
             "PHOENIX_PROJECT",
             "PHOENIX_PROJECT_NAME",
+            "CUSTOM_OTLP_ENDPOINT",
+            "CUSTOM_AUTH_COMMAND",
         ):
             monkeypatch.delenv(key, raising=False)
 
@@ -1773,6 +1877,125 @@ class TestResolveBackend:
         assert result["target"] == "none"
         stderr = capsys.readouterr().err
         assert "No service.name attribute found" in stderr
+
+    # ── CUSTOM_OTLP_ENDPOINT / token_command (issue #120) ──────────────────
+
+    def test_custom_otlp_endpoint_overrides_config_endpoint(self, monkeypatch):
+        """CUSTOM_OTLP_ENDPOINT env wins over harness_cfg['endpoint']."""
+        monkeypatch.setenv("CUSTOM_OTLP_ENDPOINT", "jaeger-otlp-staging.uberinternal.com:443")
+        cfg = {
+            "harnesses": {
+                "claude-code": {
+                    "target": "arize",
+                    "endpoint": "otlp.arize.com:443",
+                    "api_key": "ak",
+                    "space_id": "sp",
+                },
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["endpoint"] == "jaeger-otlp-staging.uberinternal.com:443"
+
+    def test_custom_otlp_endpoint_overrides_default(self, monkeypatch):
+        """CUSTOM_OTLP_ENDPOINT wins even with no config entry (default otlp.arize.com)."""
+        monkeypatch.setenv("ARIZE_API_KEY", "ak-env")
+        monkeypatch.setenv("ARIZE_SPACE_ID", "space-env")
+        monkeypatch.setenv("CUSTOM_OTLP_ENDPOINT", "custom-collector.example.com:443")
+        monkeypatch.setattr("core.config.load_config", lambda: {})
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["endpoint"] == "custom-collector.example.com:443"
+
+    def test_no_custom_otlp_endpoint_keeps_config_endpoint(self, monkeypatch):
+        """Without CUSTOM_OTLP_ENDPOINT, harness_cfg['endpoint'] is unaffected."""
+        monkeypatch.delenv("CUSTOM_OTLP_ENDPOINT", raising=False)
+        cfg = {
+            "harnesses": {
+                "claude-code": {
+                    "target": "arize",
+                    "endpoint": "otlp.arize.com:443",
+                    "api_key": "ak",
+                    "space_id": "sp",
+                },
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["endpoint"] == "otlp.arize.com:443"
+
+    def test_token_command_from_config(self, monkeypatch):
+        """harness_cfg['token_command'] is surfaced on the resolved backend dict."""
+        monkeypatch.delenv("CUSTOM_AUTH_COMMAND", raising=False)
+        cfg = {
+            "harnesses": {
+                "claude-code": {
+                    "target": "arize",
+                    "endpoint": "otlp.arize.com:443",
+                    "space_id": "sp",
+                    "token_command": "usso -ussh jaeger-otlp-staging.uberinternal.com -print",
+                },
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["target"] == "arize"
+        assert result["token_command"] == "usso -ussh jaeger-otlp-staging.uberinternal.com -print"
+        assert result["api_key"] == ""
+
+    def test_custom_auth_command_env_overrides_config_token_command(self, monkeypatch):
+        """CUSTOM_AUTH_COMMAND env wins over harness_cfg['token_command']."""
+        monkeypatch.setenv("CUSTOM_AUTH_COMMAND", "env-token-cmd")
+        cfg = {
+            "harnesses": {
+                "claude-code": {
+                    "target": "arize",
+                    "space_id": "sp",
+                    "token_command": "config-token-cmd",
+                },
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["token_command"] == "env-token-cmd"
+
+    def test_token_command_satisfies_missing_api_key(self, capsys, monkeypatch):
+        """A token_command (with no static api_key) is sufficient — no 'missing api_key' error."""
+        cfg = {
+            "harnesses": {
+                "claude-code": {
+                    "target": "arize",
+                    "space_id": "sp",
+                    "token_command": "usso -print",
+                },
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["target"] == "arize"
+        assert capsys.readouterr().err == ""
+
+    def test_missing_api_key_and_token_command_errors(self, capsys, monkeypatch):
+        """Neither api_key nor token_command present → none, with an actionable error."""
+        cfg = {
+            "harnesses": {
+                "claude-code": {
+                    "target": "arize",
+                    "space_id": "sp",
+                },
+            },
+        }
+        monkeypatch.setattr("core.config.load_config", lambda: cfg)
+
+        result = resolve_backend(self._make_span("claude-code"))
+        assert result["target"] == "none"
+        stderr = capsys.readouterr().err
+        assert "token_command" in stderr
 
 
 # ── send_span integration edge cases ─────────────────────────────────────


### PR DESCRIPTION
## Summary

resolves #120

Adds a new `custom` backend target — distinct from `arize` and `phoenix` — for routing spans to any generic OTLP/HTTP collector (e.g. an internal Jaeger instance), closing the endpoint-routing gap #120 asks for plus a related credential-rotation gap raised in its discussion.

An earlier revision of this PR nested this behavior inside the `arize` target's branches. That coupled two different things: real Arize semantics (which require an Arize-issued `api_key` and `space_id`, and get an `arize.project.name` attribute injected onto every span) with a generic custom-collector use case that has no concept of `space_id` at all. This revision splits them into a genuinely separate target:

- `CUSTOM_OTLP_ENDPOINT` (env var): selects the `custom` target (highest priority — this is the most explicit thing a caller can say) and sets its endpoint. Lets a team point spans at a non-Arize-branded OTLP collector without touching `config.json`.
- `CUSTOM_AUTH_COMMAND` (env var) / `harnesses.<name>.token_command` (config field): a shell command run immediately before each span POST to produce a fresh bearer token, for backends whose credentials expire faster than a session (e.g. an SSO-derived token). Overrides a static `api_key` when set; falls back to it (or drops the span, logging via `error()`) if the command fails — never raises.

The `custom` target requires only an `endpoint` and either an `api_key` or a `token_command` — no `space_id`. It sends the raw OTLP payload as-is: no `arize.project.name` injection, no `space_id` header, and a conditional `Authorization: Bearer` header only when a key is available (mirroring the existing `phoenix` target's shape).

The `arize` target itself is unchanged from `main` — this PR is purely additive.

Both follow the existing precedence convention (env var > `harnesses.<name>` in config.json > default).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## How tested

- `uv run pytest tests/ -m "not slow"` — 2582 passed, 2 skipped
- `uv run pre-commit run --all-files` — all hooks passed (isort, black, ruff, mypy across core + all harness packages)
- Ran the repo's `code-review` skill locally (dry-run) against `origin/main...HEAD`: no blocking findings — no 3.10+ syntax introduced, no new runtime dependencies (`subprocess` is stdlib), `shell=True` in `_resolve_token_via_command` executes an admin-configured command (config.json/env var), not span-derived input, matching the trust model of existing credential-rotation wrappers in the wild.

## Checklist

- [x] Tests pass (`uv run pytest tests/ -m "not slow"`)
- [x] Pre-commit clean (`uv run pre-commit run --all-files`)
- [x] Ran the `code-review` skill and addressed findings
- [ ] Docs updated if needed — happy to add README coverage for the `custom` target if maintainers want it in this PR
