### PR TITLE
fix/codex openinference llm attrs

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -4,6 +4,7 @@
 Every module that needs a path imports it from here. Tests monkeypatch these
 values via the tmp_harness_dir fixture to avoid touching the real filesystem.
 """
+
 from pathlib import Path
 from typing import TypedDict
 
@@ -91,3 +92,16 @@ HARNESSES: dict[str, HarnessMetadata] = {
         "default_log_file": LOG_DIR / "omp.log",
     },
 }
+
+MODEL_FAMILY_SYSTEMS: tuple[tuple[str, str], ...] = (
+    ("codex", "openai"),
+    ("gpt-", "openai"),
+    ("claude", "anthropic"),
+    ("llama", "meta"),
+    ("deepseek", "deepseek"),
+    ("mixtral", "mistralai"),
+    ("mistral", "mistralai"),
+    ("gemini", "vertexai"),
+    ("grok", "xai"),
+    ("command-", "cohere"),
+)

--- a/tests/tracing/codex/test_codex_hook.py
+++ b/tests/tracing/codex/test_codex_hook.py
@@ -16,6 +16,7 @@ from tracing.codex.hooks.handlers import (
     _find_rollout_file,
     _handle_notify,
     _iso_to_ms,
+    _llm_identity,
     _send_legacy_single_span,
     notify,
 )
@@ -210,6 +211,7 @@ class TestExtractTurnFromRollout:
                             "output_tokens": 20,
                             "total_tokens": 120,
                             "cached_input_tokens": 80,
+                            "cache_write_input_tokens": 4,
                             "reasoning_output_tokens": 5,
                         }
                     },
@@ -223,6 +225,7 @@ class TestExtractTurnFromRollout:
                             "input_tokens": 50,
                             "output_tokens": 10,
                             "total_tokens": 60,
+                            "cache_write_input_tokens": 3,
                         }
                     },
                 }
@@ -235,7 +238,85 @@ class TestExtractTurnFromRollout:
         assert usage["completion_tokens"] == 30
         assert usage["total_tokens"] == 180
         assert usage["cached_input_tokens"] == 80
+        assert usage["cache_write_input_tokens"] == 7
         assert usage["reasoning_output_tokens"] == 5
+        # Codex doesn't serialize non_cached_input_tokens; we derive it the
+        # same way Codex itself does: max(input - cached, 0).
+        assert usage["non_cached_input_tokens"] == 70
+
+    def test_cache_write_input_tokens_summed_across_events(self, tmp_path):
+        """cache_write_input_tokens is read (it was previously never read at all)."""
+        path = _write_rollout(
+            tmp_path,
+            "s1",
+            _evt({"type": "task_started", "turn_id": "t1"}),
+            _evt(
+                {
+                    "type": "token_count",
+                    "info": {"last_token_usage": {"cache_write_input_tokens": 5}},
+                }
+            ),
+            _evt(
+                {
+                    "type": "token_count",
+                    "info": {"last_token_usage": {"cache_write_input_tokens": 2}},
+                }
+            ),
+            _evt({"type": "task_complete", "turn_id": "t1"}),
+        )
+        turn = _extract_turn_from_rollout(path, "t1")
+        assert turn["token_usage"]["cache_write_input_tokens"] == 7
+
+    def test_observed_zero_preserved_unobserved_field_absent(self, tmp_path):
+        """An observed 0 stays in the dict; a field never seen anywhere is absent."""
+        path = _write_rollout(
+            tmp_path,
+            "s1",
+            _evt({"type": "task_started", "turn_id": "t1"}),
+            _evt(
+                {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": 10,
+                            "output_tokens": 0,
+                            "total_tokens": 10,
+                        }
+                    },
+                }
+            ),
+            _evt({"type": "task_complete", "turn_id": "t1"}),
+        )
+        turn = _extract_turn_from_rollout(path, "t1")
+        usage = turn["token_usage"]
+        assert usage["completion_tokens"] == 0
+        assert "reasoning_output_tokens" not in usage
+        assert "cache_write_input_tokens" not in usage
+
+    def test_session_meta_model_provider_captured(self, tmp_path):
+        path = _write_rollout(
+            tmp_path,
+            "s1",
+            {
+                "timestamp": "2026-05-20T00:00:00Z",
+                "type": "session_meta",
+                "payload": {"id": "s1", "model_provider": "ollama"},
+            },
+            _evt({"type": "task_started", "turn_id": "t1"}),
+            _evt({"type": "task_complete", "turn_id": "t1"}),
+        )
+        turn = _extract_turn_from_rollout(path, "t1")
+        assert turn["model_provider"] == "ollama"
+
+    def test_missing_session_meta_gives_none_provider(self, tmp_path):
+        path = _write_rollout(
+            tmp_path,
+            "s1",
+            _evt({"type": "task_started", "turn_id": "t1"}),
+            _evt({"type": "task_complete", "turn_id": "t1"}),
+        )
+        turn = _extract_turn_from_rollout(path, "t1")
+        assert turn["model_provider"] is None
 
     def test_function_call_pairs_with_output_by_call_id(self, tmp_path):
         path = _write_rollout(
@@ -426,6 +507,7 @@ class TestBuildAndSendSpans:
             "user_prompt": "hi",
             "assistant_output": "hello",
             "model": "gpt-5.5",
+            "model_provider": "openai",
             "cwd": "/x/workspace",
             "permission_mode": "on-request",
             "sandbox_mode": "workspace-write",
@@ -433,6 +515,9 @@ class TestBuildAndSendSpans:
                 "prompt_tokens": 10,
                 "completion_tokens": 5,
                 "total_tokens": 15,
+                "cached_input_tokens": 8,
+                "cache_write_input_tokens": 2,
+                "reasoning_output_tokens": 1,
                 "model": "gpt-5.5",
             },
             "tool_calls": [
@@ -460,14 +545,24 @@ class TestBuildAndSendSpans:
         assert parent_attrs["input.value"]["stringValue"] == "hi"
         assert parent_attrs["output.value"]["stringValue"] == "hello"
         assert parent_attrs["llm.model_name"]["stringValue"] == "gpt-5.5"
+        assert parent_attrs["llm.system"]["stringValue"] == "openai"
+        assert parent_attrs["llm.provider"]["stringValue"] == "openai"
         assert parent_attrs["codex.approval_mode"]["stringValue"] == "on-request"
         assert parent_attrs["codex.sandbox_mode"]["stringValue"] == "workspace-write"
         assert parent_attrs["codex.cwd"]["stringValue"] == "/x/workspace"
         assert parent_attrs["codex.workspace"]["stringValue"] == "workspace"
         assert parent_attrs["llm.token_count.total"]["intValue"] == 15
+        assert parent_attrs["llm.token_count.prompt_details.cache_read"]["intValue"] == 8
+        assert parent_attrs["llm.token_count.prompt_details.cache_write"]["intValue"] == 2
+        assert parent_attrs["llm.token_count.completion_details.reasoning"]["intValue"] == 1
+        assert parent_attrs["llm.input_messages.0.message.role"]["stringValue"] == "user"
+        assert parent_attrs["llm.input_messages.0.message.content"]["stringValue"] == "hi"
+        assert parent_attrs["llm.output_messages.0.message.role"]["stringValue"] == "assistant"
+        assert parent_attrs["llm.output_messages.0.message.content"]["stringValue"] == "hello"
 
         child_attrs = _attrs_of_span(spans[1])
         assert child_attrs["tool.name"]["stringValue"] == "exec_command"
+        assert child_attrs["tool.id"]["stringValue"] == "c1"
         assert child_attrs["codex.tool.call_id"]["stringValue"] == "c1"
         assert child_attrs["codex.cwd"]["stringValue"] == "/x/workspace"
         assert child_attrs["codex.workspace"]["stringValue"] == "workspace"
@@ -515,6 +610,170 @@ class TestBuildAndSendSpans:
             _build_and_send_spans("sess-1", "turn-1", turn)
         parent_attrs = _attrs_of_span(sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
         assert parent_attrs["output.value"]["stringValue"] == "(No response)"
+
+    def test_zero_token_counts_kept_unobserved_fields_absent(self):
+        """Observed zero prompt/completion/total survive as intValue 0; a
+        field that was never in the token_usage dict emits no attribute."""
+        turn = {
+            "trace_count": 1,
+            "turn_start_ms": 1000,
+            "turn_end_ms": 1500,
+            "duration_ms": 0,
+            "user_prompt": "hi",
+            "assistant_output": "hello",
+            "model": "gpt-5-codex",
+            "cwd": "",
+            "permission_mode": "",
+            "sandbox_mode": "",
+            "token_usage": {
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "model": "gpt-5-codex",
+            },
+            "tool_calls": [],
+        }
+        sent, patcher = self._send_capture()
+        with patcher:
+            _build_and_send_spans("sess-1", "turn-1", turn)
+        parent_attrs = _attrs_of_span(sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
+        assert parent_attrs["llm.token_count.prompt"]["intValue"] == 0
+        assert parent_attrs["llm.token_count.completion"]["intValue"] == 0
+        assert parent_attrs["llm.token_count.total"]["intValue"] == 0
+        assert "llm.token_count.prompt_details.cache_read" not in parent_attrs
+        assert "llm.token_count.prompt_details.cache_write" not in parent_attrs
+        assert "llm.token_count.completion_details.reasoning" not in parent_attrs
+
+    def test_llm_system_and_provider_from_model_provider(self):
+        """model_provider 'ollama' with model 'llama3' -> both llm.system and
+        llm.provider are 'ollama' (no OpenAI-family signal in the model name)."""
+        turn = {
+            "trace_count": 1,
+            "turn_start_ms": 1000,
+            "turn_end_ms": 1500,
+            "user_prompt": "hi",
+            "assistant_output": "hello",
+            "model": "llama3",
+            "model_provider": "ollama",
+            "cwd": "",
+            "permission_mode": "",
+            "sandbox_mode": "",
+            "token_usage": None,
+            "tool_calls": [],
+        }
+        sent, patcher = self._send_capture()
+        with patcher:
+            _build_and_send_spans("sess-1", "turn-1", turn)
+        parent_attrs = _attrs_of_span(sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
+        assert parent_attrs["llm.system"]["stringValue"] == "ollama"
+        assert parent_attrs["llm.provider"]["stringValue"] == "ollama"
+
+    def test_llm_system_and_provider_default_openai_without_session_meta(self):
+        """No model_provider (old session, or session_meta missing the field)
+        and a gpt-5-codex model -> both default to openai."""
+        turn = {
+            "trace_count": 1,
+            "turn_start_ms": 1000,
+            "turn_end_ms": 1500,
+            "user_prompt": "hi",
+            "assistant_output": "hello",
+            "model": "gpt-5-codex",
+            "model_provider": None,
+            "cwd": "",
+            "permission_mode": "",
+            "sandbox_mode": "",
+            "token_usage": None,
+            "tool_calls": [],
+        }
+        sent, patcher = self._send_capture()
+        with patcher:
+            _build_and_send_spans("sess-1", "turn-1", turn)
+        parent_attrs = _attrs_of_span(sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
+        assert parent_attrs["llm.system"]["stringValue"] == "openai"
+        assert parent_attrs["llm.provider"]["stringValue"] == "openai"
+
+    def test_input_message_content_omitted_when_prompt_empty(self):
+        """Role is always set on the indexed message; content is only added
+        when the redacted text is non-empty."""
+        turn = {
+            "trace_count": 1,
+            "turn_start_ms": 1000,
+            "turn_end_ms": 1500,
+            "user_prompt": "",
+            "assistant_output": "",
+            "model": "",
+            "cwd": "",
+            "permission_mode": "",
+            "sandbox_mode": "",
+            "token_usage": None,
+            "tool_calls": [],
+        }
+        sent, patcher = self._send_capture()
+        with patcher:
+            _build_and_send_spans("sess-1", "turn-1", turn)
+        parent_attrs = _attrs_of_span(sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
+        assert parent_attrs["llm.input_messages.0.message.role"]["stringValue"] == "user"
+        assert "llm.input_messages.0.message.content" not in parent_attrs
+        assert parent_attrs["llm.output_messages.0.message.role"]["stringValue"] == "assistant"
+        assert "llm.output_messages.0.message.content" not in parent_attrs
+
+    def test_indexed_messages_respect_redaction(self, monkeypatch):
+        """With ARIZE_LOG_PROMPTS=false, the indexed message contents are
+        redacted the same way input.value/output.value are."""
+        monkeypatch.setenv("ARIZE_LOG_PROMPTS", "false")
+        turn = {
+            "trace_count": 1,
+            "turn_start_ms": 1000,
+            "turn_end_ms": 1500,
+            "user_prompt": "secret prompt",
+            "assistant_output": "secret answer",
+            "model": "",
+            "cwd": "",
+            "permission_mode": "",
+            "sandbox_mode": "",
+            "token_usage": None,
+            "tool_calls": [],
+        }
+        sent, patcher = self._send_capture()
+        with patcher:
+            _build_and_send_spans("sess-1", "turn-1", turn)
+        parent_attrs = _attrs_of_span(sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
+        in_content = parent_attrs["llm.input_messages.0.message.content"]["stringValue"]
+        out_content = parent_attrs["llm.output_messages.0.message.content"]["stringValue"]
+        assert in_content.startswith("<redacted (")
+        assert out_content.startswith("<redacted (")
+        assert in_content == parent_attrs["input.value"]["stringValue"]
+        assert out_content == parent_attrs["output.value"]["stringValue"]
+
+
+# ---------------------------------------------------------------------------
+# _llm_identity
+# ---------------------------------------------------------------------------
+
+
+class TestLlmIdentity:
+
+    def test_openai_provider_gives_openai_system(self):
+        assert _llm_identity("gpt-5.5", "openai") == ("openai", "openai")
+
+    def test_azure_provider_gives_openai_system(self):
+        assert _llm_identity("gpt-4o", "azure") == ("openai", "azure")
+
+    def test_ollama_provider_with_non_openai_model_gives_ollama_system(self):
+        assert _llm_identity("llama3", "ollama") == ("ollama", "ollama")
+
+    def test_missing_provider_defaults_to_openai(self):
+        assert _llm_identity("gpt-5-codex", None) == ("openai", "openai")
+
+    def test_codex_in_model_name_gives_openai_system_regardless_of_provider(self):
+        # The model name is a stronger signal than an unrecognized provider id.
+        system, provider = _llm_identity("codex-mini", "custom-proxy")
+        assert system == "openai"
+        assert provider == "custom-proxy"
+
+    def test_o_series_model_prefix_gives_openai_system(self):
+        for model in ("o1-preview", "o3-mini", "o4-mini"):
+            assert _llm_identity(model, "some-provider")[0] == "openai"
 
 
 # ---------------------------------------------------------------------------
@@ -645,6 +904,15 @@ class TestSendLegacySingleSpan:
         assert attrs["codex.notify_fallback"]["stringValue"] == "true"
         assert attrs["input.value"]["stringValue"] == "yo"
         assert attrs["output.value"]["stringValue"] == "hi"
+        # The fallback path has no rollout/session_meta to confirm hosting
+        # provider, but llm.system is still required and trustworthy: Codex
+        # is OpenAI's own CLI.
+        assert attrs["llm.system"]["stringValue"] == "openai"
+        assert "llm.provider" not in attrs
+        assert attrs["llm.input_messages.0.message.role"]["stringValue"] == "user"
+        assert attrs["llm.input_messages.0.message.content"]["stringValue"] == "yo"
+        assert attrs["llm.output_messages.0.message.role"]["stringValue"] == "assistant"
+        assert attrs["llm.output_messages.0.message.content"]["stringValue"] == "hi"
 
     def test_extracts_string_array_prompt(self):
         sent = []

--- a/tests/tracing/codex/test_codex_hook.py
+++ b/tests/tracing/codex/test_codex_hook.py
@@ -72,7 +72,6 @@ def _attrs_of_span(span):
 
 
 class TestIsoToMs:
-
     def test_valid_iso_with_Z(self):
         assert _iso_to_ms("2026-05-20T23:42:45.649Z") > 0
 
@@ -92,7 +91,6 @@ class TestIsoToMs:
 
 
 class TestFindRolloutFile:
-
     def test_returns_none_when_root_missing(self, tmp_path):
         nonexistent = tmp_path / "no" / "sessions"
         assert _find_rollout_file("s1", sessions_root=nonexistent) is None
@@ -123,7 +121,6 @@ class TestFindRolloutFile:
 
 
 class TestExtractTurnFromRollout:
-
     def test_returns_none_for_missing_file(self, tmp_path):
         from pathlib import Path
 
@@ -240,8 +237,6 @@ class TestExtractTurnFromRollout:
         assert usage["cached_input_tokens"] == 80
         assert usage["cache_write_input_tokens"] == 7
         assert usage["reasoning_output_tokens"] == 5
-        # Codex doesn't serialize non_cached_input_tokens; we derive it the
-        # same way Codex itself does: max(input - cached, 0).
         assert usage["non_cached_input_tokens"] == 70
 
     def test_cache_write_input_tokens_summed_across_events(self, tmp_path):
@@ -292,9 +287,6 @@ class TestExtractTurnFromRollout:
         assert usage["completion_tokens"] == 0
         assert "reasoning_output_tokens" not in usage
         assert "cache_write_input_tokens" not in usage
-        # input_tokens was observed but cached_input_tokens never was --
-        # deriving non_cached_input_tokens from an unobserved cached value
-        # would fabricate a number, so it must be absent too.
         assert "non_cached_input_tokens" not in usage
 
     def test_non_cached_derived_only_when_both_input_and_cached_observed(self, tmp_path):
@@ -367,6 +359,33 @@ class TestExtractTurnFromRollout:
         assert tc["args"] == '{"cmd":"ls"}'
         assert tc["output"] == "file1\nfile2"
         assert tc["end_ts"] > tc["start_ts"]
+
+    def test_spawn_agent_function_call_keeps_argument_string(self, tmp_path):
+        """spawn_agent is a regular function_call: args stay the raw JSON
+        string (including the nested model field), not parsed or rewritten."""
+        spawn_args = '{"model": "gpt-5.4", "prompt": "investigate the bug"}'
+        path = _write_rollout(
+            tmp_path,
+            "s1",
+            _evt({"type": "task_started", "turn_id": "t1"}),
+            _resp(
+                {
+                    "type": "function_call",
+                    "name": "spawn_agent",
+                    "arguments": spawn_args,
+                    "call_id": "call_spawn_1",
+                },
+                ts="2026-05-20T00:00:01.000Z",
+            ),
+            _evt({"type": "task_complete", "turn_id": "t1"}),
+        )
+        turn = _extract_turn_from_rollout(path, "t1")
+        assert len(turn["tool_calls"]) == 1
+        tc = turn["tool_calls"][0]
+        assert tc["tool"] == "spawn_agent"
+        assert tc["call_id"] == "call_spawn_1"
+        assert tc["args"] == spawn_args
+        assert isinstance(tc["args"], str)
 
     def test_custom_tool_call_pairs_with_output_by_call_id(self, tmp_path):
         path = _write_rollout(
@@ -492,7 +511,6 @@ class TestExtractTurnFromRollout:
 
 
 class TestBuildAndSendSpans:
-
     def _send_capture(self):
         sent = []
         return sent, mock.patch(
@@ -594,6 +612,51 @@ class TestBuildAndSendSpans:
         assert child_attrs["codex.workspace"]["stringValue"] == "workspace"
         assert child_attrs["input.value"]["stringValue"] == '{"cmd":"ls"}'
         assert child_attrs["output.value"]["stringValue"] == "ok"
+
+    def test_spawn_agent_becomes_one_tool_span(self):
+        """A spawn_agent tool_calls entry is one TOOL child named spawn_agent,
+        not a nested AGENT trace. tool.id is the call_id; input.value is the
+        raw argument string, including the nested model field.
+
+        TODO: monitor how #114 affects this"""
+        spawn_args = '{"model": "gpt-5.4", "prompt": "investigate the bug"}'
+        turn = {
+            "trace_count": 1,
+            "turn_start_ms": 1000,
+            "turn_end_ms": 2000,
+            "user_prompt": "hi",
+            "assistant_output": "hello",
+            "model": "",
+            "cwd": "",
+            "permission_mode": "",
+            "sandbox_mode": "",
+            "token_usage": None,
+            "tool_calls": [
+                {
+                    "tool": "spawn_agent",
+                    "args": spawn_args,
+                    "output": "",
+                    "call_id": "call_spawn_1",
+                    "start_ts": 1100,
+                    "end_ts": 1200,
+                    "decision": None,
+                },
+            ],
+        }
+
+        sent, patcher = self._send_capture()
+        with patcher:
+            _build_and_send_spans("sess-1", "turn-1", turn)
+
+        spans = sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"]
+        assert len(spans) == 2  # parent + 1 child
+        child = spans[1]
+        assert child["name"] == "spawn_agent"
+        child_attrs = _attrs_of_span(child)
+        assert child_attrs["openinference.span.kind"]["stringValue"] == "TOOL"
+        assert child_attrs["tool.name"]["stringValue"] == "spawn_agent"
+        assert child_attrs["tool.id"]["stringValue"] == "call_spawn_1"
+        assert child_attrs["input.value"]["stringValue"] == spawn_args
 
     def test_single_span_when_no_tool_calls(self):
         turn = {
@@ -809,7 +872,6 @@ class TestBuildAndSendSpans:
 
 
 class TestLlmIdentity:
-
     def test_openai_provider_gives_openai_system(self):
         assert _llm_identity("gpt-5.5", "openai") == ("openai", "openai")
 
@@ -866,7 +928,6 @@ class TestLlmIdentity:
 
 
 class TestHandleNotify:
-
     def test_ignores_non_agent_turn_complete(self):
         with mock.patch("tracing.codex.hooks.handlers.send_span_to_backend") as send:
             _handle_notify({"type": "session-start"})
@@ -942,7 +1003,6 @@ class TestHandleNotify:
 
 
 class TestNotifyEntryPoint:
-
     def test_tracing_disabled_returns_early(self, monkeypatch):
         monkeypatch.setenv("ARIZE_TRACE_ENABLED", "false")
         with mock.patch.object(sys, "argv", ["hook", "{}"]):
@@ -969,7 +1029,6 @@ class TestNotifyEntryPoint:
 
 
 class TestSendLegacySingleSpan:
-
     def test_emits_one_span_with_fallback_marker(self):
         sent = []
         with mock.patch(

--- a/tests/tracing/codex/test_codex_hook.py
+++ b/tests/tracing/codex/test_codex_hook.py
@@ -292,6 +292,32 @@ class TestExtractTurnFromRollout:
         assert usage["completion_tokens"] == 0
         assert "reasoning_output_tokens" not in usage
         assert "cache_write_input_tokens" not in usage
+        # input_tokens was observed but cached_input_tokens never was --
+        # deriving non_cached_input_tokens from an unobserved cached value
+        # would fabricate a number, so it must be absent too.
+        assert "non_cached_input_tokens" not in usage
+
+    def test_non_cached_derived_only_when_both_input_and_cached_observed(self, tmp_path):
+        path = _write_rollout(
+            tmp_path,
+            "s1",
+            _evt({"type": "task_started", "turn_id": "t1"}),
+            _evt(
+                {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": 100,
+                            "cached_input_tokens": 30,
+                        }
+                    },
+                }
+            ),
+            _evt({"type": "task_complete", "turn_id": "t1"}),
+        )
+        turn = _extract_turn_from_rollout(path, "t1")
+        usage = turn["token_usage"]
+        assert usage["non_cached_input_tokens"] == 70
 
     def test_session_meta_model_provider_captured(self, tmp_path):
         path = _write_rollout(
@@ -645,8 +671,8 @@ class TestBuildAndSendSpans:
         assert "llm.token_count.completion_details.reasoning" not in parent_attrs
 
     def test_llm_system_and_provider_from_model_provider(self):
-        """model_provider 'ollama' with model 'llama3' -> both llm.system and
-        llm.provider are 'ollama' (no OpenAI-family signal in the model name)."""
+        """model_provider 'ollama' with model 'llama3' -> llm.system is the
+        well-known family value 'meta' (Llama), llm.provider stays 'ollama'."""
         turn = {
             "trace_count": 1,
             "turn_start_ms": 1000,
@@ -665,12 +691,13 @@ class TestBuildAndSendSpans:
         with patcher:
             _build_and_send_spans("sess-1", "turn-1", turn)
         parent_attrs = _attrs_of_span(sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
-        assert parent_attrs["llm.system"]["stringValue"] == "ollama"
+        assert parent_attrs["llm.system"]["stringValue"] == "meta"
         assert parent_attrs["llm.provider"]["stringValue"] == "ollama"
 
-    def test_llm_system_and_provider_default_openai_without_session_meta(self):
+    def test_llm_system_defaults_openai_and_provider_absent_without_session_meta(self):
         """No model_provider (old session, or session_meta missing the field)
-        and a gpt-5-codex model -> both default to openai."""
+        and a gpt-5-codex model -> llm.system defaults to openai, and
+        llm.provider is NOT emitted (never fabricated)."""
         turn = {
             "trace_count": 1,
             "turn_start_ms": 1000,
@@ -690,11 +717,41 @@ class TestBuildAndSendSpans:
             _build_and_send_spans("sess-1", "turn-1", turn)
         parent_attrs = _attrs_of_span(sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
         assert parent_attrs["llm.system"]["stringValue"] == "openai"
-        assert parent_attrs["llm.provider"]["stringValue"] == "openai"
+        assert "llm.provider" not in parent_attrs
 
-    def test_input_message_content_omitted_when_prompt_empty(self):
-        """Role is always set on the indexed message; content is only added
-        when the redacted text is non-empty."""
+    def test_null_session_meta_provider_omits_llm_provider_but_keeps_system(self, tmp_path):
+        """A rollout whose session_meta has model_provider: null must not
+        emit llm.provider, but llm.system is still always present."""
+        path = _write_rollout(
+            tmp_path,
+            "s1",
+            {
+                "timestamp": "2026-05-20T00:00:00Z",
+                "type": "session_meta",
+                "payload": {"id": "s1", "model_provider": None},
+            },
+            _evt({"type": "task_started", "turn_id": "t1"}),
+            {
+                "timestamp": "2026-05-20T00:00:00Z",
+                "type": "turn_context",
+                "payload": {"turn_id": "t1", "model": "gpt-5.5"},
+            },
+            _evt({"type": "task_complete", "turn_id": "t1"}),
+        )
+        turn = _extract_turn_from_rollout(path, "t1")
+        assert turn["model_provider"] is None
+
+        sent, patcher = self._send_capture()
+        with patcher:
+            _build_and_send_spans("sess-1", "t1", turn)
+        parent_attrs = _attrs_of_span(sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
+        assert parent_attrs["llm.system"]["stringValue"] == "openai"
+        assert "llm.provider" not in parent_attrs
+
+    def test_input_message_omitted_entirely_when_prompt_empty(self):
+        """No indexed message (neither role nor content) is written when the
+        content is empty -- a turn with no user/assistant message must not
+        claim a message that was never observed."""
         turn = {
             "trace_count": 1,
             "turn_start_ms": 1000,
@@ -712,9 +769,9 @@ class TestBuildAndSendSpans:
         with patcher:
             _build_and_send_spans("sess-1", "turn-1", turn)
         parent_attrs = _attrs_of_span(sent[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
-        assert parent_attrs["llm.input_messages.0.message.role"]["stringValue"] == "user"
+        assert "llm.input_messages.0.message.role" not in parent_attrs
         assert "llm.input_messages.0.message.content" not in parent_attrs
-        assert parent_attrs["llm.output_messages.0.message.role"]["stringValue"] == "assistant"
+        assert "llm.output_messages.0.message.role" not in parent_attrs
         assert "llm.output_messages.0.message.content" not in parent_attrs
 
     def test_indexed_messages_respect_redaction(self, monkeypatch):
@@ -759,11 +816,15 @@ class TestLlmIdentity:
     def test_azure_provider_gives_openai_system(self):
         assert _llm_identity("gpt-4o", "azure") == ("openai", "azure")
 
-    def test_ollama_provider_with_non_openai_model_gives_ollama_system(self):
-        assert _llm_identity("llama3", "ollama") == ("ollama", "ollama")
+    def test_llama_model_gives_meta_system_regardless_of_provider(self):
+        """Model-family match wins over provider: llama on ollama is still
+        llm.system=meta (Meta's well-known value), llm.provider=ollama."""
+        assert _llm_identity("llama3", "ollama") == ("meta", "ollama")
 
     def test_missing_provider_defaults_to_openai(self):
-        assert _llm_identity("gpt-5-codex", None) == ("openai", "openai")
+        # No model_provider observed -> llm.provider is omitted (None), not
+        # fabricated as "openai".
+        assert _llm_identity("gpt-5-codex", None) == ("openai", None)
 
     def test_codex_in_model_name_gives_openai_system_regardless_of_provider(self):
         # The model name is a stronger signal than an unrecognized provider id.
@@ -774,6 +835,29 @@ class TestLlmIdentity:
     def test_o_series_model_prefix_gives_openai_system(self):
         for model in ("o1-preview", "o3-mini", "o4-mini"):
             assert _llm_identity(model, "some-provider")[0] == "openai"
+
+    def test_deepseek_model_on_azure_gives_deepseek_system(self):
+        assert _llm_identity("DeepSeek-R1", "azure") == ("deepseek", "azure")
+
+    def test_unknown_model_and_provider_uses_provider_as_custom_system(self):
+        # Neither model nor provider is a recognized family -> the provider
+        # id itself is used as the (spec-permitted) custom system value.
+        assert _llm_identity("some-custom-model", "my-proxy") == ("my-proxy", "my-proxy")
+
+    def test_claude_model_on_third_party_provider_gives_anthropic_system(self):
+        assert _llm_identity("claude-sonnet-4.5", "openrouter") == ("anthropic", "openrouter")
+
+    def test_null_provider_never_fabricated(self):
+        """model_provider observed as JSON null -> llm.provider is None."""
+        assert _llm_identity("gpt-5.5", None)[1] is None
+
+    def test_non_string_provider_treated_as_absent(self):
+        # A corrupt/unexpected field type must not raise and must not be
+        # treated as a real provider id.
+        assert _llm_identity("gpt-5", 123) == ("openai", None)
+
+    def test_non_string_model_treated_as_absent(self):
+        assert _llm_identity(None, "azure") == ("openai", "azure")
 
 
 # ---------------------------------------------------------------------------

--- a/tracing/codex/hooks/handlers.py
+++ b/tracing/codex/hooks/handlers.py
@@ -115,7 +115,8 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
     """Walk the rollout JSONL and extract everything for one turn.
 
     Returns a dict with: ``trace_count``, ``turn_start_ms``, ``turn_end_ms``,
-    ``duration_ms``, ``user_prompt``, ``assistant_output``, ``model``, ``cwd``,
+    ``duration_ms``, ``user_prompt``, ``assistant_output``, ``model``,
+    ``model_provider`` (from ``session_meta``, may be ``None``), ``cwd``,
     ``permission_mode``, ``sandbox_mode``, ``token_usage`` (or None), and
     ``tool_calls`` (a list of ``{tool, args, output, call_id, start_ts, end_ts}``).
 
@@ -129,11 +130,11 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
         "output_tokens",
         "total_tokens",
         "cached_input_tokens",
-        "non_cached_input_tokens",
+        "cache_write_input_tokens",
         "reasoning_output_tokens",
     )
     token_sums: dict = {k: 0 for k in fields}
-    saw_tokens = False
+    observed_fields: set = set()
 
     in_turn = False
     trace_count = 0
@@ -143,6 +144,7 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
     user_prompt = ""
     assistant_output = ""
     model = ""
+    model_provider: "str | None" = None
     cwd = ""
     permission_mode = ""
     sandbox_mode = ""
@@ -167,6 +169,14 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
                 payload = obj.get("payload") or {}
                 ptype = payload.get("type") if isinstance(payload, dict) else None
                 ts_ms = _iso_to_ms(obj.get("timestamp", ""))
+
+                # session_meta is the rollout's first record and carries the
+                # authoritative provider id for the whole session. It arrives
+                # before any task_started, so it must be read outside the
+                # in_turn gate below.
+                if outer == "session_meta" and isinstance(payload, dict):
+                    model_provider = payload.get("model_provider")
+                    continue
 
                 # turn_context records carry per-turn settings (model, cwd, sandbox).
                 # They live at the outer level (no payload.type).
@@ -235,7 +245,7 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
                         v = last.get(k)
                         if isinstance(v, int):
                             token_sums[k] += v
-                            saw_tokens = True
+                            observed_fields.add(k)
                     continue
 
                 # Shell / apply_patch tool call
@@ -337,16 +347,29 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
         turn_end_ms = max(candidates) if candidates else turn_start_ms
 
     token_usage: "dict | None" = None
-    if saw_tokens:
-        token_usage = {
-            "prompt_tokens": token_sums["input_tokens"] or None,
-            "completion_tokens": token_sums["output_tokens"] or None,
-            "total_tokens": token_sums["total_tokens"] or None,
-            "cached_input_tokens": token_sums["cached_input_tokens"],
-            "non_cached_input_tokens": token_sums["non_cached_input_tokens"],
-            "reasoning_output_tokens": token_sums["reasoning_output_tokens"],
-            "model": model or "",
+    if observed_fields:
+        token_usage = {"model": model or ""}
+        # An OBSERVED zero is preserved as 0; a field never observed in any
+        # token_count event is omitted entirely (rather than coerced via
+        # `or None`), so downstream code can tell "zero" from "unknown".
+        field_to_key = {
+            "input_tokens": "prompt_tokens",
+            "output_tokens": "completion_tokens",
+            "total_tokens": "total_tokens",
+            "cached_input_tokens": "cached_input_tokens",
+            "cache_write_input_tokens": "cache_write_input_tokens",
+            "reasoning_output_tokens": "reasoning_output_tokens",
         }
+        for field, key in field_to_key.items():
+            if field in observed_fields:
+                token_usage[key] = token_sums[field]
+        # Codex derives non_cached_input_tokens rather than serializing it
+        # (see protocol.rs); we do the same, only when input was observed,
+        # to keep the codex.token_usage JSON backward compatible.
+        if "input_tokens" in observed_fields:
+            token_usage["non_cached_input_tokens"] = max(
+                token_sums["input_tokens"] - token_sums["cached_input_tokens"], 0
+            )
 
     return {
         "trace_count": trace_count,
@@ -356,6 +379,7 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
         "user_prompt": user_prompt,
         "assistant_output": assistant_output,
         "model": model,
+        "model_provider": model_provider,
         "cwd": cwd,
         "permission_mode": permission_mode,
         "sandbox_mode": sandbox_mode,
@@ -367,6 +391,47 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
 # ---------------------------------------------------------------------------
 # Span assembly
 # ---------------------------------------------------------------------------
+
+
+def _llm_identity(model: str, provider: "str | None") -> "tuple[str, str]":
+    """Derive OpenInference ``llm.system``/``llm.provider`` for a Codex turn.
+
+    ``llm.system`` names the AI product/model family (e.g. ``openai``,
+    ``anthropic``); ``llm.provider`` names the hosting provider (e.g.
+    ``openai``, ``azure``, ``ollama``). They can differ (an OpenAI model
+    hosted on Azure), so we derive them separately instead of assuming every
+    Codex session talks to OpenAI-hosted models.
+
+    ``provider`` is the ``model_provider`` field from the rollout's
+    ``session_meta`` payload. It is Codex's own built-in default provider id
+    when absent, so we fall back to ``"openai"`` in that case. ``llm.system``
+    must always be emitted on LLM spans -- OpenInference requires it -- so we
+    fall back to the provider id itself when the model name doesn't give us
+    a better answer.
+    """
+    llm_provider = (provider or "openai").lower()
+    model_lower = (model or "").lower()
+    if (
+        llm_provider in ("openai", "azure")
+        or model_lower.startswith(("gpt-", "o1", "o3", "o4"))
+        or "codex" in model_lower
+    ):
+        llm_system = "openai"
+    else:
+        llm_system = llm_provider
+    return llm_system, llm_provider
+
+
+def _put_indexed_message(attrs: dict, prefix: str, role: str, content: str) -> None:
+    """Write one OpenInference indexed message attribute pair at index 0.
+
+    ``prefix`` is ``llm.input_messages`` or ``llm.output_messages``. The role
+    is always set; the content attribute is only added when non-empty so we
+    never emit an empty ``message.content``.
+    """
+    attrs[f"{prefix}.0.message.role"] = role
+    if content:
+        attrs[f"{prefix}.0.message.content"] = content
 
 
 def _build_and_send_spans(thread_id: str, turn_id: str, turn: dict) -> None:
@@ -408,14 +473,27 @@ def _build_and_send_spans(thread_id: str, turn_id: str, turn: dict) -> None:
         attrs["codex.sandbox_mode"] = turn["sandbox_mode"]
     if turn.get("duration_ms") is not None:
         attrs["codex.turn.duration_ms"] = turn["duration_ms"]
-    if assistant_output:
-        attrs["llm.output_messages"] = json.dumps([{"message.role": "assistant", "message.content": assistant_output}])
+
+    llm_system, llm_provider = _llm_identity(turn.get("model") or "", turn.get("model_provider"))
+    attrs["llm.system"] = llm_system
+    attrs["llm.provider"] = llm_provider
+
+    _put_indexed_message(attrs, "llm.input_messages", "user", user_prompt)
+    _put_indexed_message(attrs, "llm.output_messages", "assistant", assistant_output)
 
     usage = turn.get("token_usage") or {}
     for src, dst in (
         ("prompt_tokens", "llm.token_count.prompt"),
         ("completion_tokens", "llm.token_count.completion"),
         ("total_tokens", "llm.token_count.total"),
+    ):
+        v = usage.get(src)
+        if isinstance(v, int):
+            attrs[dst] = v
+    for src, dst in (
+        ("cached_input_tokens", "llm.token_count.prompt_details.cache_read"),
+        ("cache_write_input_tokens", "llm.token_count.prompt_details.cache_write"),
+        ("reasoning_output_tokens", "llm.token_count.completion_details.reasoning"),
     ):
         v = usage.get(src)
         if isinstance(v, int):
@@ -440,6 +518,7 @@ def _build_and_send_spans(thread_id: str, turn_id: str, turn: dict) -> None:
         if workspace:
             tool_attrs["codex.workspace"] = workspace
         if entry.get("call_id"):
+            tool_attrs["tool.id"] = entry["call_id"]
             tool_attrs["codex.tool.call_id"] = entry["call_id"]
         child_start = entry.get("start_ts") or turn["turn_start_ms"]
         child_end = entry.get("end_ts") or child_start
@@ -539,12 +618,17 @@ def _send_legacy_single_span(thread_id: str, turn_id: str, input_json: dict) -> 
         "codex.thread_id": thread_id,
         "codex.turn_id": turn_id,
         "codex.notify_fallback": "true",
+        # Codex is OpenAI's own CLI and this fallback path has no rollout to
+        # say otherwise, so llm.system is trustworthy even here. llm.provider
+        # is left out -- we have no session_meta to confirm the hosting
+        # provider on this path.
+        "llm.system": "openai",
     }
     user_id = env.get_user_id(SERVICE_NAME)
     if user_id:
         attrs["user.id"] = user_id
-    if assistant_output:
-        attrs["llm.output_messages"] = json.dumps([{"message.role": "assistant", "message.content": assistant_output}])
+    _put_indexed_message(attrs, "llm.input_messages", "user", user_prompt)
+    _put_indexed_message(attrs, "llm.output_messages", "assistant", assistant_output)
 
     parent_span = build_span(
         "Turn",

--- a/tracing/codex/hooks/handlers.py
+++ b/tracing/codex/hooks/handlers.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -364,9 +365,10 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
             if field in observed_fields:
                 token_usage[key] = token_sums[field]
         # Codex derives non_cached_input_tokens rather than serializing it
-        # (see protocol.rs); we do the same, only when input was observed,
-        # to keep the codex.token_usage JSON backward compatible.
-        if "input_tokens" in observed_fields:
+        # (see protocol.rs); we do the same, only when BOTH input and cached
+        # were observed -- deriving from an unobserved (default-0) cached
+        # value would fabricate a number from unknown cache data.
+        if "input_tokens" in observed_fields and "cached_input_tokens" in observed_fields:
             token_usage["non_cached_input_tokens"] = max(
                 token_sums["input_tokens"] - token_sums["cached_input_tokens"], 0
             )
@@ -393,45 +395,96 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
 # ---------------------------------------------------------------------------
 
 
-def _llm_identity(model: str, provider: "str | None") -> "tuple[str, str]":
+# OpenInference's llm.system well-known values (spec/semantic_conventions.md):
+# anthropic, openai, vertexai, cohere, mistralai, xai, deepseek, amazon,
+# meta, ai21. Model-family substrings below map to those exact values --
+# "the respective value MUST be used" when one applies. Order matters: more
+# specific/likely substrings are checked first.
+_MODEL_FAMILY_SYSTEMS: "tuple[tuple[str, str], ...]" = (
+    ("codex", "openai"),
+    ("gpt-", "openai"),
+    ("claude", "anthropic"),
+    ("llama", "meta"),
+    ("deepseek", "deepseek"),
+    ("mixtral", "mistralai"),
+    ("mistral", "mistralai"),
+    ("gemini", "vertexai"),
+    ("grok", "xai"),
+    ("command-", "cohere"),
+)
+
+# o1/o3/o4 only as a whole model-name token (o1, o1-preview, ...), not as a
+# substring of an unrelated word.
+_O_SERIES_MODEL_RE = re.compile(r"^o[134](\b|-|$)")
+
+
+def _llm_identity(model: "object", provider: "object") -> "tuple[str, str | None]":
     """Derive OpenInference ``llm.system``/``llm.provider`` for a Codex turn.
 
     ``llm.system`` names the AI product/model family (e.g. ``openai``,
-    ``anthropic``); ``llm.provider`` names the hosting provider (e.g.
-    ``openai``, ``azure``, ``ollama``). They can differ (an OpenAI model
-    hosted on Azure), so we derive them separately instead of assuming every
-    Codex session talks to OpenAI-hosted models.
+    ``anthropic``, ``meta``); ``llm.provider`` names the hosting provider
+    (e.g. ``openai``, ``azure``, ``ollama``). They can differ (a Llama model
+    hosted on Ollama, a DeepSeek model hosted on Azure), so we derive them
+    separately instead of assuming every Codex session talks to
+    OpenAI-hosted models.
 
-    ``provider`` is the ``model_provider`` field from the rollout's
-    ``session_meta`` payload. It is Codex's own built-in default provider id
-    when absent, so we fall back to ``"openai"`` in that case. ``llm.system``
-    must always be emitted on LLM spans -- OpenInference requires it -- so we
-    fall back to the provider id itself when the model name doesn't give us
-    a better answer.
+    Precedence for ``llm.system`` (OpenInference says a well-known value
+    MUST be used when one applies):
+      1. A model-family match on the model name (openai, anthropic, meta,
+         deepseek, mistralai, vertexai, xai, cohere, ...).
+      2. Else the provider, when it is ``openai`` or ``azure`` (both mean
+         an OpenAI-family model).
+      3. Else, when the provider itself is absent, ``"openai"`` -- Codex's
+         own built-in default provider id when ``session_meta`` omits the
+         field, and ``llm.system`` is required so we must emit something.
+      4. Else the provider id itself, as a spec-permitted custom value.
+
+    ``llm.provider`` is optional in the spec, so it is returned as ``None``
+    (meaning "do not emit the attribute") when ``model_provider`` was never
+    observed or was JSON ``null`` -- we never fabricate a hosting provider.
+
+    ``model``/``provider`` are accepted as ``object`` and type-guarded: any
+    non-string value (e.g. a corrupt rollout field) is treated as absent
+    rather than raising, so one bad field can't drop the whole turn's span.
     """
-    llm_provider = (provider or "openai").lower()
-    model_lower = (model or "").lower()
-    if (
-        llm_provider in ("openai", "azure")
-        or model_lower.startswith(("gpt-", "o1", "o3", "o4"))
-        or "codex" in model_lower
-    ):
+    model_str = model if isinstance(model, str) else ""
+    provider_str = provider if isinstance(provider, str) else None
+
+    model_lower = model_str.lower()
+    provider_lower = provider_str.lower() if provider_str else None
+
+    llm_system: "str | None" = None
+    if _O_SERIES_MODEL_RE.match(model_lower):
         llm_system = "openai"
     else:
-        llm_system = llm_provider
-    return llm_system, llm_provider
+        for substr, system in _MODEL_FAMILY_SYSTEMS:
+            if substr in model_lower:
+                llm_system = system
+                break
+
+    if llm_system is None:
+        if provider_lower in ("openai", "azure"):
+            llm_system = "openai"
+        elif provider_lower is None:
+            llm_system = "openai"
+        else:
+            llm_system = provider_lower
+
+    return llm_system, provider_lower
 
 
 def _put_indexed_message(attrs: dict, prefix: str, role: str, content: str) -> None:
     """Write one OpenInference indexed message attribute pair at index 0.
 
-    ``prefix`` is ``llm.input_messages`` or ``llm.output_messages``. The role
-    is always set; the content attribute is only added when non-empty so we
-    never emit an empty ``message.content``.
+    ``prefix`` is ``llm.input_messages`` or ``llm.output_messages``. Writes
+    nothing at all -- neither role nor content -- when ``content`` is empty,
+    so a turn with no user/assistant message doesn't claim a message that
+    was never observed.
     """
+    if not content:
+        return
     attrs[f"{prefix}.0.message.role"] = role
-    if content:
-        attrs[f"{prefix}.0.message.content"] = content
+    attrs[f"{prefix}.0.message.content"] = content
 
 
 def _build_and_send_spans(thread_id: str, turn_id: str, turn: dict) -> None:
@@ -474,9 +527,10 @@ def _build_and_send_spans(thread_id: str, turn_id: str, turn: dict) -> None:
     if turn.get("duration_ms") is not None:
         attrs["codex.turn.duration_ms"] = turn["duration_ms"]
 
-    llm_system, llm_provider = _llm_identity(turn.get("model") or "", turn.get("model_provider"))
+    llm_system, llm_provider = _llm_identity(turn.get("model"), turn.get("model_provider"))
     attrs["llm.system"] = llm_system
-    attrs["llm.provider"] = llm_provider
+    if llm_provider:
+        attrs["llm.provider"] = llm_provider
 
     _put_indexed_message(attrs, "llm.input_messages", "user", user_prompt)
     _put_indexed_message(attrs, "llm.output_messages", "assistant", assistant_output)

--- a/tracing/codex/hooks/handlers.py
+++ b/tracing/codex/hooks/handlers.py
@@ -8,16 +8,6 @@ the full turn's data: user prompt, assistant message, token usage, and every
 tool call (shell, apply_patch, web_search, open_page) with structured args,
 output, and timing. We then ship one OTLP payload with the parent LLM span
 plus all TOOL child spans.
-
-This replaces an earlier design that relied on Codex's lifecycle hooks
-(SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop). Those hooks
-only cover SOME tool types (shell/apply_patch but not web_search), use a
-brittle hook-payload schema, and require explicit ``/hooks`` trust approval.
-The rollout JSONL covers every tool, has a stable JSON schema, and is the
-single source of truth for the session.
-
-Input contract: JSON as ``sys.argv[1]`` (NOT stdin -- Codex passes notify
-JSON as a CLI argument). No stdout response expected.
 """
 
 from __future__ import annotations
@@ -42,6 +32,7 @@ from core.common import (
     redact_content,
 )
 from core.common import send_span as send_span_to_backend
+from core.constants import MODEL_FAMILY_SYSTEMS
 from tracing.codex.constants import get_codex_home
 from tracing.codex.hooks.adapter import SCOPE_NAME, SERVICE_NAME, check_requirements, load_env_file
 
@@ -113,20 +104,12 @@ def _iso_to_ms(ts: str) -> int:
 
 
 def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None":
-    """Walk the rollout JSONL and extract everything for one turn.
-
-    Returns a dict with: ``trace_count``, ``turn_start_ms``, ``turn_end_ms``,
-    ``duration_ms``, ``user_prompt``, ``assistant_output``, ``model``,
-    ``model_provider`` (from ``session_meta``, may be ``None``), ``cwd``,
-    ``permission_mode``, ``sandbox_mode``, ``token_usage`` (or None), and
-    ``tool_calls`` (a list of ``{tool, args, output, call_id, start_ts, end_ts}``).
-
-    Returns None if the turn isn't found.
-    """
+    """Walk the rollout JSONL and extract everything for one turn. Returns None if the
+    turn isn't found."""
     if not turn_id or not rollout_path.is_file():
         return None
 
-    fields = (
+    codex_token_count_fields = (
         "input_tokens",
         "output_tokens",
         "total_tokens",
@@ -134,7 +117,7 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
         "cache_write_input_tokens",
         "reasoning_output_tokens",
     )
-    token_sums: dict = {k: 0 for k in fields}
+    token_sums: dict = {k: 0 for k in codex_token_count_fields}
     observed_fields: set = set()
 
     in_turn = False
@@ -180,7 +163,6 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
                     continue
 
                 # turn_context records carry per-turn settings (model, cwd, sandbox).
-                # They live at the outer level (no payload.type).
                 if outer == "turn_context" and isinstance(payload, dict):
                     if payload.get("turn_id") == turn_id:
                         model = payload.get("model") or model
@@ -242,7 +224,7 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
                 # Token counts -- sum per-call deltas
                 if outer == "event_msg" and ptype == "token_count":
                     last = (payload.get("info") or {}).get("last_token_usage") or {}
-                    for k in fields:
+                    for k in codex_token_count_fields:
                         v = last.get(k)
                         if isinstance(v, int):
                             token_sums[k] += v
@@ -350,10 +332,7 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
     token_usage: "dict | None" = None
     if observed_fields:
         token_usage = {"model": model or ""}
-        # An OBSERVED zero is preserved as 0; a field never observed in any
-        # token_count event is omitted entirely (rather than coerced via
-        # `or None`), so downstream code can tell "zero" from "unknown".
-        field_to_key = {
+        codex_token_count_to_token_usage = {
             "input_tokens": "prompt_tokens",
             "output_tokens": "completion_tokens",
             "total_tokens": "total_tokens",
@@ -361,13 +340,12 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
             "cache_write_input_tokens": "cache_write_input_tokens",
             "reasoning_output_tokens": "reasoning_output_tokens",
         }
-        for field, key in field_to_key.items():
+        for field, key in codex_token_count_to_token_usage.items():
             if field in observed_fields:
                 token_usage[key] = token_sums[field]
         # Codex derives non_cached_input_tokens rather than serializing it
-        # (see protocol.rs); we do the same, only when BOTH input and cached
-        # were observed -- deriving from an unobserved (default-0) cached
-        # value would fabricate a number from unknown cache data.
+        # we do the same, but only when BOTH input and cached are observed
+        # otherwise, we'd be fabricating a number from unknown cache data
         if "input_tokens" in observed_fields and "cached_input_tokens" in observed_fields:
             token_usage["non_cached_input_tokens"] = max(
                 token_sums["input_tokens"] - token_sums["cached_input_tokens"], 0
@@ -394,25 +372,6 @@ def _extract_turn_from_rollout(rollout_path: Path, turn_id: str) -> "dict | None
 # Span assembly
 # ---------------------------------------------------------------------------
 
-
-# OpenInference's llm.system well-known values (spec/semantic_conventions.md):
-# anthropic, openai, vertexai, cohere, mistralai, xai, deepseek, amazon,
-# meta, ai21. Model-family substrings below map to those exact values --
-# "the respective value MUST be used" when one applies. Order matters: more
-# specific/likely substrings are checked first.
-_MODEL_FAMILY_SYSTEMS: "tuple[tuple[str, str], ...]" = (
-    ("codex", "openai"),
-    ("gpt-", "openai"),
-    ("claude", "anthropic"),
-    ("llama", "meta"),
-    ("deepseek", "deepseek"),
-    ("mixtral", "mistralai"),
-    ("mistral", "mistralai"),
-    ("gemini", "vertexai"),
-    ("grok", "xai"),
-    ("command-", "cohere"),
-)
-
 # o1/o3/o4 only as a whole model-name token (o1, o1-preview, ...), not as a
 # substring of an unrelated word.
 _O_SERIES_MODEL_RE = re.compile(r"^o[134](\b|-|$)")
@@ -421,31 +380,17 @@ _O_SERIES_MODEL_RE = re.compile(r"^o[134](\b|-|$)")
 def _llm_identity(model: "object", provider: "object") -> "tuple[str, str | None]":
     """Derive OpenInference ``llm.system``/``llm.provider`` for a Codex turn.
 
-    ``llm.system`` names the AI product/model family (e.g. ``openai``,
-    ``anthropic``, ``meta``); ``llm.provider`` names the hosting provider
-    (e.g. ``openai``, ``azure``, ``ollama``). They can differ (a Llama model
-    hosted on Ollama, a DeepSeek model hosted on Azure), so we derive them
-    separately instead of assuming every Codex session talks to
-    OpenAI-hosted models.
+    ``llm.system`` = the AI product/model family
+    ``llm.provider`` = the hosting provider.
+    Different bc DeepSeek models can be hosted on Azure, and other such cases.
 
-    Precedence for ``llm.system`` (OpenInference says a well-known value
-    MUST be used when one applies):
-      1. A model-family match on the model name (openai, anthropic, meta,
-         deepseek, mistralai, vertexai, xai, cohere, ...).
-      2. Else the provider, when it is ``openai`` or ``azure`` (both mean
-         an OpenAI-family model).
-      3. Else, when the provider itself is absent, ``"openai"`` -- Codex's
-         own built-in default provider id when ``session_meta`` omits the
-         field, and ``llm.system`` is required so we must emit something.
-      4. Else the provider id itself, as a spec-permitted custom value.
-
-    ``llm.provider`` is optional in the spec, so it is returned as ``None``
-    (meaning "do not emit the attribute") when ``model_provider`` was never
-    observed or was JSON ``null`` -- we never fabricate a hosting provider.
-
-    ``model``/``provider`` are accepted as ``object`` and type-guarded: any
-    non-string value (e.g. a corrupt rollout field) is treated as absent
-    rather than raising, so one bad field can't drop the whole turn's span.
+    For llm.system, per OpenInference, a well-known value MUST be used when one
+    applies:
+        1. A model-family match on the model name
+        2. Else, the provider, when it is ``openai`` or ``azure``
+        3. Else, when the provider is absent, ``"openai"``, which is the default
+           provider id when ``session_meta`` omits the field.
+        4. Else, the provider id itself as a spec permitted custom value
     """
     model_str = model if isinstance(model, str) else ""
     provider_str = provider if isinstance(provider, str) else None
@@ -457,7 +402,7 @@ def _llm_identity(model: "object", provider: "object") -> "tuple[str, str | None
     if _O_SERIES_MODEL_RE.match(model_lower):
         llm_system = "openai"
     else:
-        for substr, system in _MODEL_FAMILY_SYSTEMS:
+        for substr, system in MODEL_FAMILY_SYSTEMS:
             if substr in model_lower:
                 llm_system = system
                 break
@@ -474,13 +419,7 @@ def _llm_identity(model: "object", provider: "object") -> "tuple[str, str | None
 
 
 def _put_indexed_message(attrs: dict, prefix: str, role: str, content: str) -> None:
-    """Write one OpenInference indexed message attribute pair at index 0.
-
-    ``prefix`` is ``llm.input_messages`` or ``llm.output_messages``. Writes
-    nothing at all -- neither role nor content -- when ``content`` is empty,
-    so a turn with no user/assistant message doesn't claim a message that
-    was never observed.
-    """
+    """Write one OpenInference indexed message attribute pair at index 0."""
     if not content:
         return
     attrs[f"{prefix}.0.message.role"] = role
@@ -544,6 +483,7 @@ def _build_and_send_spans(thread_id: str, turn_id: str, turn: dict) -> None:
         v = usage.get(src)
         if isinstance(v, int):
             attrs[dst] = v
+    # map the token_usage keys to the OpenInference attribute names
     for src, dst in (
         ("cached_input_tokens", "llm.token_count.prompt_details.cache_read"),
         ("cache_write_input_tokens", "llm.token_count.prompt_details.cache_write"),
@@ -618,7 +558,7 @@ def _build_and_send_spans(thread_id: str, turn_id: str, turn: dict) -> None:
 
 
 def _send_legacy_single_span(thread_id: str, turn_id: str, input_json: dict) -> None:
-    """Fallback when no rollout file is found -- emit a single LLM span from
+    """Fallback when no rollout file or turn is found - emit a single LLM span from
     the notify payload alone."""
     assistant_msg = (
         input_json.get("last-assistant-message")
@@ -673,9 +613,8 @@ def _send_legacy_single_span(thread_id: str, turn_id: str, input_json: dict) -> 
         "codex.turn_id": turn_id,
         "codex.notify_fallback": "true",
         # Codex is OpenAI's own CLI and this fallback path has no rollout to
-        # say otherwise, so llm.system is trustworthy even here. llm.provider
-        # is left out -- we have no session_meta to confirm the hosting
-        # provider on this path.
+        # say otherwise, so llm.system is hardcoded to openai.
+        # llm.provider is left out bc we have no session_meta to confirm hosting
         "llm.system": "openai",
     }
     user_id = env.get_user_id(SERVICE_NAME)


### PR DESCRIPTION
## Summary

Codex LLM spans lacked `llm.system`, and standard token counts, message, and tool data lived only in custom `codex.*` attributes – this PR brings codex tracing up to respect the basic OpenInference contract. 

> [!note]
> it's not up to parity with the OpenInference instrumentors – as one example, the overall structure is still flat for tool calls made within one LLM call, something #114 aims to fix. it's one step in the right direction, and this addresses all the defects listed in #95 

resolves #95 

- `llm.system` on both the rollout path and the notify fallback
- `llm.provider` derived from `session_meta.model_provider` and only emitted when it's actually observed
- `cache_write_input_tokens` is read and emitted as `prompt_details.cache_write`
- cache-read and reasoning as canonical integer attributes
- indexed `llm.input_messages.0` and `llm.output_messages.0` in place of one JSON string
- `tool.id` beside the retained `codex.tool.call_id`
- observed zeros are preserved
- `non_cached_input_tokens` is now calculated the same way codex calculates it (since it's not serialized by codex)

for `llm.system` and `llm.provider`: derive the model family first, then the provider, and then the codex default. system and provider are derived separately, so a non-OpenAI model on Codex could yield a non-OpenAI system. also, the model family table (map of models to `llm.system`) lives in `core/constants.py` so other harnesses can use it. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## How tested

- parser tests for cache-write summing, zero preservation, non-cached derivation and `session_meta` provider capture
- span assembly tests for identity, indexed messages, redaction, and the `spawn_agent` `TOOL` span
- `TestLlmIdentity` class covers all the model families
- 1003 passed tests in Codex and core

## Checklist

- [x] Tests pass (`uv run pytest tests/ -m "not slow"`)
- [x] Pre-commit clean (`uv run pre-commit run --all-files`)
- [x] Ran the `code-review` skill and addressed findings
- [ ] Docs updated if needed (no docs updated)
