### PR TITLE
fix(claude): read Claude transcripts as UTF-8 on all three call sites

### DIFF
--- a/tests/tracing/claude/test_claude_transcript_encoding.py
+++ b/tests/tracing/claude/test_claude_transcript_encoding.py
@@ -1,7 +1,6 @@
 """Tests for reading claude transcripts as UTF-8"""
 
 import builtins
-import io
 import json
 from contextlib import contextmanager
 from pathlib import Path
@@ -27,7 +26,18 @@ def _non_utf8_locale():
             encoding = "ascii"
         return real_open(file, mode, buffering, encoding, errors, newline, closefd, opener)
 
-    with mock.patch.object(builtins, "open", locale_open), mock.patch.object(io, "open", locale_open):
+    real_read_text = Path.read_text
+
+    def locale_read_text(self, encoding=None, *args, **kwargs):
+        return real_read_text(self, encoding or "ascii", *args, **kwargs)
+
+    # ``open()`` in handlers.py resolves to builtins.open. pathlib reaches
+    # io.open through version-specific bindings (3.10 snapshots it at import),
+    # so patch ``Path.read_text`` itself rather than io.open.
+    with (
+        mock.patch.object(builtins, "open", locale_open),
+        mock.patch.object(Path, "read_text", locale_read_text),
+    ):
         yield
 
 

--- a/tests/tracing/claude/test_claude_transcript_encoding.py
+++ b/tests/tracing/claude/test_claude_transcript_encoding.py
@@ -58,7 +58,7 @@ def _write_transcript(path: Path) -> None:
             },
         },
     ]
-    path.write_bytes(("\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n").encode("utf-8"))
+    path.write_text("\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n", encoding="utf-8")
 
 
 @pytest.fixture
@@ -73,8 +73,6 @@ def state(tmp_path: Path) -> StateManager:
     sm = StateManager(state_dir=tmp_path, state_file=tmp_path / "state.json", lock_path=tmp_path / ".lock")
     sm.init_state()
     sm.set("session_id", "test-session")
-    sm.set("project_name", "test-project")
-    sm.set("trace_count", "0")
     return sm
 
 
@@ -125,7 +123,7 @@ def test_parse_claude_transcript_under_non_utf8_locale(transcript: Path):
     with _non_utf8_locale():
         graph = parse_claude_transcript(transcript, root)
 
-    assert [d.code for d in graph.diagnostics if d.code == "transcript_read_error"] == []
+    assert not graph.diagnostics
     models = [e for e in graph.events if isinstance(e, ModelCallEvent)]
     assert len(models) == 1
     assert models[0].output == NON_ASCII_TEXT

--- a/tests/tracing/claude/test_claude_transcript_encoding.py
+++ b/tests/tracing/claude/test_claude_transcript_encoding.py
@@ -1,0 +1,121 @@
+"""Tests for reading claude transcripts as UTF-8"""
+
+import builtins
+import io
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from core.common import StateManager
+from core.event_model import EventStatus, ModelCallEvent, TurnEvent
+from tracing.claude_code.hooks.handlers import _handle_user_prompt_submit, _scan_transcript_for_usage
+from tracing.claude_code.hooks.transcript import parse_claude_transcript
+
+NON_ASCII_TEXT = "Done ✓ — Привет 한글 العربية 😏"
+
+
+@contextmanager
+def _non_utf8_locale():
+    """Make implicit-encoding opens decode as ASCII, like a non-UTF-8 Windows codepage."""
+    real_open = builtins.open
+
+    def locale_open(file, mode="r", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None):
+        if "b" not in mode and encoding in (None, "locale"):
+            encoding = "ascii"
+        return real_open(file, mode, buffering, encoding, errors, newline, closefd, opener)
+
+    with mock.patch.object(builtins, "open", locale_open), mock.patch.object(io, "open", locale_open):
+        yield
+
+
+def _write_transcript(path: Path) -> None:
+    rows = [
+        {"type": "user", "uuid": "user-1", "message": {"role": "user", "content": NON_ASCII_TEXT}},
+        {
+            "type": "assistant",
+            "uuid": "assistant-1",
+            "timestamp": "2026-01-01T12:00:01.000Z",
+            "requestId": "req-1",
+            "message": {
+                "id": "msg-1",
+                "role": "assistant",
+                "model": "claude-test",
+                "content": [{"type": "text", "text": NON_ASCII_TEXT}],
+                "usage": {"input_tokens": 11, "output_tokens": 7},
+            },
+        },
+    ]
+    path.write_bytes(("\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n").encode("utf-8"))
+
+
+@pytest.fixture
+def transcript(tmp_path: Path) -> Path:
+    path = tmp_path / "session.jsonl"
+    _write_transcript(path)
+    return path
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> StateManager:
+    sm = StateManager(state_dir=tmp_path, state_file=tmp_path / "state.json", lock_path=tmp_path / ".lock")
+    sm.init_state()
+    sm.set("session_id", "test-session")
+    sm.set("project_name", "test-project")
+    sm.set("trace_count", "0")
+    return sm
+
+
+def test_simulated_locale_rejects_non_ascii_transcript(transcript: Path):
+    """Sanity check: the simulation really fails on an implicit-encoding read."""
+    with _non_utf8_locale(), pytest.raises(UnicodeDecodeError):
+        with open(transcript) as f:
+            f.read()
+    with _non_utf8_locale(), pytest.raises(UnicodeDecodeError):
+        transcript.read_text()
+
+
+def test_user_prompt_submit_counts_lines_under_non_utf8_locale(transcript: Path, state: StateManager):
+    """The trace-start line is recorded even when the transcript holds non-ASCII text."""
+    with (
+        _non_utf8_locale(),
+        mock.patch("tracing.claude_code.hooks.handlers.resolve_session", return_value=state),
+    ):
+        _handle_user_prompt_submit({"prompt": NON_ASCII_TEXT, "transcript_path": str(transcript)})
+
+    assert state.get("trace_start_line") == "2"
+
+
+def test_scan_transcript_for_usage_under_non_utf8_locale(transcript: Path):
+    """Token usage and output text are extracted regardless of host locale."""
+    with _non_utf8_locale():
+        output, usage, model = _scan_transcript_for_usage(transcript, 0)
+
+    assert model == "claude-test"
+    assert usage.prompt == 11
+    assert usage.completion == 7
+    assert NON_ASCII_TEXT in output
+
+
+def test_parse_claude_transcript_under_non_utf8_locale(transcript: Path):
+    """The high-fidelity parser returns model children, not a root-only graph."""
+    root = TurnEvent(
+        event_id="turn-1",
+        session_id="test-session",
+        turn_id="turn-1",
+        sequence=0,
+        started_at_ms=1_767_268_800_000,
+        ended_at_ms=None,
+        status=EventStatus.RUNNING,
+        input="prompt",
+    )
+
+    with _non_utf8_locale():
+        graph = parse_claude_transcript(transcript, root)
+
+    assert [d.code for d in graph.diagnostics if d.code == "transcript_read_error"] == []
+    models = [e for e in graph.events if isinstance(e, ModelCallEvent)]
+    assert len(models) == 1
+    assert models[0].output == NON_ASCII_TEXT

--- a/tracing/claude_code/hooks/handlers.py
+++ b/tracing/claude_code/hooks/handlers.py
@@ -394,7 +394,7 @@ def _handle_user_prompt_submit(input_json: dict) -> None:
     # Track transcript position
     transcript = input_json.get("transcript_path", "")
     if transcript and Path(transcript).is_file():
-        with open(transcript) as f:
+        with open(transcript, encoding="utf-8") as f:
             line_count = sum(1 for _ in f)
         state.set("trace_start_line", str(line_count))
     else:
@@ -464,7 +464,7 @@ def _scan_transcript_for_usage(
     # authoritative. Records with no identity at all are counted individually.
     last_usage: "dict[object, dict]" = {}
 
-    with open(transcript) as f:
+    with open(transcript, encoding="utf-8") as f:
         for i, line in enumerate(f):
             if i < start_line:
                 continue

--- a/tracing/claude_code/hooks/transcript.py
+++ b/tracing/claude_code/hooks/transcript.py
@@ -41,7 +41,7 @@ def parse_claude_transcript(
     sequence = root_event.sequence + 1
 
     try:
-        lines = transcript.read_text().splitlines()
+        lines = transcript.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeError) as exc:
         graph.diagnostics = [
             GraphDiagnostic(


### PR DESCRIPTION
## Summary

Fixes #88, Fixes #129. Supersedes #91.

Claude Code writes its JSONL transcript as UTF-8, but three reads in the Claude hooks used the host locale encoding. On Windows (cp1252, cp949, ...) any non-ASCII byte in the transcript raises `UnicodeDecodeError`:

- `handlers.py` `_handle_user_prompt_submit` and `_scan_transcript_for_usage`: the hook crashes, the wrapper logs and exits 0, and the turn is dropped (`Session complete: 0 traces`).
- `transcript.py` `parse_claude_transcript`: the parser catches the error and returns a root-only graph, so the turn lands without its LLM/tool child spans.

This PR passes `encoding="utf-8"` at all three sites, matching the Codex and Copilot adapters.

Co-authored by @moongioh — the two `handlers.py` fixes are their commit from #91, carried here with `Co-authored-by` credit. This PR also addresses the third call site in `transcript.py:44` that @tarasiscom caught on their cp1252 machine (#129) and that was requested in the #91 review but never pushed.

The fourth site, `_read_stdin`, was already fixed in #124.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## How tested

New `tests/tracing/claude/test_claude_transcript_encoding.py` simulates a non-UTF-8 host locale (implicit-encoding opens decode as ASCII, the strictest stand-in for an undefined cp1252 byte such as `0x8f`) and exercises all three read paths with Cyrillic, Hangul, Arabic and emoji text.

- Without the fix: 3 of 4 new tests fail.
- With the fix: 4 of 4 pass.
- `uv run pytest tests/tracing/claude tests/core -m "not slow"`: 1138 passed, 1 skipped.
- `uv run pre-commit run --files <changed files>`: clean.

Workaround for users until this lands: set `PYTHONUTF8=1` in the environment the hooks run in.

## Checklist

- [x] Tests pass (`uv run pytest tests/ -m "not slow"`)
- [x] Pre-commit clean (`uv run pre-commit run --all-files`)
- [x] Ran the `code-review` skill and addressed findings
- [x] Docs updated if needed (not needed)
