### PR TITLE
fix/codex preserve third party otel

### DIFF
--- a/tests/tracing/codex/test_install_codex.py
+++ b/tests/tracing/codex/test_install_codex.py
@@ -155,6 +155,19 @@ class TestTomlHelpers:
         raw = p.read_text()
         assert 'desc = "it\'s a value"' in raw
 
+    def test_roundtrip_float(self, tmp_path):
+        """A float value round-trips as a float, not a string (issue #94 review)."""
+        data = {"otel_x": 1.5}
+        p = tmp_path / "config.toml"
+        codex_toml._toml_write(data, p)
+
+        raw = p.read_text()
+        assert "otel_x = 1.5" in raw
+
+        parsed = codex_toml._toml_load_strict(p)
+        assert parsed["otel_x"] == 1.5
+        assert isinstance(parsed["otel_x"], float)
+
 
 class TestTomlLoadStrict:
     """Unit tests for _toml_load_strict's own contract, independent of install()."""
@@ -589,6 +602,258 @@ class TestDryRun:
 
         assert toml_path.is_file()
         assert env_path.is_file()
+
+
+# ---------------------------------------------------------------------------
+# Legacy [otel.exporter.otlp-http] cleanup — third-party preservation (#94)
+# ---------------------------------------------------------------------------
+#
+# cleanup_legacy_install() runs at the top of both install() and uninstall()
+# (tracing/codex/install.py), calling _strip_v1_otel_block() with the same
+# arguments either way — so exercising that function once for each of these
+# scenarios covers both call sites. Ownership requires the exact shape Arize
+# writes (loopback /v1/logs endpoint, protocol = "json", no other keys); a
+# loopback host/port alone must never be treated as proof of ownership.
+
+
+_THIRD_PARTY_OTEL_FIXTURE = (
+    "[otel]\n"
+    "log_user_prompt = true\n"
+    'metrics_exporter = "none"\n'
+    "\n"
+    "[otel.exporter.otlp-http]\n"
+    'endpoint = "http://127.0.0.1:4318/v1/logs"\n'
+    'protocol = "binary"\n'
+    'headers = { Authorization = "Bearer example-redacted" }\n'
+    "\n"
+    "[otel.trace_exporter.otlp-http]\n"
+    'endpoint = "http://127.0.0.1:4318/v1/traces"\n'
+    'protocol = "binary"\n'
+)
+
+
+class TestLegacyOtelCleanup:
+    """Regression coverage for issue #94."""
+
+    def test_third_party_fixture_untouched_on_install_path(self, tmp_path):
+        """Simulates the cleanup call install() makes at startup."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(_THIRD_PARTY_OTEL_FIXTURE)
+
+        from tracing.codex.install_legacy import _strip_v1_otel_block
+
+        _strip_v1_otel_block(config_path)
+
+        assert config_path.read_text() == _THIRD_PARTY_OTEL_FIXTURE
+
+    def test_third_party_fixture_untouched_on_uninstall_path(self, tmp_path):
+        """uninstall() calls the identical cleanup — running it again must still no-op."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(_THIRD_PARTY_OTEL_FIXTURE)
+
+        from tracing.codex.install_legacy import _strip_v1_otel_block
+
+        _strip_v1_otel_block(config_path)  # simulated install-path cleanup
+        _strip_v1_otel_block(config_path)  # simulated uninstall-path cleanup
+
+        assert config_path.read_text() == _THIRD_PARTY_OTEL_FIXTURE
+
+    def test_arize_owned_block_is_removed_other_otel_entries_survive(self, tmp_path):
+        """An Arize-owned exporter is removed; sibling [otel] content survives."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            "[otel]\n"
+            "log_user_prompt = true\n"
+            "\n"
+            "[otel.exporter.otlp-http]\n"
+            'endpoint = "http://127.0.0.1:4318/v1/logs"\n'
+            'protocol = "json"\n'
+            "\n"
+            "[otel.trace_exporter.otlp-http]\n"
+            'endpoint = "http://127.0.0.1:4318/v1/traces"\n'
+            'protocol = "binary"\n'
+        )
+        from tracing.codex.install_legacy import _strip_v1_otel_block
+
+        _strip_v1_otel_block(config_path)
+
+        content = config_path.read_text()
+        assert "[otel.exporter.otlp-http]" not in content
+        assert "http://127.0.0.1:4318/v1/logs" not in content
+        assert "log_user_prompt = true" in content
+        assert "[otel.trace_exporter.otlp-http]" in content
+        assert 'endpoint = "http://127.0.0.1:4318/v1/traces"' in content
+
+    def test_owned_looking_block_with_extra_key_is_preserved(self, tmp_path):
+        """A block shaped like Arize's but carrying an extra key (headers) is
+        third-party and must survive byte-for-byte."""
+        config_path = tmp_path / "config.toml"
+        original = (
+            "[otel.exporter.otlp-http]\n"
+            'endpoint = "http://127.0.0.1:4318/v1/logs"\n'
+            'protocol = "json"\n'
+            'headers = { Authorization = "Bearer secret" }\n'
+        )
+        config_path.write_text(original)
+        from tracing.codex.install_legacy import _strip_v1_otel_block
+
+        _strip_v1_otel_block(config_path)
+
+        assert config_path.read_text() == original
+
+    def test_dry_run_changes_nothing(self, tmp_path, monkeypatch):
+        """ARIZE_DRY_RUN=true must not touch the file even when the block is owned."""
+        config_path = tmp_path / "config.toml"
+        original = (
+            "[otel]\nlog_user_prompt = true\n\n"
+            "[otel.exporter.otlp-http]\n"
+            'endpoint = "http://127.0.0.1:4318/v1/logs"\n'
+            'protocol = "json"\n'
+        )
+        config_path.write_text(original)
+        monkeypatch.setenv("ARIZE_DRY_RUN", "true")
+
+        from tracing.codex.install_legacy import _strip_v1_otel_block
+
+        _strip_v1_otel_block(config_path)
+
+        assert config_path.read_text() == original
+
+    def test_cleanup_is_idempotent(self, tmp_path):
+        """Running the cleanup twice removes the owned block once, then no-ops."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            "[otel]\nlog_user_prompt = true\n\n"
+            "[otel.exporter.otlp-http]\n"
+            'endpoint = "http://127.0.0.1:4318/v1/logs"\n'
+            'protocol = "json"\n'
+        )
+        from tracing.codex.install_legacy import _strip_v1_otel_block
+
+        _strip_v1_otel_block(config_path)
+        once = config_path.read_text()
+        assert "[otel.exporter.otlp-http]" not in once
+
+        _strip_v1_otel_block(config_path)
+        twice = config_path.read_text()
+        assert twice == once
+
+    def test_inline_table_syntax_is_left_untouched(self, tmp_path):
+        """An Arize-shaped exporter written as an inline table has no literal
+        ``[otel.exporter.otlp-http]`` header line to locate — leave it alone
+        rather than falling back to a dict rewrite that could touch the wrong
+        text or (per issue #94 review) append a duplicate table."""
+        config_path = tmp_path / "config.toml"
+        original = "[otel.exporter]\n" 'otlp-http = { endpoint = "http://127.0.0.1:4318/v1/logs", protocol = "json" }\n'
+        config_path.write_text(original)
+        from tracing.codex.install_legacy import _strip_v1_otel_block
+
+        _strip_v1_otel_block(config_path)
+
+        assert config_path.read_text() == original
+
+    def test_quoted_key_header_is_left_untouched(self, tmp_path):
+        """A quoted-key header (``[otel.exporter."otlp-http"]``) is not the
+        literal bare header Arize writes, so it must be left alone too."""
+        config_path = tmp_path / "config.toml"
+        original = '[otel.exporter."otlp-http"]\n' 'endpoint = "http://127.0.0.1:4318/v1/logs"\n' 'protocol = "json"\n'
+        config_path.write_text(original)
+        from tracing.codex.install_legacy import _strip_v1_otel_block
+
+        _strip_v1_otel_block(config_path)
+
+        assert config_path.read_text() == original
+
+    def test_header_inside_multiline_string_is_not_matched(self, tmp_path):
+        """A line that merely *looks like* the header inside a multi-line
+        string must not be treated as the table to remove; the real table
+        elsewhere in the file is still removed, and the string survives."""
+        config_path = tmp_path / "config.toml"
+        original = (
+            "[otel]\n"
+            'note = """\n'
+            "[otel.exporter.otlp-http]\n"
+            '"""\n'
+            "\n"
+            "[otel.exporter.otlp-http]\n"
+            'endpoint = "http://127.0.0.1:4318/v1/logs"\n'
+            'protocol = "json"\n'
+        )
+        config_path.write_text(original)
+        from tracing.codex.install_legacy import _strip_v1_otel_block
+
+        _strip_v1_otel_block(config_path)
+
+        content = config_path.read_text()
+        # The string is untouched, including the fake header line inside it.
+        assert '"""\n[otel.exporter.otlp-http]\n"""' in content
+        # The real table is gone.
+        assert content.count("[otel.exporter.otlp-http]") == 1
+        assert "http://127.0.0.1:4318/v1/logs" not in content
+        # And the file is valid TOML again.
+        import tomllib
+
+        tomllib.loads(content)
+
+    def test_trailing_comment_before_next_table_is_preserved(self, tmp_path):
+        """A comment that belongs to the table *after* the removed one must
+        survive the removal (issue #94 review)."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            "[otel.exporter.otlp-http]\n"
+            'endpoint = "http://127.0.0.1:4318/v1/logs"\n'
+            'protocol = "json"\n'
+            "\n"
+            "# my own trace exporter, do not touch\n"
+            "[otel.trace_exporter.otlp-http]\n"
+            'endpoint = "http://127.0.0.1:4318/v1/traces"\n'
+            'protocol = "binary"\n'
+        )
+        from tracing.codex.install_legacy import _strip_v1_otel_block
+
+        _strip_v1_otel_block(config_path)
+
+        content = config_path.read_text()
+        assert "[otel.exporter.otlp-http]" not in content
+        assert "# my own trace exporter, do not touch" in content
+        assert "[otel.trace_exporter.otlp-http]" in content
+
+
+class TestEndToEndThirdPartyOtelPreservation:
+    """End-to-end regression for issue #94, driven through the real
+    install()/uninstall() entry points (not just the isolated
+    _strip_v1_otel_block() unit above), covering the exact issue fixture.
+
+    install()/uninstall() rewrite config.toml through _codex_toml_apply()/
+    _codex_toml_remove(), which round-trip the whole file via a dict
+    (_toml_write()) — a separate, pre-existing limitation (drops comments,
+    restructures inline tables) called out as out of scope in the issue #94
+    review. So this asserts on *parsed* TOML values, not raw bytes.
+    """
+
+    def test_install_then_uninstall_preserves_third_party_otel(self, fake_home, mock_prompts):
+        toml_path = fake_home / ".codex" / "config.toml"
+        toml_path.parent.mkdir(parents=True, exist_ok=True)
+        toml_path.write_text(_THIRD_PARTY_OTEL_FIXTURE)
+
+        def _assert_third_party_otel_intact():
+            data = codex_toml._toml_load_strict(toml_path)
+            otel = data["otel"]
+            assert otel["log_user_prompt"] is True
+            assert otel["metrics_exporter"] == "none"
+            exporter = otel["exporter"]["otlp-http"]
+            assert exporter["endpoint"] == "http://127.0.0.1:4318/v1/logs"
+            assert exporter["protocol"] == "binary"
+            assert exporter["headers"] == {"Authorization": "Bearer example-redacted"}
+            trace_exporter = otel["trace_exporter"]["otlp-http"]
+            assert trace_exporter["endpoint"] == "http://127.0.0.1:4318/v1/traces"
+            assert trace_exporter["protocol"] == "binary"
+
+        codex_install.install()
+        _assert_third_party_otel_intact()
+
+        codex_install.uninstall()
+        _assert_third_party_otel_intact()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tracing/codex/test_install_codex.py
+++ b/tests/tracing/codex/test_install_codex.py
@@ -156,7 +156,7 @@ class TestTomlHelpers:
         assert 'desc = "it\'s a value"' in raw
 
     def test_roundtrip_float(self, tmp_path):
-        """A float value round-trips as a float, not a string (issue #94 review)."""
+        """A float value round-trips as a float, not a string."""
         data = {"otel_x": 1.5}
         p = tmp_path / "config.toml"
         codex_toml._toml_write(data, p)
@@ -605,16 +605,8 @@ class TestDryRun:
 
 
 # ---------------------------------------------------------------------------
-# Legacy [otel.exporter.otlp-http] cleanup — third-party preservation (#94)
+# Legacy [otel.exporter.otlp-http] cleanup — third-party preservation
 # ---------------------------------------------------------------------------
-#
-# cleanup_legacy_install() runs at the top of both install() and uninstall()
-# (tracing/codex/install.py), calling _strip_v1_otel_block() with the same
-# arguments either way — so exercising that function once for each of these
-# scenarios covers both call sites. Ownership requires the exact shape Arize
-# writes (loopback /v1/logs endpoint, protocol = "json", no other keys); a
-# loopback host/port alone must never be treated as proof of ownership.
-
 
 _THIRD_PARTY_OTEL_FIXTURE = (
     "[otel]\n"
@@ -742,9 +734,9 @@ class TestLegacyOtelCleanup:
         """An Arize-shaped exporter written as an inline table has no literal
         ``[otel.exporter.otlp-http]`` header line to locate — leave it alone
         rather than falling back to a dict rewrite that could touch the wrong
-        text or (per issue #94 review) append a duplicate table."""
+        text"""
         config_path = tmp_path / "config.toml"
-        original = "[otel.exporter]\n" 'otlp-http = { endpoint = "http://127.0.0.1:4318/v1/logs", protocol = "json" }\n'
+        original = '[otel.exporter]\notlp-http = { endpoint = "http://127.0.0.1:4318/v1/logs", protocol = "json" }\n'
         config_path.write_text(original)
         from tracing.codex.install_legacy import _strip_v1_otel_block
 
@@ -756,7 +748,7 @@ class TestLegacyOtelCleanup:
         """A quoted-key header (``[otel.exporter."otlp-http"]``) is not the
         literal bare header Arize writes, so it must be left alone too."""
         config_path = tmp_path / "config.toml"
-        original = '[otel.exporter."otlp-http"]\n' 'endpoint = "http://127.0.0.1:4318/v1/logs"\n' 'protocol = "json"\n'
+        original = '[otel.exporter."otlp-http"]\nendpoint = "http://127.0.0.1:4318/v1/logs"\nprotocol = "json"\n'
         config_path.write_text(original)
         from tracing.codex.install_legacy import _strip_v1_otel_block
 
@@ -930,7 +922,7 @@ class TestTomlApplyRemove:
         """apply does not touch pre-existing [[hooks.<Event>]] entries."""
         p = tmp_path / "config.toml"
         p.write_text(
-            "[[hooks.PreToolUse]]\n" "hooks = [{ type = 'command', command = '/venv/bin/arize-hook-codex-tool' }]\n"
+            "[[hooks.PreToolUse]]\nhooks = [{ type = 'command', command = '/venv/bin/arize-hook-codex-tool' }]\n"
         )
         self._apply(p)
         data = codex_toml._toml_load_strict(p)

--- a/tracing/codex/_toml.py
+++ b/tracing/codex/_toml.py
@@ -20,6 +20,94 @@ except ImportError:
         pass
 
 
+# ---------------------------------------------------------------------------
+# Arize-ownership detection for [otel.exporter.otlp-http]
+# ---------------------------------------------------------------------------
+#
+# Used by tracing/codex/install_legacy.py's legacy-install cleanup, which
+# runs on both install() and uninstall(), to decide what "ours" means. A
+# loopback host/port alone does not prove ownership — a user's own local
+# collector can live at 127.0.0.1 too — so ownership requires the *exact*
+# shape Arize itself writes: only `endpoint` and `protocol` keys, `protocol
+# = "json"`, and an endpoint of the form `http(s)://127.0.0.1:<port>/v1/logs`.
+# Anything else (extra keys such as `headers`/`tls`, `protocol = "binary"`, a
+# non-loopback host, or a different path) is third-party and must be left
+# alone.
+#
+# core/setup/codex.py (the standalone arize-setup-codex wizard) still
+# rewrites [otel] unconditionally on every run; it is out of scope for this
+# fix and is being deleted entirely in a follow-up (#132), so it does not
+# use these helpers.
+
+_ARIZE_OTLP_ENDPOINT_RE = re.compile(r"^https?://127\.0\.0\.1:\d+/v1/logs$")
+
+
+def _is_arize_owned_otlp_exporter(table: object) -> bool:
+    """Return True only if *table* is provably an Arize-written OTLP exporter."""
+    if not isinstance(table, dict):
+        return False
+    if set(table.keys()) - {"endpoint", "protocol"}:
+        return False
+    endpoint = table.get("endpoint")
+    if not (isinstance(endpoint, str) and _ARIZE_OTLP_ENDPOINT_RE.match(endpoint)):
+        return False
+    return table.get("protocol") == "json"
+
+
+_ARIZE_OTLP_HEADER = "[otel.exporter.otlp-http]"
+
+
+def _toml_owned_exporter_span(text: str, endpoint: str) -> tuple[int, int] | None:
+    """Locate the literal, canonical Arize ``[otel.exporter.otlp-http]`` table.
+
+    Arize only ever writes this table one way: a bare header line, followed
+    by exactly two body lines — ``endpoint = "<endpoint>"`` and
+    ``protocol = "json"`` (order-independent), with no other content before
+    the next table header or EOF. Any other shape — an inline table, a
+    quoted or dotted-key header (``[otel.exporter."otlp-http"]``,
+    ``otel.exporter.otlp-http = ...``), or a header that merely *appears* as
+    a line inside a multi-line string — is not something we can safely
+    locate and edit, so this returns None for all of those instead of
+    guessing.
+
+    Callers must already know (via ``_is_arize_owned_otlp_exporter`` on the
+    parsed dict) that *some* Arize-shaped table exists before calling this;
+    this function's job is only to find *where in the text* it literally is,
+    so the caller can edit just those lines and leave everything else —
+    including comments and blank lines belonging to whatever table follows —
+    untouched.
+
+    The returned span's end excludes any trailing blank lines or comments
+    between the table's last body line and the next header/EOF, so removing
+    or replacing ``text[start:end]`` never disturbs a comment that belongs to
+    the following table (see issue #94 review). Returns None if zero or more
+    than one candidate header line has a body matching that exact shape —
+    ambiguity is treated the same as "not found": leave the file alone.
+    """
+    lines = text.splitlines(keepends=True)
+    expected = {f'endpoint = "{endpoint}"', 'protocol = "json"'}
+
+    matches: list[tuple[int, int]] = []
+    for start, line in enumerate(lines):
+        if line.strip() != _ARIZE_OTLP_HEADER:
+            continue
+        end = start + 1
+        body_end = start
+        body: list[str] = []
+        while end < len(lines) and not lines[end].lstrip().startswith("["):
+            stripped = lines[end].strip()
+            if stripped and not stripped.startswith("#"):
+                body.append(stripped)
+                body_end = end + 1
+            end += 1
+        if len(body) == 2 and set(body) == expected:
+            matches.append((start, body_end))
+
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
 def _toml_load_strict(path: Path) -> dict:
     """Load TOML without falling back to a lossy parser.
 
@@ -178,6 +266,8 @@ def _inline_table(table: dict) -> str:
             parts.append(f"{kk} = {'true' if v else 'false'}")
         elif isinstance(v, int):
             parts.append(f"{kk} = {v}")
+        elif isinstance(v, float):
+            parts.append(f"{kk} = {v!r}")
         elif isinstance(v, list):
             if _is_table_array(v):
                 items = ", ".join(_inline_table(d) for d in v)
@@ -199,6 +289,8 @@ def _toml_write_value(key: str, val: object, lines: list[str]) -> None:
         lines.append(f"{k} = {'true' if val else 'false'}")
     elif isinstance(val, int):
         lines.append(f"{k} = {val}")
+    elif isinstance(val, float):
+        lines.append(f"{k} = {val!r}")
     else:
         lines.append(f"{k} = {_toml_string_literal(val)}")
 

--- a/tracing/codex/_toml.py
+++ b/tracing/codex/_toml.py
@@ -19,26 +19,6 @@ except ImportError:
     except ImportError:
         pass
 
-
-# ---------------------------------------------------------------------------
-# Arize-ownership detection for [otel.exporter.otlp-http]
-# ---------------------------------------------------------------------------
-#
-# Used by tracing/codex/install_legacy.py's legacy-install cleanup, which
-# runs on both install() and uninstall(), to decide what "ours" means. A
-# loopback host/port alone does not prove ownership — a user's own local
-# collector can live at 127.0.0.1 too — so ownership requires the *exact*
-# shape Arize itself writes: only `endpoint` and `protocol` keys, `protocol
-# = "json"`, and an endpoint of the form `http(s)://127.0.0.1:<port>/v1/logs`.
-# Anything else (extra keys such as `headers`/`tls`, `protocol = "binary"`, a
-# non-loopback host, or a different path) is third-party and must be left
-# alone.
-#
-# core/setup/codex.py (the standalone arize-setup-codex wizard) still
-# rewrites [otel] unconditionally on every run; it is out of scope for this
-# fix and is being deleted entirely in a follow-up (#132), so it does not
-# use these helpers.
-
 _ARIZE_OTLP_ENDPOINT_RE = re.compile(r"^https?://127\.0\.0\.1:\d+/v1/logs$")
 
 
@@ -62,27 +42,9 @@ def _toml_owned_exporter_span(text: str, endpoint: str) -> tuple[int, int] | Non
 
     Arize only ever writes this table one way: a bare header line, followed
     by exactly two body lines — ``endpoint = "<endpoint>"`` and
-    ``protocol = "json"`` (order-independent), with no other content before
-    the next table header or EOF. Any other shape — an inline table, a
-    quoted or dotted-key header (``[otel.exporter."otlp-http"]``,
-    ``otel.exporter.otlp-http = ...``), or a header that merely *appears* as
-    a line inside a multi-line string — is not something we can safely
-    locate and edit, so this returns None for all of those instead of
-    guessing.
-
-    Callers must already know (via ``_is_arize_owned_otlp_exporter`` on the
-    parsed dict) that *some* Arize-shaped table exists before calling this;
-    this function's job is only to find *where in the text* it literally is,
-    so the caller can edit just those lines and leave everything else —
-    including comments and blank lines belonging to whatever table follows —
-    untouched.
-
-    The returned span's end excludes any trailing blank lines or comments
-    between the table's last body line and the next header/EOF, so removing
-    or replacing ``text[start:end]`` never disturbs a comment that belongs to
-    the following table (see issue #94 review). Returns None if zero or more
-    than one candidate header line has a body matching that exact shape —
-    ambiguity is treated the same as "not found": leave the file alone.
+    ``protocol = "json"`` with no other content before the next table header or
+    EOF. Any other shape is not something we can safely locate and edit, so this
+    returns None for all of those instead of guessing.
     """
     lines = text.splitlines(keepends=True)
     expected = {f'endpoint = "{endpoint}"', 'protocol = "json"'}

--- a/tracing/codex/install_legacy.py
+++ b/tracing/codex/install_legacy.py
@@ -16,15 +16,11 @@ import time
 from pathlib import Path
 
 from core.setup import BIN_DIR, dry_run, info
-from tracing.codex._toml import _toml_load_strict, _toml_write
+from tracing.codex._toml import _is_arize_owned_otlp_exporter, _toml_load_strict, _toml_owned_exporter_span
 from tracing.codex.constants import get_codex_home
 
 _PATH_MARKER_BEGIN = "# >>> arize codex tracing PATH >>>"
 _PATH_MARKER_END = "# <<< arize codex tracing PATH <<<"
-
-# v1 OTLP endpoint pattern. Matches any 127.0.0.1 endpoint ending in /v1/logs
-# to catch installs where the user customized the buffer port via config.json.
-_V1_OTEL_ENDPOINT_RE = re.compile(r"^https?://127\.0\.0\.1:\d+/v1/logs$")
 
 
 def _codex_proxy_shim_path() -> Path:
@@ -212,7 +208,19 @@ def _remove_windows_user_path_block() -> None:
 def _strip_v1_otel_block(path: Path) -> None:
     """Strip a stale v1 ``[otel.exporter.otlp-http]`` block pointing at the
     local buffer service from ~/.codex/config.toml. Idempotent; no-op if the
-    file or block is absent, or if the endpoint targets a foreign collector.
+    file or block is absent, or if the table isn't provably Arize-owned (see
+    ``_is_arize_owned_otlp_exporter`` — a loopback host/port alone does not
+    prove ownership, so a third-party exporter is left untouched).
+
+    Removal is a targeted line-based edit of just the literal, canonical
+    ``[otel.exporter.otlp-http]`` table (see ``_toml_owned_exporter_span``),
+    so comments and everything else in the file are preserved unchanged. If
+    the table is Arize-shaped but its canonical header can't be located
+    (written as an inline table, a quoted/dotted key, or merely appearing as
+    text inside a multi-line string), that's treated as *not* provably ours
+    either — we leave the file untouched rather than risk editing the wrong
+    thing. There is no dict-rewrite fallback: without a safely located span
+    we do nothing.
     """
     if not path.is_file():
         return
@@ -229,22 +237,36 @@ def _strip_v1_otel_block(path: Path) -> None:
     if not isinstance(exporter, dict):
         return
     otlp = exporter.get("otlp-http")
-    if not isinstance(otlp, dict):
-        return
-    endpoint = otlp.get("endpoint", "")
-    if not (isinstance(endpoint, str) and _V1_OTEL_ENDPOINT_RE.match(endpoint)):
+    if not isinstance(otlp, dict) or not _is_arize_owned_otlp_exporter(otlp):
         return
 
     if dry_run():
         info(f"would strip legacy [otel.exporter.otlp-http] block from {path}")
         return
 
-    del exporter["otlp-http"]
-    if not exporter:
-        del otel["exporter"]
-    if not otel:
-        del data["otel"]
-    _toml_write(data, path)
+    text = path.read_text()
+    span = _toml_owned_exporter_span(text, otlp["endpoint"])
+    if span is None:
+        info(
+            f"Found an Arize-shaped [otel.exporter.otlp-http] table in {path} written in "
+            "non-standard syntax (inline table, quoted/dotted key, or found inside a string) "
+            "— left untouched."
+        )
+        return
+
+    lines = text.splitlines(keepends=True)
+    start, end = span
+    del lines[start:end]
+    # Collapse a blank line left immediately before + after the removed
+    # block down to one, mirroring normal TOML spacing. If the removed
+    # table was the very first thing in the file, drop a lone leading
+    # blank line entirely instead of leaving the file starting on blank.
+    if start == 0:
+        if lines and lines[0].strip() == "":
+            del lines[0]
+    elif start < len(lines) and lines[start - 1].strip() == "" and lines[start].strip() == "":
+        del lines[start]
+    path.write_text("".join(lines))
     info(f"Removed legacy [otel.exporter.otlp-http] block from {path}")
 
 

--- a/tracing/codex/install_legacy.py
+++ b/tracing/codex/install_legacy.py
@@ -207,21 +207,7 @@ def _remove_windows_user_path_block() -> None:
 
 def _strip_v1_otel_block(path: Path) -> None:
     """Strip a stale v1 ``[otel.exporter.otlp-http]`` block pointing at the
-    local buffer service from ~/.codex/config.toml. Idempotent; no-op if the
-    file or block is absent, or if the table isn't provably Arize-owned (see
-    ``_is_arize_owned_otlp_exporter`` — a loopback host/port alone does not
-    prove ownership, so a third-party exporter is left untouched).
-
-    Removal is a targeted line-based edit of just the literal, canonical
-    ``[otel.exporter.otlp-http]`` table (see ``_toml_owned_exporter_span``),
-    so comments and everything else in the file are preserved unchanged. If
-    the table is Arize-shaped but its canonical header can't be located
-    (written as an inline table, a quoted/dotted key, or merely appearing as
-    text inside a multi-line string), that's treated as *not* provably ours
-    either — we leave the file untouched rather than risk editing the wrong
-    thing. There is no dict-rewrite fallback: without a safely located span
-    we do nothing.
-    """
+    local buffer service from ~/.codex/config.toml."""
     if not path.is_file():
         return
 
@@ -257,10 +243,8 @@ def _strip_v1_otel_block(path: Path) -> None:
     lines = text.splitlines(keepends=True)
     start, end = span
     del lines[start:end]
-    # Collapse a blank line left immediately before + after the removed
-    # block down to one, mirroring normal TOML spacing. If the removed
-    # table was the very first thing in the file, drop a lone leading
-    # blank line entirely instead of leaving the file starting on blank.
+    # Collapse a blank line left immediately before and after the removed
+    # block down to one, mirroring normal TOML spacing.
     if start == 0:
         if lines and lines[0].strip() == "":
             del lines[0]


### PR DESCRIPTION
## Summary

fixes a bug where our legacy installer would nuke any custom OTLP config in `~/.codex/config.toml`. post this, our legacy cleanup script searches for *precisely* what we wrote, and removes that. if it does not match, it doesn't touch the config.toml. 

partially resolves #94. the standalone `arize-setup-codex` wizard still rewrites `[otel.*]`; #139 removes that wizard and closes the issue.
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## How tested

`TestLegacyOtelCleanup` under tests/tracing/codex. among others, it:
- ensures any deviations from what we expect remain untouched
- if there's a mixture of otel blocks, only the line matching exactly what we wrote is wiped
- cleanup is idempotent
- any deviations from what we expect are preserved

## Checklist

- [x] Tests pass (`uv run pytest tests/ -m "not slow"`)
- [x] Pre-commit clean (`uv run pre-commit run --all-files`)
- [x] Ran the `code-review` skill and addressed findings
- [x] Docs updated if needed

